### PR TITLE
fix(generated-files): derive config required flag from schema

### DIFF
--- a/hack/platform/partials/main.go
+++ b/hack/platform/partials/main.go
@@ -1126,8 +1126,6 @@ spec:
 		},
 		Create: true,
 	})
-
-	util.DefaultRequire = false
 }
 
 // removeAllExceptPreserved deletes basePath and recreates it, but first backs

--- a/hack/platform/util/schema.go
+++ b/hack/platform/util/schema.go
@@ -642,13 +642,23 @@ func renderField(
 		fieldType = "&#123;key: " + fieldType + "&#125;"
 	}
 
+	// requiredText is the visible badge text. It must be empty for optional
+	// fields, not just hidden via CSS: the heading text feeds the right-hand
+	// table of contents, which ignores CSS, so a hardcoded "required" would
+	// otherwise label every field "required" in the nav regardless of
+	// data-required. See DOC-1526.
+	requiredText := ""
+	if required {
+		requiredText = "required"
+	}
+
 	if ref != "" {
 		refSplit := strings.Split(ref, "/")
 		_, ok = definitions[refSplit[len(refSplit)-1]]
 		if ok {
 			anchorName := anchorPrefix + fieldName
 			proLabel := ""
-			fieldContent = fmt.Sprintf(TemplateConfigField, true, "", headlinePrefix, fieldName, required, fieldType, "", "", proLabel, anchorName, description, fieldContent)
+			fieldContent = fmt.Sprintf(TemplateConfigField, true, "", headlinePrefix, fieldName, required, requiredText, fieldType, "", "", proLabel, anchorName, description, fieldContent)
 		}
 	} else {
 		if defaults != nil {
@@ -665,7 +675,7 @@ func renderField(
 		enumValues := GetEumValues(fieldSchema, required, &fieldDefault)
 		anchorName := anchorPrefix + fieldName
 		proLabel := ""
-		fieldContent = fmt.Sprintf(TemplateConfigField, expandable, " open", headlinePrefix, fieldName, required, fieldType, fieldDefault, enumValues, proLabel, anchorName, description, fieldContent)
+		fieldContent = fmt.Sprintf(TemplateConfigField, expandable, " open", headlinePrefix, fieldName, required, requiredText, fieldType, fieldDefault, enumValues, proLabel, anchorName, description, fieldContent)
 	}
 
 	return fieldContent

--- a/hack/platform/util/schema.go
+++ b/hack/platform/util/schema.go
@@ -23,7 +23,6 @@ const (
 	anchorSeparator = "-"
 )
 
-var DefaultRequire = true
 
 // BasePath and BaseResourcesPath are package-level vars (not const) so the
 // release-dispatch receiver can redirect generator output to versioned
@@ -77,7 +76,16 @@ func GenerateSchema(configInstance interface{}) *jsonschema.Schema {
 func generateSchema(configInstance interface{}) *jsonschema.Schema {
 	r := new(jsonschema.Reflector)
 	r.AllowAdditionalProperties = true
-	r.RequiredFromJSONSchemaTags = true
+	// RequiredFromJSONSchemaTags=false makes the reflector populate each
+	// object's `required` array from the Kubernetes convention the loft-sh/api
+	// structs actually use (absence of `,omitempty` in the json tag) rather
+	// than from explicit `jsonschema:"required"` tags, which those structs do
+	// not carry. renderField then derives the "required" badge from that array,
+	// so a field is only flagged required when the upstream type genuinely
+	// requires it within its parent object. The `+optional` comment override in
+	// renderField further demotes fields that lack `,omitempty` but are
+	// annotated optional.
+	r.RequiredFromJSONSchemaTags = false
 	r.ExpandedStruct = true
 
 	// add comments
@@ -361,10 +369,12 @@ func RenderFromPath(schema *jsonschema.Schema, schemaPath string, defaults map[s
 	splittedSchemaPath := strings.Split(schemaPath, "/")
 
 	fieldSchema := schema
+	parentSchema := schema
 	lastProperty := schemaPath
 	for i, property := range splittedSchemaPath {
 		var ok bool
 		lastProperty = property
+		parentSchema = fieldSchema
 		fieldSchema, ok = fieldSchema.Properties.Get(property)
 		if !ok {
 			return "", fmt.Errorf("couldn't find schema path '%s' at '%s'", schemaPath, property)
@@ -409,6 +419,7 @@ func RenderFromPath(schema *jsonschema.Schema, schemaPath string, defaults map[s
 		false,
 		1,
 		defaults,
+		requiredSet(parentSchema)[lastProperty],
 	)
 	return content, nil
 }
@@ -443,6 +454,7 @@ func createSections(pageFile string, schema *jsonschema.Schema, definitions json
 func buildContent(prefix string, schema *jsonschema.Schema, definitions jsonschema.Definitions, metadataOnly bool, depth int, defaults interface{}) string {
 	content := ""
 	if schema.Properties != nil {
+		requiredFields := requiredSet(schema)
 		for pair := schema.Properties.Oldest(); pair != nil; pair = pair.Next() {
 			fieldName := pair.Key
 
@@ -475,6 +487,7 @@ func buildContent(prefix string, schema *jsonschema.Schema, definitions jsonsche
 				metadataOnly,
 				depth,
 				defaults,
+				requiredFields[fieldName],
 			)
 			if fieldContent != "" {
 				content += "\n\n" + fieldContent
@@ -485,6 +498,18 @@ func buildContent(prefix string, schema *jsonschema.Schema, definitions jsonsche
 	return content
 }
 
+// requiredSet returns the set of property names that the schema marks as
+// required. For reflected types this comes from the Kubernetes `,omitempty`
+// convention (see generateSchema); for schemas loaded from a values.schema.json
+// file it comes from the `required` arrays already present in the file.
+func requiredSet(schema *jsonschema.Schema) map[string]bool {
+	set := map[string]bool{}
+	for _, name := range schema.Required {
+		set[name] = true
+	}
+	return set
+}
+
 func renderField(
 	prefix,
 	fieldName string,
@@ -493,6 +518,7 @@ func renderField(
 	metadataOnly bool,
 	depth int,
 	defaults interface{},
+	isRequired bool,
 ) string {
 	headlinePrefix := strings.Repeat("#", int(math.Min(5, float64(depth+1)))) + " "
 	anchorPrefix := strings.TrimPrefix(strings.ReplaceAll(prefix, prefixSeparator, anchorSeparator), anchorSeparator)
@@ -534,10 +560,23 @@ func renderField(
 		}
 	}
 
-	required := DefaultRequire
+	required := isRequired
 	fieldDefault := ""
 
 	description := fieldSchema.Description
+	// Nullable fields (`jsonschema:"nullable"`) are reflected as a oneOf of the
+	// real type plus a null type, which leaves the field's own Description empty
+	// and moves the documentation (including any `+optional` marker) onto the
+	// non-null member. Fall back to that member so the description still renders
+	// and the `+optional` demotion below still fires.
+	if description == "" {
+		for _, member := range fieldSchema.OneOf {
+			if member.Type != "null" && member.Description != "" {
+				description = member.Description
+				break
+			}
+		}
+	}
 
 	// replace { & }
 	description = strings.ReplaceAll(description, "{", "&#123;")

--- a/hack/platform/util/templates.go
+++ b/hack/platform/util/templates.go
@@ -4,7 +4,7 @@ const TemplateConfigField = `
 <details className="config-field" data-expandable="%t"%s>
 <summary>
 
-%s` + "`%s`" + ` <span className="config-field-required" data-required="%t">required</span> <span className="config-field-type">%s</span> <span className="config-field-default">%s</span> <span className="config-field-enum">%s</span>%s {#%s}
+%s` + "`%s`" + ` <span className="config-field-required" data-required="%t">%s</span> <span className="config-field-type">%s</span> <span className="config-field-default">%s</span> <span className="config-field-enum">%s</span>%s {#%s}
 
 %s
 

--- a/hack/vcluster/partials/main.go
+++ b/hack/vcluster/partials/main.go
@@ -176,7 +176,6 @@ func main() {
 			"(positional args still accepted for back-compat)")
 	}
 
-	util.DefaultRequire = false
 	jsonSchemaPath := filepath.Join(versionDir, "vcluster.schema.json")
 	defaultValues := filepath.Join(versionDir, "default_values.yaml")
 	values, err := os.ReadFile(defaultValues)

--- a/hack/vcluster/partials/main.go
+++ b/hack/vcluster/partials/main.go
@@ -46,6 +46,11 @@ var pathExtras = map[string]Extras{
 			"`joinNode.enabled: false` and use separate worker nodes for tenant workloads.\n" +
 			":::\n\n",
 	},
+	"sync/toHost/gatewayApi": {
+		Before: "\nSetting `enabled: true` turns on Gateway and HTTPRoute sync, imports control plane " +
+			"cluster GatewayClasses so tenant Gateways can resolve them, and serves tenant ReferenceGrants " +
+			"for validation; TLSRoutes and BackendTLSPolicies must be enabled individually.\n\n",
+	},
 }
 
 // we only generate paths we actually need

--- a/hack/vcluster/partials/main.go
+++ b/hack/vcluster/partials/main.go
@@ -49,7 +49,9 @@ var pathExtras = map[string]Extras{
 	"sync/toHost/gatewayApi": {
 		Before: "\nSetting `enabled: true` turns on Gateway and HTTPRoute sync, imports control plane " +
 			"cluster GatewayClasses so tenant Gateways can resolve them, and serves tenant ReferenceGrants " +
-			"for validation; TLSRoutes and BackendTLSPolicies must be enabled individually.\n\n",
+			"for validation; TLSRoutes and BackendTLSPolicies must be enabled individually.\n\n" +
+			"In auto mode grants follow route sync and are validated within the tenant cluster; " +
+			"they sync to the control plane cluster only when namespace sync is also enabled.\n\n",
 	},
 }
 

--- a/platform/api/_partials/resources/apps/reference.mdx
+++ b/platform/api/_partials/resources/apps/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes an app
 
@@ -50,7 +50,7 @@ Description describes an app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
+### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
 
 Clusters are the clusters this app can be installed in.
 
@@ -110,7 +110,7 @@ Clusters are the clusters this app can be installed in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `recommendedApp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-recommendedApp}
+### `recommendedApp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-recommendedApp}
 
 RecommendedApp specifies where this app should show up as recommended app
 
@@ -125,7 +125,7 @@ RecommendedApp specifies where this app should show up as recommended app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-defaultNamespace}
+### `defaultNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-defaultNamespace}
 
 DefaultNamespace is the default namespace this app should installed
 in.
@@ -141,7 +141,7 @@ in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `readme` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-readme}
+### `readme` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-readme}
 
 Readme is a longer markdown string that describes the app.
 
@@ -156,7 +156,7 @@ Readme is a longer markdown string that describes the app.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-icon}
+### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-icon}
 
 Icon holds an URL to the app icon
 
@@ -171,7 +171,7 @@ Icon holds an URL to the app icon
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config}
+### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config}
 
 Config is the helm config to use to deploy the helm release
 
@@ -183,7 +183,7 @@ Config is the helm config to use to deploy the helm release
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart}
+#### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart}
 
 Chart holds information about a chart that should get deployed
 
@@ -195,7 +195,7 @@ Chart holds information about a chart that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-name}
 
 Name is the chart name in the repository
 
@@ -210,7 +210,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-version}
 
 Version is the chart version in the repository
 
@@ -225,7 +225,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -240,7 +240,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-username}
 
 The username that is required for this repository
 
@@ -255,7 +255,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef}
 
 The username that is required for this repository
 
@@ -267,7 +267,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -279,7 +279,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -294,7 +294,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -309,7 +309,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -330,7 +330,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-password}
 
 The password that is required for this repository
 
@@ -345,7 +345,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef}
 
 The password that is required for this repository
 
@@ -357,7 +357,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -369,7 +369,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -384,7 +384,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -399,7 +399,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -420,7 +420,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -438,7 +438,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-manifests}
+#### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-manifests}
 
 Manifests holds kube manifests that will be deployed as a chart
 
@@ -453,7 +453,7 @@ Manifests holds kube manifests that will be deployed as a chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `bash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash}
+#### `bash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash}
 
 Bash holds the bash script to execute in a container in the target
 
@@ -465,7 +465,7 @@ Bash holds the bash script to execute in a container in the target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `script` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-script}
+##### `script` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-script}
 
 Script is the script to execute.
 
@@ -480,7 +480,7 @@ Script is the script to execute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-image}
 
 Image is the image to use for this app
 
@@ -495,7 +495,7 @@ Image is the image to use for this app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-clusterRole}
 
 ClusterRole is the cluster role to use for this job
 
@@ -510,7 +510,7 @@ ClusterRole is the cluster role to use for this job
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext}
 
 PodSecurityContext for the bash pod.
 
@@ -522,7 +522,7 @@ PodSecurityContext for the bash pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seLinuxOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions}
+##### `seLinuxOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions}
 
 The SELinux context to be applied to all containers.
 If unspecified, the container runtime will allocate a random SELinux context for each
@@ -539,7 +539,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-user}
 
 User is a SELinux user label that applies to the container.
 
@@ -554,7 +554,7 @@ User is a SELinux user label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-role}
 
 Role is a SELinux role label that applies to the container.
 
@@ -569,7 +569,7 @@ Role is a SELinux role label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-type}
 
 Type is a SELinux type label that applies to the container.
 
@@ -584,7 +584,7 @@ Type is a SELinux type label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-level}
+##### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-level}
 
 Level is SELinux level label that applies to the container.
 
@@ -602,7 +602,7 @@ Level is SELinux level label that applies to the container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `windowsOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions}
+##### `windowsOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions}
 
 The Windows specific settings applied to all containers.
 If unspecified, the options within a container's SecurityContext will be used.
@@ -617,7 +617,7 @@ Note that this field cannot be set when spec.os.name is linux.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpecName}
+##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpecName}
 
 GMSACredentialSpecName is the name of the GMSA credential spec to use.
 
@@ -632,7 +632,7 @@ GMSACredentialSpecName is the name of the GMSA credential spec to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpec}
+##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpec}
 
 GMSACredentialSpec is where the GMSA admission webhook
 (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
@@ -649,7 +649,7 @@ GMSA credential spec named by the GMSACredentialSpecName field.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUserName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-runAsUserName}
+##### `runAsUserName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-runAsUserName}
 
 The UserName in Windows to run the entrypoint of the container process.
 Defaults to the user specified in image metadata if unspecified.
@@ -667,7 +667,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostProcess` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-hostProcess}
+##### `hostProcess` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-hostProcess}
 
 HostProcess determines if a container should be run as a 'Host Process' container.
 All of a Pod's containers must have the same effective HostProcess value
@@ -688,7 +688,7 @@ In addition, if HostProcess is true then HostNetwork must also be set to true.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUser` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsUser}
+##### `runAsUser` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsUser}
 
 The UID to run the entrypoint of the container process.
 Defaults to user specified in image metadata if unspecified.
@@ -708,7 +708,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsGroup}
+##### `runAsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsGroup}
 
 The GID to run the entrypoint of the container process.
 Uses runtime default if unset.
@@ -728,7 +728,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsNonRoot` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsNonRoot}
+##### `runAsNonRoot` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsNonRoot}
 
 Indicates that the container must run as a non-root user.
 If true, the Kubelet will validate the image at runtime to ensure that it
@@ -748,7 +748,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `supplementalGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-supplementalGroups}
+##### `supplementalGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-supplementalGroups}
 
 A list of groups applied to the first process run in each container, in
 addition to the container's primary GID and fsGroup (if specified).  If
@@ -771,7 +771,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `supplementalGroupsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-supplementalGroupsPolicy}
+##### `supplementalGroupsPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-supplementalGroupsPolicy}
 
 Defines how supplemental groups of the first container processes are calculated.
 Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
@@ -791,7 +791,7 @@ TODO: update the default value to "Merge" when spec.os.name is not windows in v1
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-fsGroup}
+##### `fsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-fsGroup}
 
 A special supplemental group that applies to all containers in a pod.
 Some volume types allow the Kubelet to change the ownership of that volume
@@ -815,7 +815,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sysctls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-sysctls}
+##### `sysctls` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-sysctls}
 
 Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
 sysctls (by the container runtime) might fail to launch.
@@ -862,7 +862,7 @@ Value of a property to set
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fsGroupChangePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-fsGroupChangePolicy}
+##### `fsGroupChangePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-fsGroupChangePolicy}
 
 fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
 before being exposed inside Pod. This field will only apply to
@@ -883,7 +883,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seccompProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seccompProfile}
+##### `seccompProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seccompProfile}
 
 The seccomp options to use by the containers in this pod.
 Note that this field cannot be set when spec.os.name is windows.
@@ -916,7 +916,7 @@ Unconfined - no profile should be applied.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seccompProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seccompProfile-localhostProfile}
 
 localhostProfile indicates a profile defined in a file on the node should be used.
 The profile must be preconfigured on the node to work.
@@ -937,7 +937,7 @@ Must be set if type is "Localhost". Must NOT be set for any other type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `appArmorProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-appArmorProfile}
+##### `appArmorProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-appArmorProfile}
 
 appArmorProfile is the AppArmor options to use by the containers in this pod.
 Note that this field cannot be set when spec.os.name is windows.
@@ -969,7 +969,7 @@ Valid options are:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-appArmorProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-appArmorProfile-localhostProfile}
 
 localhostProfile indicates a profile loaded on the node that should be used.
 The profile must be preconfigured on the node to work.
@@ -990,7 +990,7 @@ Must be set if and only if type is "Localhost".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `seLinuxChangePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxChangePolicy}
+##### `seLinuxChangePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxChangePolicy}
 
 seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
 It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
@@ -1030,7 +1030,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext}
 
 SecurityContext for the bash container.
 
@@ -1042,7 +1042,7 @@ SecurityContext for the bash container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities}
 
 The capabilities to add/drop when running containers.
 Defaults to the default set of capabilities granted by the container runtime.
@@ -1056,7 +1056,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `add` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities-add}
+##### `add` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities-add}
 
 Added capabilities
 
@@ -1071,7 +1071,7 @@ Added capabilities
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `drop` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities-drop}
+##### `drop` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities-drop}
 
 Removed capabilities
 
@@ -1089,7 +1089,7 @@ Removed capabilities
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `privileged` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-privileged}
+##### `privileged` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-privileged}
 
 Run container in privileged mode.
 Processes in privileged containers are essentially equivalent to root on the host.
@@ -1107,7 +1107,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seLinuxOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions}
+##### `seLinuxOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions}
 
 The SELinux context to be applied to the container.
 If unspecified, the container runtime will allocate a random SELinux context for each
@@ -1123,7 +1123,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-user}
 
 User is a SELinux user label that applies to the container.
 
@@ -1138,7 +1138,7 @@ User is a SELinux user label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-role}
 
 Role is a SELinux role label that applies to the container.
 
@@ -1153,7 +1153,7 @@ Role is a SELinux role label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-type}
 
 Type is a SELinux type label that applies to the container.
 
@@ -1168,7 +1168,7 @@ Type is a SELinux type label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-level}
+##### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-level}
 
 Level is SELinux level label that applies to the container.
 
@@ -1186,7 +1186,7 @@ Level is SELinux level label that applies to the container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `windowsOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions}
+##### `windowsOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions}
 
 The Windows specific settings applied to all containers.
 If unspecified, the options from the PodSecurityContext will be used.
@@ -1201,7 +1201,7 @@ Note that this field cannot be set when spec.os.name is linux.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-gmsaCredentialSpecName}
+##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-gmsaCredentialSpecName}
 
 GMSACredentialSpecName is the name of the GMSA credential spec to use.
 
@@ -1216,7 +1216,7 @@ GMSACredentialSpecName is the name of the GMSA credential spec to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-gmsaCredentialSpec}
+##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-gmsaCredentialSpec}
 
 GMSACredentialSpec is where the GMSA admission webhook
 (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
@@ -1233,7 +1233,7 @@ GMSA credential spec named by the GMSACredentialSpecName field.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUserName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-runAsUserName}
+##### `runAsUserName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-runAsUserName}
 
 The UserName in Windows to run the entrypoint of the container process.
 Defaults to the user specified in image metadata if unspecified.
@@ -1251,7 +1251,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostProcess` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-hostProcess}
+##### `hostProcess` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-hostProcess}
 
 HostProcess determines if a container should be run as a 'Host Process' container.
 All of a Pod's containers must have the same effective HostProcess value
@@ -1272,7 +1272,7 @@ In addition, if HostProcess is true then HostNetwork must also be set to true.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUser` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsUser}
+##### `runAsUser` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsUser}
 
 The UID to run the entrypoint of the container process.
 Defaults to user specified in image metadata if unspecified.
@@ -1291,7 +1291,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsGroup}
+##### `runAsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsGroup}
 
 The GID to run the entrypoint of the container process.
 Uses runtime default if unset.
@@ -1310,7 +1310,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsNonRoot` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsNonRoot}
+##### `runAsNonRoot` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsNonRoot}
 
 Indicates that the container must run as a non-root user.
 If true, the Kubelet will validate the image at runtime to ensure that it
@@ -1330,7 +1330,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnlyRootFilesystem` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-readOnlyRootFilesystem}
+##### `readOnlyRootFilesystem` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-readOnlyRootFilesystem}
 
 Whether this container has a read-only root filesystem.
 Default is false.
@@ -1347,7 +1347,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowPrivilegeEscalation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-allowPrivilegeEscalation}
+##### `allowPrivilegeEscalation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-allowPrivilegeEscalation}
 
 AllowPrivilegeEscalation controls whether a process can gain more
 privileges than its parent process. This bool directly controls if
@@ -1368,7 +1368,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `procMount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-procMount}
+##### `procMount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-procMount}
 
 procMount denotes the type of proc mount to use for the containers.
 The default value is Default which uses the container runtime defaults for
@@ -1386,7 +1386,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seccompProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seccompProfile}
+##### `seccompProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seccompProfile}
 
 The seccomp options to use by this container. If seccomp options are
 provided at both the pod & container level, the container options
@@ -1421,7 +1421,7 @@ Unconfined - no profile should be applied.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seccompProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seccompProfile-localhostProfile}
 
 localhostProfile indicates a profile defined in a file on the node should be used.
 The profile must be preconfigured on the node to work.
@@ -1442,7 +1442,7 @@ Must be set if type is "Localhost". Must NOT be set for any other type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `appArmorProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-appArmorProfile}
+##### `appArmorProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-appArmorProfile}
 
 appArmorProfile is the AppArmor options to use by this container. If set, this profile
 overrides the pod's appArmorProfile.
@@ -1475,7 +1475,7 @@ Valid options are:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-appArmorProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-appArmorProfile-localhostProfile}
 
 localhostProfile indicates a profile loaded on the node that should be used.
 The profile must be preconfigured on the node to work.
@@ -1502,7 +1502,7 @@ Must be set if and only if type is "Localhost".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-values}
+#### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-values}
 
 Values is the set of extra Values added to the chart.
 These values merge with the default values inside of the chart.
@@ -1519,7 +1519,7 @@ You can use golang templating in here with values from parameters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-parameters}
 
 Parameters are additional helm chart values that will get merged
 with config and are then used to deploy the helm chart.
@@ -1535,7 +1535,7 @@ with config and are then used to deploy the helm chart.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-annotations}
 
 Annotations are extra annotations for this helm release
 
@@ -1553,7 +1553,7 @@ Annotations are extra annotations for this helm release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-wait}
+### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1568,7 +1568,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-timeout}
+### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1583,7 +1583,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -1595,7 +1595,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
+#### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -1610,7 +1610,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
+#### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -1625,7 +1625,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -1640,7 +1640,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
+#### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -1656,7 +1656,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
+#### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -1671,7 +1671,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
+#### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -1686,7 +1686,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
+#### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -1701,7 +1701,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
+#### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -1716,7 +1716,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
+#### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -1731,7 +1731,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
+#### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -1746,7 +1746,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
+#### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -1761,7 +1761,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
+#### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -1776,7 +1776,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
+#### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -1794,7 +1794,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `streamContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer}
+### `streamContainer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer}
 
 DEPRECATED: Use config.bash instead
 StreamContainer can be used to stream a containers logs instead of the helm output.
@@ -1807,7 +1807,7 @@ StreamContainer can be used to stream a containers logs instead of the helm outp
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector}
 
 Label selector for pods. The newest matching pod will be used to stream logs from
 
@@ -1819,7 +1819,7 @@ Label selector for pods. The newest matching pod will be used to stream logs fro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchLabels}
 
 matchLabels is a map of &#123;key,value&#125; pairs. A single &#123;key,value&#125; in the matchLabels
 map is equivalent to an element of matchExpressions, whose key field is "key", the
@@ -1836,7 +1836,7 @@ operator is "In", and the values array contains only "value". The requirements a
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchExpressions}
 
 matchExpressions is a list of label selector requirements. The requirements are ANDed.
 
@@ -1879,7 +1879,7 @@ Valid operators are In, NotIn, Exists and DoesNotExist.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchExpressions-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchExpressions-values}
 
 values is an array of string values. If the operator is In or NotIn,
 the values array must be non-empty. If the operator is Exists or DoesNotExist,
@@ -1903,7 +1903,7 @@ merge patch.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `container` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-container}
+#### `container` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-container}
 
 Container is the container name to use
 
@@ -1921,7 +1921,7 @@ Container is the container name to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `versions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
+### `versions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
 
 Versions are different app versions that can be referenced
 
@@ -1933,7 +1933,7 @@ Versions are different app versions that can be referenced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-defaultNamespace}
+#### `defaultNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-defaultNamespace}
 
 DefaultNamespace is the default namespace this app should installed
 in.
@@ -1949,7 +1949,7 @@ in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `readme` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-readme}
+#### `readme` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-readme}
 
 Readme is a longer markdown string that describes the app.
 
@@ -1964,7 +1964,7 @@ Readme is a longer markdown string that describes the app.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-icon}
 
 Icon holds an URL to the app icon
 
@@ -1979,7 +1979,7 @@ Icon holds an URL to the app icon
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config}
+#### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config}
 
 Config is the helm config to use to deploy the helm release
 
@@ -1991,7 +1991,7 @@ Config is the helm config to use to deploy the helm release
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart}
 
 Chart holds information about a chart that should get deployed
 
@@ -2003,7 +2003,7 @@ Chart holds information about a chart that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-name}
 
 Name is the chart name in the repository
 
@@ -2018,7 +2018,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-version}
 
 Version is the chart version in the repository
 
@@ -2033,7 +2033,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -2048,7 +2048,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-username}
 
 The username that is required for this repository
 
@@ -2063,7 +2063,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef}
 
 The username that is required for this repository
 
@@ -2075,7 +2075,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2087,7 +2087,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2102,7 +2102,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2117,7 +2117,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2138,7 +2138,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-password}
 
 The password that is required for this repository
 
@@ -2153,7 +2153,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef}
 
 The password that is required for this repository
 
@@ -2165,7 +2165,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2177,7 +2177,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2192,7 +2192,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2207,7 +2207,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2228,7 +2228,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -2246,7 +2246,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-manifests}
+##### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-manifests}
 
 Manifests holds kube manifests that will be deployed as a chart
 
@@ -2261,7 +2261,7 @@ Manifests holds kube manifests that will be deployed as a chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `bash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash}
+##### `bash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash}
 
 Bash holds the bash script to execute in a container in the target
 
@@ -2273,7 +2273,7 @@ Bash holds the bash script to execute in a container in the target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `script` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-script}
+##### `script` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-script}
 
 Script is the script to execute.
 
@@ -2288,7 +2288,7 @@ Script is the script to execute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-image}
 
 Image is the image to use for this app
 
@@ -2303,7 +2303,7 @@ Image is the image to use for this app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-clusterRole}
 
 ClusterRole is the cluster role to use for this job
 
@@ -2318,7 +2318,7 @@ ClusterRole is the cluster role to use for this job
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext}
 
 PodSecurityContext for the bash pod.
 
@@ -2330,7 +2330,7 @@ PodSecurityContext for the bash pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seLinuxOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions}
+##### `seLinuxOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions}
 
 The SELinux context to be applied to all containers.
 If unspecified, the container runtime will allocate a random SELinux context for each
@@ -2347,7 +2347,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-user}
 
 User is a SELinux user label that applies to the container.
 
@@ -2362,7 +2362,7 @@ User is a SELinux user label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-role}
 
 Role is a SELinux role label that applies to the container.
 
@@ -2377,7 +2377,7 @@ Role is a SELinux role label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-type}
 
 Type is a SELinux type label that applies to the container.
 
@@ -2392,7 +2392,7 @@ Type is a SELinux type label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-level}
+##### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-level}
 
 Level is SELinux level label that applies to the container.
 
@@ -2410,7 +2410,7 @@ Level is SELinux level label that applies to the container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `windowsOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions}
+##### `windowsOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions}
 
 The Windows specific settings applied to all containers.
 If unspecified, the options within a container's SecurityContext will be used.
@@ -2425,7 +2425,7 @@ Note that this field cannot be set when spec.os.name is linux.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpecName}
+##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpecName}
 
 GMSACredentialSpecName is the name of the GMSA credential spec to use.
 
@@ -2440,7 +2440,7 @@ GMSACredentialSpecName is the name of the GMSA credential spec to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpec}
+##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpec}
 
 GMSACredentialSpec is where the GMSA admission webhook
 (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
@@ -2457,7 +2457,7 @@ GMSA credential spec named by the GMSACredentialSpecName field.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUserName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-runAsUserName}
+##### `runAsUserName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-runAsUserName}
 
 The UserName in Windows to run the entrypoint of the container process.
 Defaults to the user specified in image metadata if unspecified.
@@ -2475,7 +2475,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostProcess` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-hostProcess}
+##### `hostProcess` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-hostProcess}
 
 HostProcess determines if a container should be run as a 'Host Process' container.
 All of a Pod's containers must have the same effective HostProcess value
@@ -2496,7 +2496,7 @@ In addition, if HostProcess is true then HostNetwork must also be set to true.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUser` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsUser}
+##### `runAsUser` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsUser}
 
 The UID to run the entrypoint of the container process.
 Defaults to user specified in image metadata if unspecified.
@@ -2516,7 +2516,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsGroup}
+##### `runAsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsGroup}
 
 The GID to run the entrypoint of the container process.
 Uses runtime default if unset.
@@ -2536,7 +2536,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsNonRoot` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsNonRoot}
+##### `runAsNonRoot` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsNonRoot}
 
 Indicates that the container must run as a non-root user.
 If true, the Kubelet will validate the image at runtime to ensure that it
@@ -2556,7 +2556,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `supplementalGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-supplementalGroups}
+##### `supplementalGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-supplementalGroups}
 
 A list of groups applied to the first process run in each container, in
 addition to the container's primary GID and fsGroup (if specified).  If
@@ -2579,7 +2579,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `supplementalGroupsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-supplementalGroupsPolicy}
+##### `supplementalGroupsPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-supplementalGroupsPolicy}
 
 Defines how supplemental groups of the first container processes are calculated.
 Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
@@ -2599,7 +2599,7 @@ TODO: update the default value to "Merge" when spec.os.name is not windows in v1
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-fsGroup}
+##### `fsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-fsGroup}
 
 A special supplemental group that applies to all containers in a pod.
 Some volume types allow the Kubelet to change the ownership of that volume
@@ -2623,7 +2623,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sysctls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-sysctls}
+##### `sysctls` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-sysctls}
 
 Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
 sysctls (by the container runtime) might fail to launch.
@@ -2670,7 +2670,7 @@ Value of a property to set
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fsGroupChangePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-fsGroupChangePolicy}
+##### `fsGroupChangePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-fsGroupChangePolicy}
 
 fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
 before being exposed inside Pod. This field will only apply to
@@ -2691,7 +2691,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seccompProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seccompProfile}
+##### `seccompProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seccompProfile}
 
 The seccomp options to use by the containers in this pod.
 Note that this field cannot be set when spec.os.name is windows.
@@ -2724,7 +2724,7 @@ Unconfined - no profile should be applied.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seccompProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seccompProfile-localhostProfile}
 
 localhostProfile indicates a profile defined in a file on the node should be used.
 The profile must be preconfigured on the node to work.
@@ -2745,7 +2745,7 @@ Must be set if type is "Localhost". Must NOT be set for any other type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `appArmorProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-appArmorProfile}
+##### `appArmorProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-appArmorProfile}
 
 appArmorProfile is the AppArmor options to use by the containers in this pod.
 Note that this field cannot be set when spec.os.name is windows.
@@ -2777,7 +2777,7 @@ Valid options are:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-appArmorProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-appArmorProfile-localhostProfile}
 
 localhostProfile indicates a profile loaded on the node that should be used.
 The profile must be preconfigured on the node to work.
@@ -2798,7 +2798,7 @@ Must be set if and only if type is "Localhost".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `seLinuxChangePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxChangePolicy}
+##### `seLinuxChangePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxChangePolicy}
 
 seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
 It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
@@ -2838,7 +2838,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext}
 
 SecurityContext for the bash container.
 
@@ -2850,7 +2850,7 @@ SecurityContext for the bash container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities}
 
 The capabilities to add/drop when running containers.
 Defaults to the default set of capabilities granted by the container runtime.
@@ -2864,7 +2864,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `add` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities-add}
+##### `add` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities-add}
 
 Added capabilities
 
@@ -2879,7 +2879,7 @@ Added capabilities
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `drop` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities-drop}
+##### `drop` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities-drop}
 
 Removed capabilities
 
@@ -2897,7 +2897,7 @@ Removed capabilities
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `privileged` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-privileged}
+##### `privileged` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-privileged}
 
 Run container in privileged mode.
 Processes in privileged containers are essentially equivalent to root on the host.
@@ -2915,7 +2915,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seLinuxOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions}
+##### `seLinuxOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions}
 
 The SELinux context to be applied to the container.
 If unspecified, the container runtime will allocate a random SELinux context for each
@@ -2931,7 +2931,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-user}
 
 User is a SELinux user label that applies to the container.
 
@@ -2946,7 +2946,7 @@ User is a SELinux user label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-role}
 
 Role is a SELinux role label that applies to the container.
 
@@ -2961,7 +2961,7 @@ Role is a SELinux role label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-type}
 
 Type is a SELinux type label that applies to the container.
 
@@ -2976,7 +2976,7 @@ Type is a SELinux type label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-level}
+##### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-level}
 
 Level is SELinux level label that applies to the container.
 
@@ -2994,7 +2994,7 @@ Level is SELinux level label that applies to the container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `windowsOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions}
+##### `windowsOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions}
 
 The Windows specific settings applied to all containers.
 If unspecified, the options from the PodSecurityContext will be used.
@@ -3009,7 +3009,7 @@ Note that this field cannot be set when spec.os.name is linux.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-gmsaCredentialSpecName}
+##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-gmsaCredentialSpecName}
 
 GMSACredentialSpecName is the name of the GMSA credential spec to use.
 
@@ -3024,7 +3024,7 @@ GMSACredentialSpecName is the name of the GMSA credential spec to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-gmsaCredentialSpec}
+##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-gmsaCredentialSpec}
 
 GMSACredentialSpec is where the GMSA admission webhook
 (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
@@ -3041,7 +3041,7 @@ GMSA credential spec named by the GMSACredentialSpecName field.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUserName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-runAsUserName}
+##### `runAsUserName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-runAsUserName}
 
 The UserName in Windows to run the entrypoint of the container process.
 Defaults to the user specified in image metadata if unspecified.
@@ -3059,7 +3059,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostProcess` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-hostProcess}
+##### `hostProcess` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-hostProcess}
 
 HostProcess determines if a container should be run as a 'Host Process' container.
 All of a Pod's containers must have the same effective HostProcess value
@@ -3080,7 +3080,7 @@ In addition, if HostProcess is true then HostNetwork must also be set to true.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUser` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsUser}
+##### `runAsUser` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsUser}
 
 The UID to run the entrypoint of the container process.
 Defaults to user specified in image metadata if unspecified.
@@ -3099,7 +3099,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsGroup}
+##### `runAsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsGroup}
 
 The GID to run the entrypoint of the container process.
 Uses runtime default if unset.
@@ -3118,7 +3118,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsNonRoot` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsNonRoot}
+##### `runAsNonRoot` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsNonRoot}
 
 Indicates that the container must run as a non-root user.
 If true, the Kubelet will validate the image at runtime to ensure that it
@@ -3138,7 +3138,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnlyRootFilesystem` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-readOnlyRootFilesystem}
+##### `readOnlyRootFilesystem` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-readOnlyRootFilesystem}
 
 Whether this container has a read-only root filesystem.
 Default is false.
@@ -3155,7 +3155,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowPrivilegeEscalation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-allowPrivilegeEscalation}
+##### `allowPrivilegeEscalation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-allowPrivilegeEscalation}
 
 AllowPrivilegeEscalation controls whether a process can gain more
 privileges than its parent process. This bool directly controls if
@@ -3176,7 +3176,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `procMount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-procMount}
+##### `procMount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-procMount}
 
 procMount denotes the type of proc mount to use for the containers.
 The default value is Default which uses the container runtime defaults for
@@ -3194,7 +3194,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seccompProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seccompProfile}
+##### `seccompProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seccompProfile}
 
 The seccomp options to use by this container. If seccomp options are
 provided at both the pod & container level, the container options
@@ -3229,7 +3229,7 @@ Unconfined - no profile should be applied.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seccompProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seccompProfile-localhostProfile}
 
 localhostProfile indicates a profile defined in a file on the node should be used.
 The profile must be preconfigured on the node to work.
@@ -3250,7 +3250,7 @@ Must be set if type is "Localhost". Must NOT be set for any other type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `appArmorProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-appArmorProfile}
+##### `appArmorProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-appArmorProfile}
 
 appArmorProfile is the AppArmor options to use by this container. If set, this profile
 overrides the pod's appArmorProfile.
@@ -3283,7 +3283,7 @@ Valid options are:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-appArmorProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-appArmorProfile-localhostProfile}
 
 localhostProfile indicates a profile loaded on the node that should be used.
 The profile must be preconfigured on the node to work.
@@ -3310,7 +3310,7 @@ Must be set if and only if type is "Localhost".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-values}
 
 Values is the set of extra Values added to the chart.
 These values merge with the default values inside of the chart.
@@ -3327,7 +3327,7 @@ You can use golang templating in here with values from parameters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-parameters}
 
 Parameters are additional helm chart values that will get merged
 with config and are then used to deploy the helm chart.
@@ -3343,7 +3343,7 @@ with config and are then used to deploy the helm chart.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-annotations}
 
 Annotations are extra annotations for this helm release
 
@@ -3361,7 +3361,7 @@ Annotations are extra annotations for this helm release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-wait}
+#### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -3376,7 +3376,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-timeout}
+#### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -3391,7 +3391,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -3403,7 +3403,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -3418,7 +3418,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -3433,7 +3433,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -3448,7 +3448,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -3464,7 +3464,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -3479,7 +3479,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -3494,7 +3494,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -3509,7 +3509,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -3524,7 +3524,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -3539,7 +3539,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -3554,7 +3554,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -3569,7 +3569,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -3584,7 +3584,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -3602,7 +3602,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `streamContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer}
+#### `streamContainer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer}
 
 DEPRECATED: Use config.bash instead
 StreamContainer can be used to stream a containers logs instead of the helm output.
@@ -3615,7 +3615,7 @@ StreamContainer can be used to stream a containers logs instead of the helm outp
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector}
 
 Label selector for pods. The newest matching pod will be used to stream logs from
 
@@ -3627,7 +3627,7 @@ Label selector for pods. The newest matching pod will be used to stream logs fro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchLabels}
 
 matchLabels is a map of &#123;key,value&#125; pairs. A single &#123;key,value&#125; in the matchLabels
 map is equivalent to an element of matchExpressions, whose key field is "key", the
@@ -3644,7 +3644,7 @@ operator is "In", and the values array contains only "value". The requirements a
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchExpressions}
 
 matchExpressions is a list of label selector requirements. The requirements are ANDed.
 
@@ -3687,7 +3687,7 @@ Valid operators are In, NotIn, Exists and DoesNotExist.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchExpressions-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchExpressions-values}
 
 values is an array of string values. If the operator is In or NotIn,
 the values array must be non-empty. If the operator is Exists or DoesNotExist,
@@ -3711,7 +3711,7 @@ merge patch.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `container` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-container}
+##### `container` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-container}
 
 Container is the container name to use
 
@@ -3729,7 +3729,7 @@ Container is the container name to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
 
 Version is the version. Needs to be in X.X.X format.
 
@@ -3747,7 +3747,7 @@ Version is the version. Needs to be in X.X.X format.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -3759,7 +3759,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -3789,7 +3789,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -3804,7 +3804,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -3819,7 +3819,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -3837,7 +3837,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-manifests}
+### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-manifests}
 
 DEPRECATED: Use config instead
 manifest represents kubernetes resources that will be deployed into the target namespace
@@ -3853,7 +3853,7 @@ manifest represents kubernetes resources that will be deployed into the target n
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm}
+### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm}
 
 DEPRECATED: Use config instead
 helm defines the configuration for a helm deployment
@@ -3881,7 +3881,7 @@ Name of the chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-values}
+#### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-values}
 
 The additional helm values to use. Expected block string
 
@@ -3896,7 +3896,7 @@ The additional helm values to use. Expected block string
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-version}
 
 Version is the version of the chart to deploy
 
@@ -3911,7 +3911,7 @@ Version is the version of the chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repoUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-repoUrl}
+#### `repoUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-repoUrl}
 
 The repo url to use
 
@@ -3926,7 +3926,7 @@ The repo url to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-username}
 
 The username to use for the selected repository
 
@@ -3941,7 +3941,7 @@ The username to use for the selected repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-password}
+#### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-password}
 
 The password to use for the selected repository
 
@@ -3956,7 +3956,7 @@ The password to use for the selected repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-insecure}
+#### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-insecure}
 
 Determines if the remote location uses an insecure
 TLS certificate.
@@ -3978,7 +3978,7 @@ TLS certificate.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 

--- a/platform/api/_partials/resources/apps/reference.mdx
+++ b/platform/api/_partials/resources/apps/reference.mdx
@@ -195,7 +195,7 @@ Chart holds information about a chart that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-name}
 
 Name is the chart name in the repository
 
@@ -2003,7 +2003,7 @@ Chart holds information about a chart that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-name}
 
 Name is the chart name in the repository
 

--- a/platform/api/_partials/resources/clusteraccesses/reference.mdx
+++ b/platform/api/_partials/resources/clusteraccesses/reference.mdx
@@ -200,7 +200,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `localClusterAccessTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate}
+### `localClusterAccessTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate}
 
 LocalClusterAccessTemplate holds the cluster access template
 
@@ -640,7 +640,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -655,7 +655,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -671,7 +671,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -708,7 +708,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -739,7 +739,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The

--- a/platform/api/_partials/resources/clusteraccesses/reference.mdx
+++ b/platform/api/_partials/resources/clusteraccesses/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a cluster access object
 
@@ -50,7 +50,7 @@ Description describes a cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
+### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
 
 Clusters are the clusters this template should be applied on.
 
@@ -110,7 +110,7 @@ Clusters are the clusters this template should be applied on.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -122,7 +122,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -152,7 +152,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -167,7 +167,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -182,7 +182,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -200,7 +200,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `localClusterAccessTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate}
+### `localClusterAccessTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate}
 
 LocalClusterAccessTemplate holds the cluster access template
 
@@ -212,7 +212,7 @@ LocalClusterAccessTemplate holds the cluster access template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata}
 
 Metadata is the metadata of the cluster access object
 
@@ -224,7 +224,7 @@ Metadata is the metadata of the cluster access object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -244,7 +244,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-generateName}
+##### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -270,7 +270,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -292,7 +292,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-selfLink}
+##### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -307,7 +307,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-uid}
+##### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -328,7 +328,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-resourceVersion}
+##### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -352,7 +352,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-generation}
+##### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -368,7 +368,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-creationTimestamp}
+##### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -390,7 +390,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-deletionTimestamp}
+##### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -422,7 +422,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-deletionGracePeriodSeconds}
+##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -440,7 +440,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -458,7 +458,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -476,7 +476,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences}
+##### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -554,7 +554,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -569,7 +569,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -594,7 +594,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-finalizers}
+##### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -621,7 +621,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields}
+##### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -640,7 +640,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -655,7 +655,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -671,7 +671,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -689,7 +689,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -708,7 +708,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -724,7 +724,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -739,7 +739,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -766,7 +766,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec}
 
 LocalClusterAccessSpec holds the spec of the cluster access in the cluster
 
@@ -778,7 +778,7 @@ LocalClusterAccessSpec holds the spec of the cluster access in the cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-displayName}
 
 DisplayName is the name that should be shown in the UI
 
@@ -793,7 +793,7 @@ DisplayName is the name that should be shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-description}
 
 Description is the description of this object in
 human-readable text.
@@ -809,7 +809,7 @@ human-readable text.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users}
 
 Users are the users affected by this cluster access object
 
@@ -821,7 +821,7 @@ Users are the users affected by this cluster access object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users-user}
 
 User specifies a Loft user.
 
@@ -836,7 +836,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users-team}
+##### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users-team}
 
 Team specifies a Loft team.
 
@@ -854,7 +854,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-teams}
 
 Teams are the teams affected by this cluster access object
 
@@ -869,7 +869,7 @@ Teams are the teams affected by this cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-clusterRoles}
+##### `clusterRoles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-clusterRoles}
 
 ClusterRoles define the cluster roles that the users should have assigned in the cluster.
 
@@ -881,7 +881,7 @@ ClusterRoles define the cluster roles that the users should have assigned in the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-clusterRoles-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-clusterRoles-name}
 
 Name is the cluster role to assign
 
@@ -899,7 +899,7 @@ Name is the cluster role to assign
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priority` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-priority}
+##### `priority` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-priority}
 
 Priority is a unique value that specifies the priority of this cluster access
 for the space constraints and quota. A higher priority means the cluster access object
@@ -925,7 +925,7 @@ will override the space constraints of lower priority cluster access objects
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 

--- a/platform/api/_partials/resources/clusterroletemplates/reference.mdx
+++ b/platform/api/_partials/resources/clusterroletemplates/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a cluster role template object
 
@@ -50,7 +50,7 @@ Description describes a cluster role template object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
+### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
 
 Clusters are the clusters this template should be applied on.
 
@@ -110,7 +110,7 @@ Clusters are the clusters this template should be applied on.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `management` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-management}
+### `management` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-management}
 
 Management defines if this cluster role should be created in the management instance.
 
@@ -125,7 +125,7 @@ Management defines if this cluster role should be created in the management inst
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -137,7 +137,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -167,7 +167,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -182,7 +182,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -197,7 +197,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -215,7 +215,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRoleTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate}
+### `clusterRoleTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate}
 
 ClusterRoleTemplate holds the cluster role template
 
@@ -227,7 +227,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata}
 
 
 
@@ -239,7 +239,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -259,7 +259,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-generateName}
+##### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -285,7 +285,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -307,7 +307,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-selfLink}
+##### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -322,7 +322,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-uid}
+##### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -343,7 +343,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-resourceVersion}
+##### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -367,7 +367,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-generation}
+##### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -383,7 +383,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-creationTimestamp}
+##### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -405,7 +405,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-deletionTimestamp}
+##### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -437,7 +437,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-deletionGracePeriodSeconds}
+##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -455,7 +455,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -473,7 +473,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -491,7 +491,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences}
+##### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -569,7 +569,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -584,7 +584,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -609,7 +609,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-finalizers}
+##### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -636,7 +636,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields}
+##### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -655,7 +655,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -670,7 +670,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -686,7 +686,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -704,7 +704,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -723,7 +723,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -739,7 +739,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -754,7 +754,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -781,7 +781,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules}
 
 Rules holds all the PolicyRules for this ClusterRole
 
@@ -808,7 +808,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-apiGroups}
 
 
 
@@ -823,7 +823,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resources}
 
 
 
@@ -838,7 +838,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resourceNames}
 
 
 
@@ -853,7 +853,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-nonResourceURLs}
 
 
 
@@ -871,7 +871,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `aggregationRule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule}
+#### `aggregationRule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule}
 
 AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
@@ -885,7 +885,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoleSelectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
+##### `clusterRoleSelectors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
 
 
 
@@ -897,7 +897,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchLabels}
 
 matchLabels is a map of &#123;key,value&#125; pairs. A single &#123;key,value&#125; in the matchLabels
 map is equivalent to an element of matchExpressions, whose key field is "key", the
@@ -914,7 +914,7 @@ operator is "In", and the values array contains only "value". The requirements a
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions}
 
 matchExpressions is a list of label selector requirements. The requirements are ANDed.
 
@@ -957,7 +957,7 @@ Valid operators are In, NotIn, Exists and DoesNotExist.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions-values}
 
 values is an array of string values. If the operator is In or NotIn,
 the values array must be non-empty. If the operator is Exists or DoesNotExist,
@@ -987,7 +987,7 @@ merge patch.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `localClusterRoleTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate}
+### `localClusterRoleTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate}
 
 DEPRECATED: Use ClusterRoleTemplate instead
 LocalClusterRoleTemplate holds the cluster role template
@@ -1000,7 +1000,7 @@ LocalClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata}
 
 Metadata is the metadata of the cluster role template object
 
@@ -1012,7 +1012,7 @@ Metadata is the metadata of the cluster role template object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -1032,7 +1032,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-generateName}
+##### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -1058,7 +1058,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -1080,7 +1080,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-selfLink}
+##### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -1095,7 +1095,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-uid}
+##### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -1116,7 +1116,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-resourceVersion}
+##### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -1140,7 +1140,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-generation}
+##### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -1156,7 +1156,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-creationTimestamp}
+##### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -1178,7 +1178,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-deletionTimestamp}
+##### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -1210,7 +1210,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-deletionGracePeriodSeconds}
+##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -1228,7 +1228,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -1246,7 +1246,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -1264,7 +1264,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences}
+##### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -1342,7 +1342,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -1357,7 +1357,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -1382,7 +1382,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-finalizers}
+##### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -1409,7 +1409,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields}
+##### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -1428,7 +1428,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -1443,7 +1443,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -1459,7 +1459,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -1477,7 +1477,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -1496,7 +1496,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -1512,7 +1512,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -1527,7 +1527,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -1554,7 +1554,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec}
 
 LocalClusterRoleTemplateSpec holds the spec of the cluster role template in the cluster
 
@@ -1566,7 +1566,7 @@ LocalClusterRoleTemplateSpec holds the spec of the cluster role template in the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-displayName}
 
 DisplayName is the name that should be shown in the UI
 
@@ -1581,7 +1581,7 @@ DisplayName is the name that should be shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-description}
 
 Description is the description of this object in
 human-readable text.
@@ -1597,7 +1597,7 @@ human-readable text.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoleTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate}
+##### `clusterRoleTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate}
 
 ClusterRoleTemplate holds the cluster role template
 
@@ -1609,7 +1609,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata}
 
 
 
@@ -1621,7 +1621,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -1641,7 +1641,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-generateName}
+##### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -1667,7 +1667,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -1689,7 +1689,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-selfLink}
+##### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -1704,7 +1704,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-uid}
+##### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -1725,7 +1725,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-resourceVersion}
+##### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -1749,7 +1749,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-generation}
+##### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -1765,7 +1765,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-creationTimestamp}
+##### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -1787,7 +1787,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-deletionTimestamp}
+##### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -1819,7 +1819,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-deletionGracePeriodSeconds}
+##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -1837,7 +1837,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -1855,7 +1855,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -1873,7 +1873,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences}
+##### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -1951,7 +1951,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -1966,7 +1966,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -1991,7 +1991,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-finalizers}
+##### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -2018,7 +2018,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields}
+##### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -2037,7 +2037,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -2052,7 +2052,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -2068,7 +2068,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -2086,7 +2086,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -2105,7 +2105,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -2121,7 +2121,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -2136,7 +2136,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -2163,7 +2163,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules}
 
 Rules holds all the PolicyRules for this ClusterRole
 
@@ -2190,7 +2190,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-apiGroups}
 
 
 
@@ -2205,7 +2205,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resources}
 
 
 
@@ -2220,7 +2220,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resourceNames}
 
 
 
@@ -2235,7 +2235,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-nonResourceURLs}
 
 
 
@@ -2253,7 +2253,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `aggregationRule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule}
+##### `aggregationRule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule}
 
 AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
@@ -2267,7 +2267,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoleSelectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
+##### `clusterRoleSelectors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
 
 
 
@@ -2279,7 +2279,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchLabels}
 
 matchLabels is a map of &#123;key,value&#125; pairs. A single &#123;key,value&#125; in the matchLabels
 map is equivalent to an element of matchExpressions, whose key field is "key", the
@@ -2296,7 +2296,7 @@ operator is "In", and the values array contains only "value". The requirements a
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions}
 
 matchExpressions is a list of label selector requirements. The requirements are ANDed.
 
@@ -2339,7 +2339,7 @@ Valid operators are In, NotIn, Exists and DoesNotExist.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions-values}
 
 values is an array of string values. If the operator is In or NotIn,
 the values array must be non-empty. If the operator is Exists or DoesNotExist,
@@ -2378,7 +2378,7 @@ merge patch.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -2390,7 +2390,7 @@ merge patch.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters}
+### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters}
 
 
 
@@ -2402,7 +2402,7 @@ merge patch.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-name}
 
 Name is the kubernetes name of the object
 
@@ -2417,7 +2417,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-displayName}
 
 The display name shown in the UI
 
@@ -2432,7 +2432,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-icon}
 
 Icon is the icon of the user / team
 
@@ -2447,7 +2447,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-username}
 
 The username that is used to login
 
@@ -2462,7 +2462,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-email}
 
 The users email address
 
@@ -2477,7 +2477,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-subject}
+#### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-subject}
 
 The user subject
 

--- a/platform/api/_partials/resources/clusterroletemplates/reference.mdx
+++ b/platform/api/_partials/resources/clusterroletemplates/reference.mdx
@@ -227,7 +227,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata}
 
 
 
@@ -655,7 +655,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -670,7 +670,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -686,7 +686,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -723,7 +723,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -754,7 +754,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -808,7 +808,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-apiGroups}
 
 
 
@@ -823,7 +823,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resources}
 
 
 
@@ -838,7 +838,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resourceNames}
 
 
 
@@ -853,7 +853,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-nonResourceURLs}
 
 
 
@@ -885,7 +885,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoleSelectors` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
+##### `clusterRoleSelectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
 
 
 
@@ -987,7 +987,7 @@ merge patch.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `localClusterRoleTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate}
+### `localClusterRoleTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate}
 
 DEPRECATED: Use ClusterRoleTemplate instead
 LocalClusterRoleTemplate holds the cluster role template
@@ -1428,7 +1428,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -1443,7 +1443,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -1459,7 +1459,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -1496,7 +1496,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -1527,7 +1527,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -1609,7 +1609,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata}
 
 
 
@@ -2037,7 +2037,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -2052,7 +2052,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -2068,7 +2068,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -2105,7 +2105,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -2136,7 +2136,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -2190,7 +2190,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-apiGroups}
 
 
 
@@ -2205,7 +2205,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resources}
 
 
 
@@ -2220,7 +2220,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resourceNames}
 
 
 
@@ -2235,7 +2235,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-nonResourceURLs}
 
 
 
@@ -2267,7 +2267,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoleSelectors` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
+##### `clusterRoleSelectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
 
 
 
@@ -2402,7 +2402,7 @@ merge patch.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-name}
 
 Name is the kubernetes name of the object
 

--- a/platform/api/_partials/resources/clusters/reference.mdx
+++ b/platform/api/_partials/resources/clusters/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 If specified this name is displayed in the UI instead of the metadata name
 
@@ -35,7 +35,7 @@ If specified this name is displayed in the UI instead of the metadata name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a cluster access object
 
@@ -50,7 +50,7 @@ Description describes a cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config}
+### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config}
 
 Holds a reference to a secret that holds the kube config to access this cluster
 
@@ -107,7 +107,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-secretName}
 
 
 
@@ -122,7 +122,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-secretNamespace}
+#### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-secretNamespace}
 
 
 
@@ -137,7 +137,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-key}
+#### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-key}
 
 
 
@@ -155,7 +155,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `local` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-local}
+### `local` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-local}
 
 Local specifies if it is the local cluster that should be connected, when this is specified, config is optional
 
@@ -170,7 +170,7 @@ Local specifies if it is the local cluster that should be connected, when this i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `networkPeer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-networkPeer}
+### `networkPeer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-networkPeer}
 
 NetworkPeer specifies if the cluster is connected via tailscale, when this is specified, config is optional
 
@@ -185,7 +185,7 @@ NetworkPeer specifies if the cluster is connected via tailscale, when this is sp
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `managementNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-managementNamespace}
+### `managementNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-managementNamespace}
 
 The namespace where the cluster components will be installed in
 
@@ -200,7 +200,7 @@ The namespace where the cluster components will be installed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `unusable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-unusable}
+### `unusable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-unusable}
 
 If unusable is true, no spaces or tenant clusters can be scheduled on this cluster.
 
@@ -215,7 +215,7 @@ If unusable is true, no spaces or tenant clusters can be scheduled on this clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -227,7 +227,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -257,7 +257,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -272,7 +272,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -287,7 +287,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -305,7 +305,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics}
+### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics}
 
 Metrics holds the cluster's metrics backend configuration
 
@@ -317,7 +317,7 @@ Metrics holds the cluster's metrics backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-replicas}
+#### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -332,7 +332,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -344,7 +344,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -360,7 +360,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -378,7 +378,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -414,7 +414,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -438,7 +438,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-retention}
+#### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -453,7 +453,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage}
+#### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage}
 
 
 
@@ -465,7 +465,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -482,7 +482,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -503,7 +503,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost}
+### `opencost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost}
 
 OpenCost holds the cluster's OpenCost backend configuration
 
@@ -515,7 +515,7 @@ OpenCost holds the cluster's OpenCost backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-replicas}
+#### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -530,7 +530,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -542,7 +542,7 @@ Resources are compute resource required by the OpenCost backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -558,7 +558,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -576,7 +576,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -612,7 +612,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -639,7 +639,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `argoCD` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD}
+### `argoCD` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD}
 
 ArgoCD holds the cluster's argo cd configuration
 
@@ -651,7 +651,7 @@ ArgoCD holds the cluster's argo cd configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-enabled}
 
 Enabled defines if argo cd is enabled
 
@@ -666,7 +666,7 @@ Enabled defines if argo cd is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-connector}
+#### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-connector}
 
 Connector specifies the argo cd connector name
 
@@ -687,7 +687,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -699,22 +699,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `phase` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-### `reason` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
+### `phase` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
 
 
 
@@ -729,7 +714,22 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `message` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
+### `reason` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
 
 
 
@@ -744,7 +744,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions holds several conditions the cluster might be in
 

--- a/platform/api/_partials/resources/clusters/reference.mdx
+++ b/platform/api/_partials/resources/clusters/reference.mdx
@@ -305,7 +305,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics}
+### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics}
 
 Metrics holds the cluster's metrics backend configuration
 
@@ -317,7 +317,7 @@ Metrics holds the cluster's metrics backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -332,7 +332,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -438,7 +438,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-retention}
+#### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -453,7 +453,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage}
+#### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage}
 
 
 
@@ -465,7 +465,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -482,7 +482,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -503,7 +503,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `opencost` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost}
+### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost}
 
 OpenCost holds the cluster's OpenCost backend configuration
 
@@ -515,7 +515,7 @@ OpenCost holds the cluster's OpenCost backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -530,7 +530,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 

--- a/platform/api/_partials/resources/config/reference.mdx
+++ b/platform/api/_partials/resources/config/reference.mdx
@@ -74,7 +74,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -97,7 +97,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -117,7 +117,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -132,7 +132,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -409,7 +409,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-clientId}
 
 ClientID holds the github client id
 
@@ -917,7 +917,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -934,7 +934,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -965,7 +965,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -980,7 +980,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -1161,7 +1161,7 @@ Password holds password authentication relevant information
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `disabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password-disabled}
+##### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password-disabled}
 
 If true login via password is disabled
 
@@ -1233,7 +1233,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -1256,7 +1256,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -1276,7 +1276,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -1291,7 +1291,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -1568,7 +1568,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-clientId}
 
 ClientID holds the github client id
 
@@ -2076,7 +2076,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -2093,7 +2093,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -2124,7 +2124,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -2139,7 +2139,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -2395,7 +2395,7 @@ CustomHttpHeaders are additional headers that should be set for the authenticati
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsFilters` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-groupsFilters}
+#### `groupsFilters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-groupsFilters}
 
 GroupsFilters is a regex expression to only save matching sso groups into the user resource
 
@@ -2425,7 +2425,7 @@ DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-enabled}
 
 If true indicates that loft will act as an OIDC server
 
@@ -2440,7 +2440,7 @@ If true indicates that loft will act as an OIDC server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `wildcardRedirect` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-wildcardRedirect}
+#### `wildcardRedirect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-wildcardRedirect}
 
 If true indicates that loft will allow wildcard '*' in client redirectURIs
 
@@ -2455,7 +2455,7 @@ If true indicates that loft will allow wildcard '*' in client redirectURIs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clients` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients}
+#### `clients` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients}
 
 The clients that are allowed to request loft tokens
 
@@ -2467,7 +2467,7 @@ The clients that are allowed to request loft tokens
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-name}
 
 The client name
 
@@ -2482,7 +2482,7 @@ The client name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientId}
 
 The client id of the client
 
@@ -2497,7 +2497,7 @@ The client id of the client
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientSecret}
 
 The client secret of the client
 
@@ -2851,7 +2851,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -3778,7 +3778,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableConfigEndpoint` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-disableConfigEndpoint}
+### `disableConfigEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-disableConfigEndpoint}
 
 DisableLoftConfigEndpoint will disable setting config via the UI and config.management.loft.sh endpoint
 
@@ -3793,7 +3793,7 @@ DisableLoftConfigEndpoint will disable setting config via the UI and config.mana
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `authenticateVersionEndpoint` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-authenticateVersionEndpoint}
+### `authenticateVersionEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-authenticateVersionEndpoint}
 
 AuthenticateVersionEndpoint will force authentication for the '/version' endpoint. Will only work with vCluster v0.27 & later
 
@@ -3808,7 +3808,7 @@ AuthenticateVersionEndpoint will force authentication for the '/version' endpoin
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cloud` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud}
+### `cloud` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud}
 
 Cloud holds the settings to be used exclusively in vCluster Cloud based
 environments and deployments.
@@ -3821,7 +3821,7 @@ environments and deployments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `releaseChannel` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-releaseChannel}
+#### `releaseChannel` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-releaseChannel}
 
 ReleaseChannel specifies the release channel for the cloud configuration.
 This can be used to determine which updates or versions are applied.
@@ -3837,7 +3837,7 @@ This can be used to determine which updates or versions are applied.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `maintenanceWindow` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow}
+#### `maintenanceWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow}
 
 MaintenanceWindow specifies the maintenance window for the cloud configuration.
 This is a structured representation of the time window during which maintenance can occur.
@@ -3850,7 +3850,7 @@ This is a structured representation of the time window during which maintenance 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dayOfWeek` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-dayOfWeek}
+##### `dayOfWeek` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-dayOfWeek}
 
 DayOfWeek specifies the day of the week for the maintenance window.
 It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
@@ -3866,7 +3866,7 @@ It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeWindow` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-timeWindow}
+##### `timeWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-timeWindow}
 
 TimeWindow specifies the time window for the maintenance.
 It should be a string representing the time range in 24-hour format, in UTC, e.g., "02:00-03:00".
@@ -3888,7 +3888,7 @@ It should be a string representing the time range in 24-hour format, in UTC, e.g
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `costControl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl}
+### `costControl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl}
 
 CostControl holds the settings related to the Cost Control ROI dashboard and its metrics gathering infrastructure
 
@@ -3900,7 +3900,7 @@ CostControl holds the settings related to the Cost Control ROI dashboard and its
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-enabled}
 
 Enabled specifies whether the ROI dashboard should be available in the UI, and if the metrics infrastructure
 that provides dashboard data is deployed
@@ -3916,7 +3916,7 @@ that provides dashboard data is deployed
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `global` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global}
+#### `global` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global}
 
 Global are settings for globally managed components
 
@@ -3928,7 +3928,7 @@ Global are settings for globally managed components
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics}
+##### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics}
 
 Metrics these settings apply to metric infrastructure used to aggregate metrics across all connected clusters
 
@@ -3940,7 +3940,7 @@ Metrics these settings apply to metric infrastructure used to aggregate metrics 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -3955,7 +3955,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4061,7 +4061,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4076,7 +4076,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage}
 
 
 
@@ -4088,7 +4088,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4105,7 +4105,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4129,7 +4129,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `cluster` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster}
+#### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster}
 
 Cluster are settings for each cluster's managed components. These settings apply to all connected clusters
 unless overridden by modifying the Cluster's spec
@@ -4142,7 +4142,7 @@ unless overridden by modifying the Cluster's spec
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics}
+##### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics}
 
 Metrics are settings applied to metric infrastructure in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4155,7 +4155,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4170,7 +4170,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4276,7 +4276,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4291,7 +4291,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage}
 
 
 
@@ -4303,7 +4303,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4320,7 +4320,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4341,7 +4341,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `opencost` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost}
+##### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost}
 
 OpenCost are settings applied to OpenCost deployments in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4354,7 +4354,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4369,7 +4369,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -4481,7 +4481,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `settings` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings}
+#### `settings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings}
 
 Settings specify price-related settings that are taken into account for the ROI dashboard calculations.
 
@@ -4493,7 +4493,7 @@ Settings specify price-related settings that are taken into account for the ROI 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priceCurrency` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-priceCurrency}
+##### `priceCurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-priceCurrency}
 
 PriceCurrency specifies the currency.
 
@@ -4508,7 +4508,7 @@ PriceCurrency specifies the currency.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageCPUPricePerNode` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode}
+##### `averageCPUPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode}
 
 AvgCPUPricePerNode specifies the average CPU price per node.
 
@@ -4520,7 +4520,7 @@ AvgCPUPricePerNode specifies the average CPU price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-price}
 
 Price specifies the price.
 
@@ -4535,7 +4535,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4553,7 +4553,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageRAMPricePerNode` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode}
+##### `averageRAMPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode}
 
 AvgRAMPricePerNode specifies the average RAM price per node.
 
@@ -4565,7 +4565,7 @@ AvgRAMPricePerNode specifies the average RAM price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-price}
 
 Price specifies the price.
 
@@ -4580,7 +4580,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4598,7 +4598,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `gpuSettings` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings}
+##### `gpuSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings}
 
 GPUSettings specifies GPU related settings.
 
@@ -4610,7 +4610,7 @@ GPUSettings specifies GPU related settings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-enabled}
 
 Enabled specifies whether GPU settings should be available in the UI.
 
@@ -4625,7 +4625,7 @@ Enabled specifies whether GPU settings should be available in the UI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageGPUPrice` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice}
+##### `averageGPUPrice` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice}
 
 AvgGPUPrice specifies the average GPU price.
 
@@ -4637,7 +4637,7 @@ AvgGPUPrice specifies the average GPU price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-price}
 
 Price specifies the price.
 
@@ -4652,7 +4652,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4673,7 +4673,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `controlPlanePricePerCluster` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster}
+##### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster}
 
 ControlPlanePricePerCluster specifies the price of one physical cluster.
 
@@ -4685,7 +4685,7 @@ ControlPlanePricePerCluster specifies the price of one physical cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-price}
 
 Price specifies the price.
 
@@ -4700,7 +4700,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4724,7 +4724,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `platformDB` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB}
+### `platformDB` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB}
 
 PlatformDB holds the settings related to the postgres database that platform uses to store data
 
@@ -4736,7 +4736,7 @@ PlatformDB holds the settings related to the postgres database that platform use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB-storageClass}
+#### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB-storageClass}
 
 StorageClass sets the storage class for the PersistentVolumeClaim used by the platform database statefulSet.
 
@@ -4754,7 +4754,7 @@ StorageClass sets the storage class for the PersistentVolumeClaim used by the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imageBuilder` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder}
+### `imageBuilder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder}
 
 ImageBuilder holds the settings related to the image builder
 
@@ -4766,7 +4766,7 @@ ImageBuilder holds the settings related to the image builder
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-enabled}
 
 Enabled specifies whether the remote image builder should be available.
 If it's not available building ad-hoc images from a devcontainer.json is not supported
@@ -4782,7 +4782,7 @@ If it's not available building ad-hoc images from a devcontainer.json is not sup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4797,7 +4797,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources}
 
 Resources are compute resource required by the buildkit containers
 
@@ -4906,7 +4906,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `database` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database}
+### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database}
 
 Database represents the database connection settings when deploying the platform with an embedded Kubernetes backed by kine
 
@@ -4918,7 +4918,7 @@ Database represents the database connection settings when deploying the platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-enabled}
 
 Enabled defines if the database should be used.
 
@@ -4933,7 +4933,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataSource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-dataSource}
+#### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -4951,7 +4951,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `identityProvider` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-identityProvider}
+#### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -4968,7 +4968,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `keyFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-keyFile}
+#### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -4983,7 +4983,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `certFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-certFile}
+#### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -4998,7 +4998,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-caFile}
+#### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -5013,7 +5013,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/platform/api/_partials/resources/config/reference.mdx
+++ b/platform/api/_partials/resources/config/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `raw` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-raw}
+### `raw` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-raw}
 
 Raw holds the raw config
 
@@ -38,7 +38,7 @@ Raw holds the raw config
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -50,7 +50,7 @@ Raw holds the raw config
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth}
+### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth}
 
 Authentication holds the information for authentication
 
@@ -62,7 +62,7 @@ Authentication holds the information for authentication
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc}
+#### `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc}
 
 OIDC holds oidc authentication configuration
 
@@ -74,7 +74,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -97,7 +97,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -117,7 +117,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -132,7 +132,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -147,7 +147,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-postLogoutRedirectURI}
+##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-postLogoutRedirectURI}
 
 Loft URI to be redirected to after successful logout by OIDC Provider
 
@@ -162,7 +162,7 @@ Loft URI to be redirected to after successful logout by OIDC Provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-caFile}
 
 Path to a PEM encoded root certificate of the provider. Optional
 
@@ -177,7 +177,7 @@ Path to a PEM encoded root certificate of the provider. Optional
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureCa` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-insecureCa}
+##### `insecureCa` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-insecureCa}
 
 Specify whether to communicate without validating SSL certificates
 
@@ -192,7 +192,7 @@ Specify whether to communicate without validating SSL certificates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `preferredUsername` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-preferredUsername}
+##### `preferredUsername` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-preferredUsername}
 
 Configurable key which contains the preferred username claims
 
@@ -207,7 +207,7 @@ Configurable key which contains the preferred username claims
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `loftUsernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-loftUsernameClaim}
+##### `loftUsernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-loftUsernameClaim}
 
 LoftUsernameClaim is the JWT field to use as the user's username.
 
@@ -222,7 +222,7 @@ LoftUsernameClaim is the JWT field to use as the user's username.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-usernameClaim}
+##### `usernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-usernameClaim}
 
 UsernameClaim is the JWT field to use as the user's id.
 
@@ -237,7 +237,7 @@ UsernameClaim is the JWT field to use as the user's id.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-emailClaim}
+##### `emailClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-emailClaim}
 
 EmailClaim is the JWT field to use as the user's email.
 
@@ -252,7 +252,7 @@ EmailClaim is the JWT field to use as the user's email.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedExtraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-allowedExtraClaims}
+##### `allowedExtraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-allowedExtraClaims}
 
 AllowedExtraClaims are claims of interest that are not part of User by default but may be provided by the OIDC provider.
 
@@ -267,7 +267,7 @@ AllowedExtraClaims are claims of interest that are not part of User by default b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernamePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-usernamePrefix}
+##### `usernamePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-usernamePrefix}
 
 UsernamePrefix, if specified, causes claims mapping to username to be prefix with
 the provided value. A value "oidc:" would result in usernames like "oidc:john".
@@ -283,7 +283,7 @@ the provided value. A value "oidc:" would result in usernames like "oidc:john".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groupsClaim}
+##### `groupsClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groupsClaim}
 
 GroupsClaim, if specified, causes the OIDCAuthenticator to try to populate the user's
 groups with an ID Token field. If the GroupsClaim field is present in an ID Token the value
@@ -300,7 +300,7 @@ must be a string or list of strings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groups}
 
 If required groups is non empty, access is denied if the user is not part of at least one
 of the specified groups.
@@ -316,7 +316,7 @@ of the specified groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-scopes}
 
 Scopes that should be sent to the server. If empty, defaults to "email" and "profile".
 
@@ -331,7 +331,7 @@ Scopes that should be sent to the server. If empty, defaults to "email" and "pro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `getUserInfo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-getUserInfo}
+##### `getUserInfo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-getUserInfo}
 
 GetUserInfo, if specified, tells the OIDCAuthenticator to try to populate the user's
 information from the UserInfo.
@@ -347,7 +347,7 @@ information from the UserInfo.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsPrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groupsPrefix}
+##### `groupsPrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groupsPrefix}
 
 GroupsPrefix, if specified, causes claims mapping to group names to be prefixed with the
 value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:marketing".
@@ -363,7 +363,7 @@ value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-type}
 
 Type of the OIDC to show in the UI. Only for displaying purposes
 
@@ -378,7 +378,7 @@ Type of the OIDC to show in the UI. Only for displaying purposes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-resource}
+##### `resource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-resource}
 
 Resource, if specified, is the value that is set for the "resource" URL parameter when making a request to the /token endpoint of the
 OIDC provider.
@@ -397,7 +397,7 @@ OIDC provider.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `github` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github}
+#### `github` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github}
 
 Github holds github authentication configuration
 
@@ -409,7 +409,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-clientId}
 
 ClientID holds the github client id
 
@@ -454,7 +454,7 @@ RedirectURI holds the redirect URI. Should be https://loft.domain.tld/auth/githu
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `orgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs}
+##### `orgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs}
 
 Loft queries the following organizations for group information.
 Group claims are formatted as "(org):(team)".
@@ -472,7 +472,7 @@ authenticate with loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs-name}
 
 Organization name in github (not slug, full name). Only users in this github
 organization can authenticate.
@@ -488,7 +488,7 @@ organization can authenticate.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs-teams}
 
 Names of teams in a github organization. A user will be able to
 authenticate if they are members of at least one of these teams. Users
@@ -509,7 +509,7 @@ config file.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-hostName}
+##### `hostName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-hostName}
 
 Required ONLY for GitHub Enterprise.
 This is the Hostname of the GitHub Enterprise account listed on the
@@ -526,7 +526,7 @@ management console. Ensure this domain is routable on your network.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rootCA` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-rootCA}
+##### `rootCA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-rootCA}
 
 ONLY for GitHub Enterprise. Optional field.
 Used to support self-signed or untrusted CA root certificates.
@@ -545,7 +545,7 @@ Used to support self-signed or untrusted CA root certificates.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gitlab` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab}
+#### `gitlab` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab}
 
 Gitlab holds gitlab authentication configuration
 
@@ -602,7 +602,7 @@ Redirect URI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `baseURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab-baseURL}
+##### `baseURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab-baseURL}
 
 BaseURL is optional, default = https://gitlab.com
 
@@ -617,7 +617,7 @@ BaseURL is optional, default = https://gitlab.com
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab-groups}
 
 Optional groups whitelist, communicated through the "groups" scope.
 If `groups` is omitted, all of the user's GitLab groups are returned.
@@ -637,7 +637,7 @@ If `groups` is provided, this acts as a whitelist - only the user's GitLab group
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `google` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google}
+#### `google` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google}
 
 Google holds google authentication configuration
 
@@ -694,7 +694,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/google/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-scopes}
 
 defaults to "profile" and "email"
 
@@ -709,7 +709,7 @@ defaults to "profile" and "email"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostedDomains` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-hostedDomains}
+##### `hostedDomains` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-hostedDomains}
 
 Optional list of whitelisted domains
 If this field is nonempty, only users from a listed domain will be allowed to log in
@@ -725,7 +725,7 @@ If this field is nonempty, only users from a listed domain will be allowed to lo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-groups}
 
 Optional list of whitelisted groups
 If this field is nonempty, only users from a listed group will be allowed to log in
@@ -741,7 +741,7 @@ If this field is nonempty, only users from a listed group will be allowed to log
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `serviceAccountFilePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-serviceAccountFilePath}
+##### `serviceAccountFilePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-serviceAccountFilePath}
 
 Optional path to service account json
 If nonempty, and groups claim is made, will use authentication from file to
@@ -758,7 +758,7 @@ check groups with the admin directory api
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `adminEmail` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-adminEmail}
+##### `adminEmail` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-adminEmail}
 
 Required if ServiceAccountFilePath
 The email of a GSuite super user which the service account will impersonate
@@ -778,7 +778,7 @@ when listing groups
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `microsoft` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft}
+#### `microsoft` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft}
 
 Microsoft holds microsoft authentication configuration
 
@@ -835,7 +835,7 @@ loft redirect uri. Usually https://loft.my.domain/auth/microsoft/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tenant` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-tenant}
+##### `tenant` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-tenant}
 
 tenant configuration parameter controls what kinds of accounts may be authenticated in loft.
 By default, all types of Microsoft accounts (consumers and organizations) can authenticate in loft via Microsoft.
@@ -857,7 +857,7 @@ tenant uuid or tenant name - only accounts belonging to specific tenant identifi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-groups}
 
 It is possible to require a user to be a member of a particular group in order to be successfully authenticated in loft.
 
@@ -872,7 +872,7 @@ It is possible to require a user to be a member of a particular group in order t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `onlySecurityGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-onlySecurityGroups}
+##### `onlySecurityGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-onlySecurityGroups}
 
 configuration option restricts the list to include only security groups. By default all groups (security, Office 365, mailing lists) are included.
 
@@ -887,7 +887,7 @@ configuration option restricts the list to include only security groups. By defa
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-useGroupsAsWhitelist}
+##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-useGroupsAsWhitelist}
 
 Restrict the groups claims to include only the user’s groups that are in the configured groups
 
@@ -905,7 +905,7 @@ Restrict the groups claims to include only the user’s groups that are in the c
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `saml` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml}
+#### `saml` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml}
 
 SAML holds saml authentication configuration
 
@@ -917,7 +917,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -934,7 +934,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -949,7 +949,7 @@ SSO URL used for POST value.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caData` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-caData}
+##### `caData` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-caData}
 
 CAData is a base64 encoded string that holds the ca certificate for validating the signature of the SAML response.
 Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
@@ -965,7 +965,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -980,7 +980,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -995,7 +995,7 @@ Name of attribute in the returned assertions to map to email
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-groupsAttr}
+##### `groupsAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-groupsAttr}
 
 Name of attribute in the returned assertions to map to groups
 
@@ -1010,7 +1010,7 @@ Name of attribute in the returned assertions to map to groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ca` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ca}
+##### `ca` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ca}
 
 CA to use when validating the signature of the SAML response.
 
@@ -1025,7 +1025,7 @@ CA to use when validating the signature of the SAML response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-insecureSkipSignatureValidation}
+##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-insecureSkipSignatureValidation}
 
 Ignore the ca cert
 
@@ -1040,7 +1040,7 @@ Ignore the ca cert
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `entityIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-entityIssuer}
+##### `entityIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-entityIssuer}
 
 When provided Loft will include this as the Issuer value during AuthnRequest.
 It will also override the redirectURI as the required audience when evaluating
@@ -1057,7 +1057,7 @@ AudienceRestriction elements in the response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoIssuer}
+##### `ssoIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoIssuer}
 
 Issuer value expected in the SAML response. Optional.
 
@@ -1072,7 +1072,7 @@ Issuer value expected in the SAML response. Optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsDelim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-groupsDelim}
+##### `groupsDelim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-groupsDelim}
 
 If GroupsDelim is supplied the connector assumes groups are returned as a
 single string instead of multiple attribute values. This delimiter will be
@@ -1089,7 +1089,7 @@ used split the groups string.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-allowedGroups}
+##### `allowedGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-allowedGroups}
 
 List of groups to filter access based on membership
 
@@ -1104,7 +1104,7 @@ List of groups to filter access based on membership
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `filterGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-filterGroups}
+##### `filterGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-filterGroups}
 
 If used with allowed groups, only forwards the allowed groups and not all
 groups specified.
@@ -1120,7 +1120,7 @@ groups specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-nameIDPolicyFormat}
+##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-nameIDPolicyFormat}
 
 Requested format of the NameID. The NameID value is is mapped to the ID Token
 'sub' claim.
@@ -1149,7 +1149,7 @@ If no value is specified, this value defaults to:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password}
+#### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password}
 
 Password holds password authentication relevant information
 
@@ -1161,7 +1161,7 @@ Password holds password authentication relevant information
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password-disabled}
+##### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password-disabled}
 
 If true login via password is disabled
 
@@ -1179,7 +1179,7 @@ If true login via password is disabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `connectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors}
+#### `connectors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors}
 
 Connectors are optional additional connectors for Loft.
 
@@ -1191,7 +1191,7 @@ Connectors are optional additional connectors for Loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `id` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-id}
+##### `id` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-id}
 
 ID is the id that should show up in the url
 
@@ -1206,7 +1206,7 @@ ID is the id that should show up in the url
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-displayName}
 
 DisplayName is the name that should show up in the ui
 
@@ -1221,7 +1221,7 @@ DisplayName is the name that should show up in the ui
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc}
+##### `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc}
 
 OIDC holds oidc authentication configuration
 
@@ -1233,7 +1233,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -1256,7 +1256,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -1276,7 +1276,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -1291,7 +1291,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -1306,7 +1306,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-postLogoutRedirectURI}
+##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-postLogoutRedirectURI}
 
 Loft URI to be redirected to after successful logout by OIDC Provider
 
@@ -1321,7 +1321,7 @@ Loft URI to be redirected to after successful logout by OIDC Provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-caFile}
 
 Path to a PEM encoded root certificate of the provider. Optional
 
@@ -1336,7 +1336,7 @@ Path to a PEM encoded root certificate of the provider. Optional
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureCa` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-insecureCa}
+##### `insecureCa` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-insecureCa}
 
 Specify whether to communicate without validating SSL certificates
 
@@ -1351,7 +1351,7 @@ Specify whether to communicate without validating SSL certificates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `preferredUsername` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-preferredUsername}
+##### `preferredUsername` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-preferredUsername}
 
 Configurable key which contains the preferred username claims
 
@@ -1366,7 +1366,7 @@ Configurable key which contains the preferred username claims
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `loftUsernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-loftUsernameClaim}
+##### `loftUsernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-loftUsernameClaim}
 
 LoftUsernameClaim is the JWT field to use as the user's username.
 
@@ -1381,7 +1381,7 @@ LoftUsernameClaim is the JWT field to use as the user's username.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-usernameClaim}
+##### `usernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-usernameClaim}
 
 UsernameClaim is the JWT field to use as the user's id.
 
@@ -1396,7 +1396,7 @@ UsernameClaim is the JWT field to use as the user's id.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-emailClaim}
+##### `emailClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-emailClaim}
 
 EmailClaim is the JWT field to use as the user's email.
 
@@ -1411,7 +1411,7 @@ EmailClaim is the JWT field to use as the user's email.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedExtraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-allowedExtraClaims}
+##### `allowedExtraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-allowedExtraClaims}
 
 AllowedExtraClaims are claims of interest that are not part of User by default but may be provided by the OIDC provider.
 
@@ -1426,7 +1426,7 @@ AllowedExtraClaims are claims of interest that are not part of User by default b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernamePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-usernamePrefix}
+##### `usernamePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-usernamePrefix}
 
 UsernamePrefix, if specified, causes claims mapping to username to be prefix with
 the provided value. A value "oidc:" would result in usernames like "oidc:john".
@@ -1442,7 +1442,7 @@ the provided value. A value "oidc:" would result in usernames like "oidc:john".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groupsClaim}
+##### `groupsClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groupsClaim}
 
 GroupsClaim, if specified, causes the OIDCAuthenticator to try to populate the user's
 groups with an ID Token field. If the GroupsClaim field is present in an ID Token the value
@@ -1459,7 +1459,7 @@ must be a string or list of strings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groups}
 
 If required groups is non empty, access is denied if the user is not part of at least one
 of the specified groups.
@@ -1475,7 +1475,7 @@ of the specified groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-scopes}
 
 Scopes that should be sent to the server. If empty, defaults to "email" and "profile".
 
@@ -1490,7 +1490,7 @@ Scopes that should be sent to the server. If empty, defaults to "email" and "pro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `getUserInfo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-getUserInfo}
+##### `getUserInfo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-getUserInfo}
 
 GetUserInfo, if specified, tells the OIDCAuthenticator to try to populate the user's
 information from the UserInfo.
@@ -1506,7 +1506,7 @@ information from the UserInfo.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsPrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groupsPrefix}
+##### `groupsPrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groupsPrefix}
 
 GroupsPrefix, if specified, causes claims mapping to group names to be prefixed with the
 value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:marketing".
@@ -1522,7 +1522,7 @@ value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-type}
 
 Type of the OIDC to show in the UI. Only for displaying purposes
 
@@ -1537,7 +1537,7 @@ Type of the OIDC to show in the UI. Only for displaying purposes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-resource}
+##### `resource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-resource}
 
 Resource, if specified, is the value that is set for the "resource" URL parameter when making a request to the /token endpoint of the
 OIDC provider.
@@ -1556,7 +1556,7 @@ OIDC provider.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `github` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github}
+##### `github` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github}
 
 Github holds github authentication configuration
 
@@ -1568,7 +1568,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-clientId}
 
 ClientID holds the github client id
 
@@ -1613,7 +1613,7 @@ RedirectURI holds the redirect URI. Should be https://loft.domain.tld/auth/githu
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `orgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs}
+##### `orgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs}
 
 Loft queries the following organizations for group information.
 Group claims are formatted as "(org):(team)".
@@ -1631,7 +1631,7 @@ authenticate with loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs-name}
 
 Organization name in github (not slug, full name). Only users in this github
 organization can authenticate.
@@ -1647,7 +1647,7 @@ organization can authenticate.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs-teams}
 
 Names of teams in a github organization. A user will be able to
 authenticate if they are members of at least one of these teams. Users
@@ -1668,7 +1668,7 @@ config file.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-hostName}
+##### `hostName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-hostName}
 
 Required ONLY for GitHub Enterprise.
 This is the Hostname of the GitHub Enterprise account listed on the
@@ -1685,7 +1685,7 @@ management console. Ensure this domain is routable on your network.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rootCA` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-rootCA}
+##### `rootCA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-rootCA}
 
 ONLY for GitHub Enterprise. Optional field.
 Used to support self-signed or untrusted CA root certificates.
@@ -1704,7 +1704,7 @@ Used to support self-signed or untrusted CA root certificates.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `gitlab` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab}
+##### `gitlab` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab}
 
 Gitlab holds gitlab authentication configuration
 
@@ -1761,7 +1761,7 @@ Redirect URI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `baseURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab-baseURL}
+##### `baseURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab-baseURL}
 
 BaseURL is optional, default = https://gitlab.com
 
@@ -1776,7 +1776,7 @@ BaseURL is optional, default = https://gitlab.com
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab-groups}
 
 Optional groups whitelist, communicated through the "groups" scope.
 If `groups` is omitted, all of the user's GitLab groups are returned.
@@ -1796,7 +1796,7 @@ If `groups` is provided, this acts as a whitelist - only the user's GitLab group
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `google` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google}
+##### `google` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google}
 
 Google holds google authentication configuration
 
@@ -1853,7 +1853,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/google/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-scopes}
 
 defaults to "profile" and "email"
 
@@ -1868,7 +1868,7 @@ defaults to "profile" and "email"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostedDomains` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-hostedDomains}
+##### `hostedDomains` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-hostedDomains}
 
 Optional list of whitelisted domains
 If this field is nonempty, only users from a listed domain will be allowed to log in
@@ -1884,7 +1884,7 @@ If this field is nonempty, only users from a listed domain will be allowed to lo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-groups}
 
 Optional list of whitelisted groups
 If this field is nonempty, only users from a listed group will be allowed to log in
@@ -1900,7 +1900,7 @@ If this field is nonempty, only users from a listed group will be allowed to log
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `serviceAccountFilePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-serviceAccountFilePath}
+##### `serviceAccountFilePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-serviceAccountFilePath}
 
 Optional path to service account json
 If nonempty, and groups claim is made, will use authentication from file to
@@ -1917,7 +1917,7 @@ check groups with the admin directory api
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `adminEmail` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-adminEmail}
+##### `adminEmail` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-adminEmail}
 
 Required if ServiceAccountFilePath
 The email of a GSuite super user which the service account will impersonate
@@ -1937,7 +1937,7 @@ when listing groups
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `microsoft` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft}
+##### `microsoft` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft}
 
 Microsoft holds microsoft authentication configuration
 
@@ -1994,7 +1994,7 @@ loft redirect uri. Usually https://loft.my.domain/auth/microsoft/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tenant` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-tenant}
+##### `tenant` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-tenant}
 
 tenant configuration parameter controls what kinds of accounts may be authenticated in loft.
 By default, all types of Microsoft accounts (consumers and organizations) can authenticate in loft via Microsoft.
@@ -2016,7 +2016,7 @@ tenant uuid or tenant name - only accounts belonging to specific tenant identifi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-groups}
 
 It is possible to require a user to be a member of a particular group in order to be successfully authenticated in loft.
 
@@ -2031,7 +2031,7 @@ It is possible to require a user to be a member of a particular group in order t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `onlySecurityGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-onlySecurityGroups}
+##### `onlySecurityGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-onlySecurityGroups}
 
 configuration option restricts the list to include only security groups. By default all groups (security, Office 365, mailing lists) are included.
 
@@ -2046,7 +2046,7 @@ configuration option restricts the list to include only security groups. By defa
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-useGroupsAsWhitelist}
+##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-useGroupsAsWhitelist}
 
 Restrict the groups claims to include only the user’s groups that are in the configured groups
 
@@ -2064,7 +2064,7 @@ Restrict the groups claims to include only the user’s groups that are in the c
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `saml` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml}
+##### `saml` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml}
 
 SAML holds saml authentication configuration
 
@@ -2076,7 +2076,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -2093,7 +2093,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -2108,7 +2108,7 @@ SSO URL used for POST value.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caData` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-caData}
+##### `caData` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-caData}
 
 CAData is a base64 encoded string that holds the ca certificate for validating the signature of the SAML response.
 Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
@@ -2124,7 +2124,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -2139,7 +2139,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -2154,7 +2154,7 @@ Name of attribute in the returned assertions to map to email
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-groupsAttr}
+##### `groupsAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-groupsAttr}
 
 Name of attribute in the returned assertions to map to groups
 
@@ -2169,7 +2169,7 @@ Name of attribute in the returned assertions to map to groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ca` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ca}
+##### `ca` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ca}
 
 CA to use when validating the signature of the SAML response.
 
@@ -2184,7 +2184,7 @@ CA to use when validating the signature of the SAML response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-insecureSkipSignatureValidation}
+##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-insecureSkipSignatureValidation}
 
 Ignore the ca cert
 
@@ -2199,7 +2199,7 @@ Ignore the ca cert
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `entityIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-entityIssuer}
+##### `entityIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-entityIssuer}
 
 When provided Loft will include this as the Issuer value during AuthnRequest.
 It will also override the redirectURI as the required audience when evaluating
@@ -2216,7 +2216,7 @@ AudienceRestriction elements in the response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoIssuer}
+##### `ssoIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoIssuer}
 
 Issuer value expected in the SAML response. Optional.
 
@@ -2231,7 +2231,7 @@ Issuer value expected in the SAML response. Optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsDelim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-groupsDelim}
+##### `groupsDelim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-groupsDelim}
 
 If GroupsDelim is supplied the connector assumes groups are returned as a
 single string instead of multiple attribute values. This delimiter will be
@@ -2248,7 +2248,7 @@ used split the groups string.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-allowedGroups}
+##### `allowedGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-allowedGroups}
 
 List of groups to filter access based on membership
 
@@ -2263,7 +2263,7 @@ List of groups to filter access based on membership
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `filterGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-filterGroups}
+##### `filterGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-filterGroups}
 
 If used with allowed groups, only forwards the allowed groups and not all
 groups specified.
@@ -2279,7 +2279,7 @@ groups specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-nameIDPolicyFormat}
+##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-nameIDPolicyFormat}
 
 Requested format of the NameID. The NameID value is is mapped to the ID Token
 'sub' claim.
@@ -2311,7 +2311,7 @@ If no value is specified, this value defaults to:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disableTeamCreation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-disableTeamCreation}
+#### `disableTeamCreation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-disableTeamCreation}
 
 Prevents from team creation for the new groups associated with the user at the time of logging in through sso,
 Default behaviour is false, this means that teams will be created for new groups.
@@ -2327,7 +2327,7 @@ Default behaviour is false, this means that teams will be created for new groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disableUserCreation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-disableUserCreation}
+#### `disableUserCreation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-disableUserCreation}
 
 DisableUserCreation prevents the SSO connectors from creating a new user on a users initial signin through sso.
 Default behaviour is false, this means that a new user object will be created once a user without
@@ -2344,7 +2344,7 @@ a Kubernetes user object logs in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `accessKeyMaxTTLSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-accessKeyMaxTTLSeconds}
+#### `accessKeyMaxTTLSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-accessKeyMaxTTLSeconds}
 
 AccessKeyMaxTTLSeconds is the global maximum lifespan of an accesskey in seconds.
 Leaving it 0 or unspecified will disable it.
@@ -2361,7 +2361,7 @@ Specifying 2592000 will mean all keys have a Time-To-Live of 30 days.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `loginAccessKeyTTLSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-loginAccessKeyTTLSeconds}
+#### `loginAccessKeyTTLSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-loginAccessKeyTTLSeconds}
 
 LoginAccessKeyTTLSeconds is the time in seconds an access key is kept
 until it is deleted.
@@ -2380,7 +2380,7 @@ Specifying 2592000 will mean all keys have a  default Time-To-Live of 30 days.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `customHttpHeaders` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-customHttpHeaders}
+#### `customHttpHeaders` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-customHttpHeaders}
 
 CustomHttpHeaders are additional headers that should be set for the authentication endpoints
 
@@ -2395,7 +2395,7 @@ CustomHttpHeaders are additional headers that should be set for the authenticati
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsFilters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-groupsFilters}
+#### `groupsFilters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-groupsFilters}
 
 GroupsFilters is a regex expression to only save matching sso groups into the user resource
 
@@ -2413,7 +2413,7 @@ GroupsFilters is a regex expression to only save matching sso groups into the us
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc}
+### `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc}
 
 DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secret. By default, vCluster Platform as an OIDC Provider is enabled but does not function without OIDC clients.
 
@@ -2425,7 +2425,7 @@ DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-enabled}
 
 If true indicates that loft will act as an OIDC server
 
@@ -2440,7 +2440,7 @@ If true indicates that loft will act as an OIDC server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `wildcardRedirect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-wildcardRedirect}
+#### `wildcardRedirect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-wildcardRedirect}
 
 If true indicates that loft will allow wildcard '*' in client redirectURIs
 
@@ -2455,7 +2455,7 @@ If true indicates that loft will allow wildcard '*' in client redirectURIs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clients` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients}
+#### `clients` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients}
 
 The clients that are allowed to request loft tokens
 
@@ -2467,7 +2467,7 @@ The clients that are allowed to request loft tokens
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-name}
 
 The client name
 
@@ -2482,7 +2482,7 @@ The client name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientId}
 
 The client id of the client
 
@@ -2497,7 +2497,7 @@ The client id of the client
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientSecret}
 
 The client secret of the client
 
@@ -2534,7 +2534,7 @@ requested to redirect to MUST match one of these values, unless the client is "p
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps}
+### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps}
 
 Apps holds configuration around apps
 
@@ -2546,7 +2546,7 @@ Apps holds configuration around apps
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `noDefault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-noDefault}
+#### `noDefault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-noDefault}
 
 If this option is true, loft will not try to parse the default apps
 
@@ -2561,7 +2561,7 @@ If this option is true, loft will not try to parse the default apps
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `repositories` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories}
+#### `repositories` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories}
 
 These are additional repositories that are parsed by loft
 
@@ -2573,7 +2573,7 @@ These are additional repositories that are parsed by loft
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-name}
 
 Name is the name of the repository
 
@@ -2588,7 +2588,7 @@ Name is the name of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-url}
 
 URL is the repository url
 
@@ -2603,7 +2603,7 @@ URL is the repository url
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-username}
 
 Username of the repository
 
@@ -2618,7 +2618,7 @@ Username of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-password}
 
 Password of the repository
 
@@ -2633,7 +2633,7 @@ Password of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-insecure}
+##### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-insecure}
 
 Insecure specifies if the chart should be retrieved without TLS
 verification
@@ -2652,7 +2652,7 @@ verification
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `predefinedApps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps}
+#### `predefinedApps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps}
 
 Predefined apps that can be selected in the Spaces ) Space menu
 
@@ -2664,7 +2664,7 @@ Predefined apps that can be selected in the Spaces ) Space menu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-chart}
 
 Chart holds the repo/chart name of the predefined app
 
@@ -2679,7 +2679,7 @@ Chart holds the repo/chart name of the predefined app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initialVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-initialVersion}
+##### `initialVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-initialVersion}
 
 InitialVersion holds the initial version of this app.
 This version will be selected automatically.
@@ -2695,7 +2695,7 @@ This version will be selected automatically.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initialValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-initialValues}
+##### `initialValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-initialValues}
 
 InitialValues holds the initial values for this app.
 The values will be prefilled automatically. There are certain
@@ -2713,7 +2713,7 @@ by the loft UI automatically.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-clusters}
+##### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-clusters}
 
 Holds the cluster names where to display this app
 
@@ -2728,7 +2728,7 @@ Holds the cluster names where to display this app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `title` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-title}
+##### `title` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-title}
 
 Title is the name that should be displayed for the predefined app.
 If empty the chart name is used.
@@ -2744,7 +2744,7 @@ If empty the chart name is used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `iconUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-iconUrl}
+##### `iconUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-iconUrl}
 
 IconURL specifies an url to the icon that should be displayed for this app.
 If none is specified the icon from the chart metadata is used.
@@ -2760,7 +2760,7 @@ If none is specified the icon from the chart metadata is used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readmeUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-readmeUrl}
+##### `readmeUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-readmeUrl}
 
 ReadmeURL specifies an url to the readme page of this predefined app. If empty
 an url will be constructed to artifact hub.
@@ -2782,7 +2782,7 @@ an url will be constructed to artifact hub.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `audit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit}
+### `audit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit}
 
 Audit holds audit configuration
 
@@ -2794,7 +2794,7 @@ Audit holds audit configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-enabled}
 
 If audit is enabled and incoming api requests will be logged based on the supplied policy.
 
@@ -2809,7 +2809,7 @@ If audit is enabled and incoming api requests will be logged based on the suppli
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disableAgentSyncBack` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-disableAgentSyncBack}
+#### `disableAgentSyncBack` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-disableAgentSyncBack}
 
 If true, the agent will not send back any audit logs to Loft itself.
 
@@ -2824,7 +2824,7 @@ If true, the agent will not send back any audit logs to Loft itself.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-level}
+#### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-level}
 
 Level is an optional log level for audit logs. Cannot be used together with policy
 
@@ -2839,7 +2839,7 @@ Level is an optional log level for audit logs. Cannot be used together with poli
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `policy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy}
+#### `policy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy}
 
 The audit policy to use and log requests. By default loft will not log anything
 
@@ -2851,7 +2851,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -2881,7 +2881,7 @@ The Level that requests matching this rule are recorded at.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-users}
 
 The users (by authenticated user name) this rule applies to.
 An empty list implies every user.
@@ -2897,7 +2897,7 @@ An empty list implies every user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `userGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-userGroups}
+##### `userGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-userGroups}
 
 The user groups this rule applies to. A user is considered matching
 if it is a member of any of the UserGroups.
@@ -2914,7 +2914,7 @@ An empty list implies every user group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -2930,7 +2930,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -2942,7 +2942,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -2958,7 +2958,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -2985,7 +2985,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -3005,7 +3005,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-namespaces}
+##### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -3022,7 +3022,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be audited.
 *s are allowed, but only as the full, final step in the path.
@@ -3041,7 +3041,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-omitStages}
+##### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified policy wide in which case the union of both are omitted.
@@ -3058,7 +3058,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-requestTargets}
+##### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-requestTargets}
 
 RequestTargets is a list of request targets for which events are created.
 An empty list implies every request.
@@ -3074,7 +3074,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-clusters}
+##### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-clusters}
 
 Clusters that this rule matches. Only applies to cluster requests.
 If this is set, no events for non cluster requests will be created.
@@ -3094,7 +3094,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-omitStages}
+##### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified per rule in which case the union of both are omitted.
@@ -3113,7 +3113,7 @@ be specified per rule in which case the union of both are omitted.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataStoreEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-dataStoreEndpoint}
+#### `dataStoreEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-dataStoreEndpoint}
 
 DataStoreEndpoint is an endpoint to store events in.
 
@@ -3128,7 +3128,7 @@ DataStoreEndpoint is an endpoint to store events in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataStoreTTL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-dataStoreTTL}
+#### `dataStoreTTL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-dataStoreTTL}
 
 DataStoreMaxAge is the maximum number of hours to retain old log events in the datastore
 
@@ -3143,7 +3143,7 @@ DataStoreMaxAge is the maximum number of hours to retain old log events in the d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-path}
+#### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-path}
 
 The path where to save the audit log files. This is required if audit is enabled. Backup log files will
 be retained in the same directory.
@@ -3159,7 +3159,7 @@ be retained in the same directory.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `maxAge` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxAge}
+#### `maxAge` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxAge}
 
 MaxAge is the maximum number of days to retain old log files based on the
 timestamp encoded in their filename.  Note that a day is defined as 24
@@ -3178,7 +3178,7 @@ based on age.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `maxBackups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxBackups}
+#### `maxBackups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxBackups}
 
 MaxBackups is the maximum number of old log files to retain.  The default
 is to retain all old log files (though MaxAge may still cause them to get
@@ -3195,7 +3195,7 @@ deleted.)
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `maxSize` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxSize}
+#### `maxSize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxSize}
 
 MaxSize is the maximum size in megabytes of the log file before it gets
 rotated. It defaults to 100 megabytes.
@@ -3211,7 +3211,7 @@ rotated. It defaults to 100 megabytes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `compress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-compress}
+#### `compress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-compress}
 
 Compress determines if the rotated log files should be compressed
 using gzip. The default is not to perform compression.
@@ -3230,7 +3230,7 @@ using gzip. The default is not to perform compression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `loftHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-loftHost}
+### `loftHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-loftHost}
 
 LoftHost holds the domain where the loft instance is hosted. This should not include https or http. E.g. loft.my-domain.com
 
@@ -3245,7 +3245,7 @@ LoftHost holds the domain where the loft instance is hosted. This should not inc
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `projectNamespacePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-projectNamespacePrefix}
+### `projectNamespacePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-projectNamespacePrefix}
 
 ProjectNamespacePrefix holds the prefix for loft project namespaces. Omitted defaults to "p-"
 
@@ -3260,7 +3260,7 @@ ProjectNamespacePrefix holds the prefix for loft project namespaces. Omitted def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `devPodSubDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-devPodSubDomain}
+### `devPodSubDomain` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-devPodSubDomain}
 
 DEPRECATED: DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.com
 DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.com
@@ -3276,7 +3276,7 @@ DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.co
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `uiSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings}
+### `uiSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings}
 
 UISettings holds the settings for modifying the Loft user interface
 
@@ -3288,7 +3288,7 @@ UISettings holds the settings for modifying the Loft user interface
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `loftVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-loftVersion}
+#### `loftVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-loftVersion}
 
 LoftVersion holds the current loft version
 
@@ -3303,7 +3303,7 @@ LoftVersion holds the current loft version
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `logoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-logoURL}
+#### `logoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-logoURL}
 
 LogoURL is url pointing to the logo to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3319,7 +3319,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `faviconURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-faviconURL}
+#### `faviconURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-faviconURL}
 
 FaviconURL is url pointing to the favicon to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3335,7 +3335,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `smallLogoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-smallLogoURL}
+#### `smallLogoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-smallLogoURL}
 
 SmallLogoURL is url pointing to the small logo to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3351,7 +3351,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `logoBackgroundColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-logoBackgroundColor}
+#### `logoBackgroundColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-logoBackgroundColor}
 
 LogoBackgroundColor is the color value (ex: "#12345") to use as the background color for the logo
 
@@ -3366,7 +3366,7 @@ LogoBackgroundColor is the color value (ex: "#12345") to use as the background c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `legalTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-legalTemplate}
+#### `legalTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-legalTemplate}
 
 LegalTemplate is a text (html) string containing the legal template to prompt to users when authenticating to Loft
 
@@ -3381,7 +3381,7 @@ LegalTemplate is a text (html) string containing the legal template to prompt to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `primaryColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-primaryColor}
+#### `primaryColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-primaryColor}
 
 PrimaryColor is the color value (ex: "#12345") to use as the primary color
 
@@ -3396,7 +3396,7 @@ PrimaryColor is the color value (ex: "#12345") to use as the primary color
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `sidebarColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-sidebarColor}
+#### `sidebarColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-sidebarColor}
 
 SidebarColor is the color value (ex: "#12345") to use for the sidebar
 
@@ -3411,7 +3411,7 @@ SidebarColor is the color value (ex: "#12345") to use for the sidebar
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `accentColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-accentColor}
+#### `accentColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-accentColor}
 
 AccentColor is the color value (ex: "#12345") to use for the accent
 
@@ -3426,7 +3426,7 @@ AccentColor is the color value (ex: "#12345") to use for the accent
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `customCss` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-customCss}
+#### `customCss` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-customCss}
 
 CustomCSS holds URLs with custom css files that should be included when loading the UI
 
@@ -3441,7 +3441,7 @@ CustomCSS holds URLs with custom css files that should be included when loading 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `customJavaScript` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-customJavaScript}
+#### `customJavaScript` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-customJavaScript}
 
 CustomJavaScript holds URLs with custom js files that should be included when loading the UI
 
@@ -3456,7 +3456,7 @@ CustomJavaScript holds URLs with custom js files that should be included when lo
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `navBarButtons` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons}
+#### `navBarButtons` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons}
 
 NavBarButtons holds extra nav bar buttons
 
@@ -3468,7 +3468,7 @@ NavBarButtons holds extra nav bar buttons
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `position` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-position}
+##### `position` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-position}
 
 Position holds the position of the button, can be one of:
 TopStart, TopEnd, BottomStart, BottomEnd. Defaults to BottomEnd
@@ -3484,7 +3484,7 @@ TopStart, TopEnd, BottomStart, BottomEnd. Defaults to BottomEnd
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `text` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-text}
+##### `text` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-text}
 
 Text holds text for the button
 
@@ -3499,7 +3499,7 @@ Text holds text for the button
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `link` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-link}
+##### `link` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-link}
 
 Link holds the link of the navbar button
 
@@ -3514,7 +3514,7 @@ Link holds the link of the navbar button
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-icon}
+##### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-icon}
 
 Icon holds the url of the icon to display
 
@@ -3532,7 +3532,7 @@ Icon holds the url of the icon to display
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `externalURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs}
+#### `externalURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs}
 
 External URLs that can be called from the UI
 
@@ -3544,7 +3544,7 @@ External URLs that can be called from the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `block` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs-block}
+##### `block` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs-block}
 
 Block determines if requests to external URLs from the UI should be blocked
 
@@ -3559,7 +3559,7 @@ Block determines if requests to external URLs from the UI should be blocked
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs-allow}
+##### `allow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs-allow}
 
 Allow specifies which external URLs can be called. In addition to the predefined modules,
 - "vcluster" (license page, feature descriptions, ...)
@@ -3585,7 +3585,7 @@ This is only active when Block is true.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault}
+### `vault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault}
 
 VaultIntegration holds the vault integration configuration
 
@@ -3597,7 +3597,7 @@ VaultIntegration holds the vault integration configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-enabled}
 
 Enabled indicates if the Vault Integration is enabled for the project -- this knob only
 enables the syncing of secrets to or from Vault, but does not setup Kubernetes authentication
@@ -3614,7 +3614,7 @@ methods or Kubernetes secrets engines for vclusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `address` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-address}
+#### `address` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-address}
 
 Address defines the address of the Vault instance to use for this project.
 Will default to the `VAULT_ADDR` environment variable if not provided.
@@ -3630,7 +3630,7 @@ Will default to the `VAULT_ADDR` environment variable if not provided.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `skipTLSVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-skipTLSVerify}
+#### `skipTLSVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-skipTLSVerify}
 
 SkipTLSVerify defines if TLS verification should be skipped when connecting to Vault.
 
@@ -3645,7 +3645,7 @@ SkipTLSVerify defines if TLS verification should be skipped when connecting to V
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-namespace}
 
 Namespace defines the namespace to use when storing secrets in Vault.
 
@@ -3660,7 +3660,7 @@ Namespace defines the namespace to use when storing secrets in Vault.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth}
+#### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth}
 
 Auth defines the authentication method to use for this project.
 
@@ -3672,7 +3672,7 @@ Auth defines the authentication method to use for this project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-token}
+##### `token` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-token}
 
 Token defines the token to use for authentication.
 
@@ -3687,7 +3687,7 @@ Token defines the token to use for authentication.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tokenSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef}
+##### `tokenSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef}
 
 TokenSecretRef defines the Kubernetes secret to use for token authentication.
 Will be used if `token` is not provided.
@@ -3702,7 +3702,7 @@ Secret data should contain the `token` key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef-name}
 
 Name of the referent.
 This field is effectively required, but due to backwards compatibility is
@@ -3737,7 +3737,7 @@ The key of the secret to select from.  Must be a valid secret key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef-optional}
+##### `optional` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef-optional}
 
 Specify whether the Secret or its key must be defined
 
@@ -3758,7 +3758,7 @@ Specify whether the Secret or its key must be defined
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-syncInterval}
+#### `syncInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-syncInterval}
 
 SyncInterval defines the interval at which to sync secrets from Vault.
 Defaults to `1m.`
@@ -3778,7 +3778,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableConfigEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-disableConfigEndpoint}
+### `disableConfigEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-disableConfigEndpoint}
 
 DisableLoftConfigEndpoint will disable setting config via the UI and config.management.loft.sh endpoint
 
@@ -3793,7 +3793,7 @@ DisableLoftConfigEndpoint will disable setting config via the UI and config.mana
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `authenticateVersionEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-authenticateVersionEndpoint}
+### `authenticateVersionEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-authenticateVersionEndpoint}
 
 AuthenticateVersionEndpoint will force authentication for the '/version' endpoint. Will only work with vCluster v0.27 & later
 
@@ -3808,7 +3808,7 @@ AuthenticateVersionEndpoint will force authentication for the '/version' endpoin
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cloud` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud}
+### `cloud` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud}
 
 Cloud holds the settings to be used exclusively in vCluster Cloud based
 environments and deployments.
@@ -3821,7 +3821,7 @@ environments and deployments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `releaseChannel` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-releaseChannel}
+#### `releaseChannel` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-releaseChannel}
 
 ReleaseChannel specifies the release channel for the cloud configuration.
 This can be used to determine which updates or versions are applied.
@@ -3837,7 +3837,7 @@ This can be used to determine which updates or versions are applied.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `maintenanceWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow}
+#### `maintenanceWindow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow}
 
 MaintenanceWindow specifies the maintenance window for the cloud configuration.
 This is a structured representation of the time window during which maintenance can occur.
@@ -3850,7 +3850,7 @@ This is a structured representation of the time window during which maintenance 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dayOfWeek` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-dayOfWeek}
+##### `dayOfWeek` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-dayOfWeek}
 
 DayOfWeek specifies the day of the week for the maintenance window.
 It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
@@ -3866,7 +3866,7 @@ It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-timeWindow}
+##### `timeWindow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-timeWindow}
 
 TimeWindow specifies the time window for the maintenance.
 It should be a string representing the time range in 24-hour format, in UTC, e.g., "02:00-03:00".
@@ -3888,7 +3888,7 @@ It should be a string representing the time range in 24-hour format, in UTC, e.g
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `costControl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl}
+### `costControl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl}
 
 CostControl holds the settings related to the Cost Control ROI dashboard and its metrics gathering infrastructure
 
@@ -3900,7 +3900,7 @@ CostControl holds the settings related to the Cost Control ROI dashboard and its
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-enabled}
 
 Enabled specifies whether the ROI dashboard should be available in the UI, and if the metrics infrastructure
 that provides dashboard data is deployed
@@ -3916,7 +3916,7 @@ that provides dashboard data is deployed
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `global` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global}
+#### `global` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global}
 
 Global are settings for globally managed components
 
@@ -3928,7 +3928,7 @@ Global are settings for globally managed components
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics}
+##### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics}
 
 Metrics these settings apply to metric infrastructure used to aggregate metrics across all connected clusters
 
@@ -3940,7 +3940,7 @@ Metrics these settings apply to metric infrastructure used to aggregate metrics 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -3955,7 +3955,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -3967,7 +3967,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -3983,7 +3983,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4001,7 +4001,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4037,7 +4037,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4061,7 +4061,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4076,7 +4076,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage}
 
 
 
@@ -4088,7 +4088,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4105,7 +4105,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4129,7 +4129,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster}
+#### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster}
 
 Cluster are settings for each cluster's managed components. These settings apply to all connected clusters
 unless overridden by modifying the Cluster's spec
@@ -4142,7 +4142,7 @@ unless overridden by modifying the Cluster's spec
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics}
+##### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics}
 
 Metrics are settings applied to metric infrastructure in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4155,7 +4155,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4170,7 +4170,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4182,7 +4182,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4198,7 +4198,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4216,7 +4216,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4252,7 +4252,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4276,7 +4276,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4291,7 +4291,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage}
 
 
 
@@ -4303,7 +4303,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4320,7 +4320,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4341,7 +4341,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost}
+##### `opencost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost}
 
 OpenCost are settings applied to OpenCost deployments in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4354,7 +4354,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4369,7 +4369,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -4381,7 +4381,7 @@ Resources are compute resource required by the OpenCost backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4397,7 +4397,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4415,7 +4415,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4451,7 +4451,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4481,7 +4481,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `settings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings}
+#### `settings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings}
 
 Settings specify price-related settings that are taken into account for the ROI dashboard calculations.
 
@@ -4493,7 +4493,7 @@ Settings specify price-related settings that are taken into account for the ROI 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priceCurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-priceCurrency}
+##### `priceCurrency` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-priceCurrency}
 
 PriceCurrency specifies the currency.
 
@@ -4508,7 +4508,7 @@ PriceCurrency specifies the currency.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageCPUPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode}
+##### `averageCPUPricePerNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode}
 
 AvgCPUPricePerNode specifies the average CPU price per node.
 
@@ -4520,7 +4520,7 @@ AvgCPUPricePerNode specifies the average CPU price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-price}
 
 Price specifies the price.
 
@@ -4535,7 +4535,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4553,7 +4553,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageRAMPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode}
+##### `averageRAMPricePerNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode}
 
 AvgRAMPricePerNode specifies the average RAM price per node.
 
@@ -4565,7 +4565,7 @@ AvgRAMPricePerNode specifies the average RAM price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-price}
 
 Price specifies the price.
 
@@ -4580,7 +4580,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4598,7 +4598,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `gpuSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings}
+##### `gpuSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings}
 
 GPUSettings specifies GPU related settings.
 
@@ -4610,7 +4610,7 @@ GPUSettings specifies GPU related settings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-enabled}
 
 Enabled specifies whether GPU settings should be available in the UI.
 
@@ -4625,7 +4625,7 @@ Enabled specifies whether GPU settings should be available in the UI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageGPUPrice` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice}
+##### `averageGPUPrice` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice}
 
 AvgGPUPrice specifies the average GPU price.
 
@@ -4637,7 +4637,7 @@ AvgGPUPrice specifies the average GPU price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-price}
 
 Price specifies the price.
 
@@ -4652,7 +4652,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4673,7 +4673,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster}
+##### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster}
 
 ControlPlanePricePerCluster specifies the price of one physical cluster.
 
@@ -4685,7 +4685,7 @@ ControlPlanePricePerCluster specifies the price of one physical cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-price}
 
 Price specifies the price.
 
@@ -4700,7 +4700,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4724,7 +4724,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `platformDB` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB}
+### `platformDB` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB}
 
 PlatformDB holds the settings related to the postgres database that platform uses to store data
 
@@ -4736,7 +4736,7 @@ PlatformDB holds the settings related to the postgres database that platform use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB-storageClass}
+#### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB-storageClass}
 
 StorageClass sets the storage class for the PersistentVolumeClaim used by the platform database statefulSet.
 
@@ -4754,7 +4754,7 @@ StorageClass sets the storage class for the PersistentVolumeClaim used by the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imageBuilder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder}
+### `imageBuilder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder}
 
 ImageBuilder holds the settings related to the image builder
 
@@ -4766,7 +4766,7 @@ ImageBuilder holds the settings related to the image builder
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-enabled}
 
 Enabled specifies whether the remote image builder should be available.
 If it's not available building ad-hoc images from a devcontainer.json is not supported
@@ -4782,7 +4782,7 @@ If it's not available building ad-hoc images from a devcontainer.json is not sup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-replicas}
+#### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4797,7 +4797,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources}
 
 Resources are compute resource required by the buildkit containers
 
@@ -4809,7 +4809,7 @@ Resources are compute resource required by the buildkit containers
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4825,7 +4825,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4843,7 +4843,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4879,7 +4879,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4906,7 +4906,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database}
+### `database` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database}
 
 Database represents the database connection settings when deploying the platform with an embedded Kubernetes backed by kine
 
@@ -4918,7 +4918,7 @@ Database represents the database connection settings when deploying the platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-enabled}
 
 Enabled defines if the database should be used.
 
@@ -4933,7 +4933,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-dataSource}
+#### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -4951,7 +4951,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-identityProvider}
+#### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -4968,7 +4968,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-keyFile}
+#### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -4983,7 +4983,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-certFile}
+#### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -4998,7 +4998,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-caFile}
+#### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -5013,7 +5013,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/platform/api/_partials/resources/config/status/audit.mdx
+++ b/platform/api/_partials/resources/config/status/audit.mdx
@@ -61,7 +61,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rules` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules}
+### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.

--- a/platform/api/_partials/resources/config/status/audit.mdx
+++ b/platform/api/_partials/resources/config/status/audit.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#enabled}
+## `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#enabled}
 
 If audit is enabled and incoming api requests will be logged based on the supplied policy.
 
@@ -19,7 +19,7 @@ If audit is enabled and incoming api requests will be logged based on the suppli
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `disableAgentSyncBack` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableAgentSyncBack}
+## `disableAgentSyncBack` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableAgentSyncBack}
 
 If true, the agent will not send back any audit logs to Loft itself.
 
@@ -34,7 +34,7 @@ If true, the agent will not send back any audit logs to Loft itself.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#level}
+## `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#level}
 
 Level is an optional log level for audit logs. Cannot be used together with policy
 
@@ -49,7 +49,7 @@ Level is an optional log level for audit logs. Cannot be used together with poli
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `policy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy}
+## `policy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy}
 
 The audit policy to use and log requests. By default loft will not log anything
 
@@ -61,7 +61,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules}
+### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -91,7 +91,7 @@ The Level that requests matching this rule are recorded at.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-users}
 
 The users (by authenticated user name) this rule applies to.
 An empty list implies every user.
@@ -107,7 +107,7 @@ An empty list implies every user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `userGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-userGroups}
+#### `userGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-userGroups}
 
 The user groups this rule applies to. A user is considered matching
 if it is a member of any of the UserGroups.
@@ -124,7 +124,7 @@ An empty list implies every user group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-verbs}
+#### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -140,7 +140,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -152,7 +152,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -168,7 +168,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -195,7 +195,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -215,7 +215,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -232,7 +232,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-nonResourceURLs}
+#### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be audited.
 *s are allowed, but only as the full, final step in the path.
@@ -251,7 +251,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-omitStages}
+#### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified policy wide in which case the union of both are omitted.
@@ -268,7 +268,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-requestTargets}
+#### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-requestTargets}
 
 RequestTargets is a list of request targets for which events are created.
 An empty list implies every request.
@@ -284,7 +284,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-clusters}
+#### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-clusters}
 
 Clusters that this rule matches. Only applies to cluster requests.
 If this is set, no events for non cluster requests will be created.
@@ -304,7 +304,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-omitStages}
+### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified per rule in which case the union of both are omitted.
@@ -323,7 +323,7 @@ be specified per rule in which case the union of both are omitted.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `dataStoreEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dataStoreEndpoint}
+## `dataStoreEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dataStoreEndpoint}
 
 DataStoreEndpoint is an endpoint to store events in.
 
@@ -338,7 +338,7 @@ DataStoreEndpoint is an endpoint to store events in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `dataStoreTTL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dataStoreTTL}
+## `dataStoreTTL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dataStoreTTL}
 
 DataStoreMaxAge is the maximum number of hours to retain old log events in the datastore
 
@@ -353,7 +353,7 @@ DataStoreMaxAge is the maximum number of hours to retain old log events in the d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#path}
+## `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#path}
 
 The path where to save the audit log files. This is required if audit is enabled. Backup log files will
 be retained in the same directory.
@@ -369,7 +369,7 @@ be retained in the same directory.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `maxAge` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxAge}
+## `maxAge` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxAge}
 
 MaxAge is the maximum number of days to retain old log files based on the
 timestamp encoded in their filename.  Note that a day is defined as 24
@@ -388,7 +388,7 @@ based on age.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `maxBackups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxBackups}
+## `maxBackups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxBackups}
 
 MaxBackups is the maximum number of old log files to retain.  The default
 is to retain all old log files (though MaxAge may still cause them to get
@@ -405,7 +405,7 @@ deleted.)
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `maxSize` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxSize}
+## `maxSize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxSize}
 
 MaxSize is the maximum size in megabytes of the log file before it gets
 rotated. It defaults to 100 megabytes.
@@ -421,7 +421,7 @@ rotated. It defaults to 100 megabytes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `compress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#compress}
+## `compress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#compress}
 
 Compress determines if the rotated log files should be compressed
 using gzip. The default is not to perform compression.

--- a/platform/api/_partials/resources/config/status/audit/policy.mdx
+++ b/platform/api/_partials/resources/config/status/audit/policy.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules}
+## `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -34,7 +34,7 @@ The Level that requests matching this rule are recorded at.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-users}
+### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-users}
 
 The users (by authenticated user name) this rule applies to.
 An empty list implies every user.
@@ -50,7 +50,7 @@ An empty list implies every user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `userGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-userGroups}
+### `userGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-userGroups}
 
 The user groups this rule applies to. A user is considered matching
 if it is a member of any of the UserGroups.
@@ -67,7 +67,7 @@ An empty list implies every user group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-verbs}
+### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -83,7 +83,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources}
+### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -95,7 +95,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-group}
+#### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -111,7 +111,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -138,7 +138,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-resourceNames}
+#### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -158,7 +158,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -175,7 +175,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-nonResourceURLs}
+### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be audited.
 *s are allowed, but only as the full, final step in the path.
@@ -194,7 +194,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-omitStages}
+### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified policy wide in which case the union of both are omitted.
@@ -211,7 +211,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-requestTargets}
+### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-requestTargets}
 
 RequestTargets is a list of request targets for which events are created.
 An empty list implies every request.
@@ -227,7 +227,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-clusters}
+### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-clusters}
 
 Clusters that this rule matches. Only applies to cluster requests.
 If this is set, no events for non cluster requests will be created.
@@ -247,7 +247,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#omitStages}
+## `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified per rule in which case the union of both are omitted.

--- a/platform/api/_partials/resources/config/status/audit/policy.mdx
+++ b/platform/api/_partials/resources/config/status/audit/policy.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `rules` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules}
+## `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.

--- a/platform/api/_partials/resources/config/status_reference.mdx
+++ b/platform/api/_partials/resources/config/status_reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth}
+## `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth}
 
 Authentication holds the information for authentication
 
@@ -16,7 +16,7 @@ Authentication holds the information for authentication
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc}
+### `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc}
 
 OIDC holds oidc authentication configuration
 
@@ -28,7 +28,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-issuerUrl}
+#### `issuerUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -51,7 +51,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientId}
+#### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -71,7 +71,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientSecret}
+#### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -86,7 +86,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-redirectURI}
+#### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -101,7 +101,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `postLogoutRedirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-postLogoutRedirectURI}
+#### `postLogoutRedirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-postLogoutRedirectURI}
 
 Loft URI to be redirected to after successful logout by OIDC Provider
 
@@ -116,7 +116,7 @@ Loft URI to be redirected to after successful logout by OIDC Provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-caFile}
+#### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-caFile}
 
 Path to a PEM encoded root certificate of the provider. Optional
 
@@ -131,7 +131,7 @@ Path to a PEM encoded root certificate of the provider. Optional
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecureCa` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-insecureCa}
+#### `insecureCa` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-insecureCa}
 
 Specify whether to communicate without validating SSL certificates
 
@@ -146,7 +146,7 @@ Specify whether to communicate without validating SSL certificates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preferredUsername` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-preferredUsername}
+#### `preferredUsername` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-preferredUsername}
 
 Configurable key which contains the preferred username claims
 
@@ -161,7 +161,7 @@ Configurable key which contains the preferred username claims
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `loftUsernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-loftUsernameClaim}
+#### `loftUsernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-loftUsernameClaim}
 
 LoftUsernameClaim is the JWT field to use as the user's username.
 
@@ -176,7 +176,7 @@ LoftUsernameClaim is the JWT field to use as the user's username.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `usernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-usernameClaim}
+#### `usernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-usernameClaim}
 
 UsernameClaim is the JWT field to use as the user's id.
 
@@ -191,7 +191,7 @@ UsernameClaim is the JWT field to use as the user's id.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `emailClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-emailClaim}
+#### `emailClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-emailClaim}
 
 EmailClaim is the JWT field to use as the user's email.
 
@@ -206,7 +206,7 @@ EmailClaim is the JWT field to use as the user's email.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allowedExtraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-allowedExtraClaims}
+#### `allowedExtraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-allowedExtraClaims}
 
 AllowedExtraClaims are claims of interest that are not part of User by default but may be provided by the OIDC provider.
 
@@ -221,7 +221,7 @@ AllowedExtraClaims are claims of interest that are not part of User by default b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `usernamePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-usernamePrefix}
+#### `usernamePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-usernamePrefix}
 
 UsernamePrefix, if specified, causes claims mapping to username to be prefix with
 the provided value. A value "oidc:" would result in usernames like "oidc:john".
@@ -237,7 +237,7 @@ the provided value. A value "oidc:" would result in usernames like "oidc:john".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groupsClaim}
+#### `groupsClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groupsClaim}
 
 GroupsClaim, if specified, causes the OIDCAuthenticator to try to populate the user's
 groups with an ID Token field. If the GroupsClaim field is present in an ID Token the value
@@ -254,7 +254,7 @@ must be a string or list of strings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groups}
+#### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groups}
 
 If required groups is non empty, access is denied if the user is not part of at least one
 of the specified groups.
@@ -270,7 +270,7 @@ of the specified groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-scopes}
+#### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-scopes}
 
 Scopes that should be sent to the server. If empty, defaults to "email" and "profile".
 
@@ -285,7 +285,7 @@ Scopes that should be sent to the server. If empty, defaults to "email" and "pro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `getUserInfo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-getUserInfo}
+#### `getUserInfo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-getUserInfo}
 
 GetUserInfo, if specified, tells the OIDCAuthenticator to try to populate the user's
 information from the UserInfo.
@@ -301,7 +301,7 @@ information from the UserInfo.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsPrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groupsPrefix}
+#### `groupsPrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groupsPrefix}
 
 GroupsPrefix, if specified, causes claims mapping to group names to be prefixed with the
 value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:marketing".
@@ -317,7 +317,7 @@ value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-type}
+#### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-type}
 
 Type of the OIDC to show in the UI. Only for displaying purposes
 
@@ -332,7 +332,7 @@ Type of the OIDC to show in the UI. Only for displaying purposes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-resource}
+#### `resource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-resource}
 
 Resource, if specified, is the value that is set for the "resource" URL parameter when making a request to the /token endpoint of the
 OIDC provider.
@@ -351,7 +351,7 @@ OIDC provider.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `github` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github}
+### `github` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github}
 
 Github holds github authentication configuration
 
@@ -363,7 +363,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-clientId}
+#### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-clientId}
 
 ClientID holds the github client id
 
@@ -408,7 +408,7 @@ RedirectURI holds the redirect URI. Should be https://loft.domain.tld/auth/githu
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `orgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs}
+#### `orgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs}
 
 Loft queries the following organizations for group information.
 Group claims are formatted as "(org):(team)".
@@ -426,7 +426,7 @@ authenticate with loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs-name}
 
 Organization name in github (not slug, full name). Only users in this github
 organization can authenticate.
@@ -442,7 +442,7 @@ organization can authenticate.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs-teams}
 
 Names of teams in a github organization. A user will be able to
 authenticate if they are members of at least one of these teams. Users
@@ -463,7 +463,7 @@ config file.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-hostName}
+#### `hostName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-hostName}
 
 Required ONLY for GitHub Enterprise.
 This is the Hostname of the GitHub Enterprise account listed on the
@@ -480,7 +480,7 @@ management console. Ensure this domain is routable on your network.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `rootCA` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-rootCA}
+#### `rootCA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-rootCA}
 
 ONLY for GitHub Enterprise. Optional field.
 Used to support self-signed or untrusted CA root certificates.
@@ -499,7 +499,7 @@ Used to support self-signed or untrusted CA root certificates.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `gitlab` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab}
+### `gitlab` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab}
 
 Gitlab holds gitlab authentication configuration
 
@@ -556,7 +556,7 @@ Redirect URI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `baseURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab-baseURL}
+#### `baseURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab-baseURL}
 
 BaseURL is optional, default = https://gitlab.com
 
@@ -571,7 +571,7 @@ BaseURL is optional, default = https://gitlab.com
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab-groups}
+#### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab-groups}
 
 Optional groups whitelist, communicated through the "groups" scope.
 If `groups` is omitted, all of the user's GitLab groups are returned.
@@ -591,7 +591,7 @@ If `groups` is provided, this acts as a whitelist - only the user's GitLab group
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `google` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google}
+### `google` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google}
 
 Google holds google authentication configuration
 
@@ -648,7 +648,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/google/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-scopes}
+#### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-scopes}
 
 defaults to "profile" and "email"
 
@@ -663,7 +663,7 @@ defaults to "profile" and "email"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostedDomains` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-hostedDomains}
+#### `hostedDomains` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-hostedDomains}
 
 Optional list of whitelisted domains
 If this field is nonempty, only users from a listed domain will be allowed to log in
@@ -679,7 +679,7 @@ If this field is nonempty, only users from a listed domain will be allowed to lo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-groups}
+#### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-groups}
 
 Optional list of whitelisted groups
 If this field is nonempty, only users from a listed group will be allowed to log in
@@ -695,7 +695,7 @@ If this field is nonempty, only users from a listed group will be allowed to log
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serviceAccountFilePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-serviceAccountFilePath}
+#### `serviceAccountFilePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-serviceAccountFilePath}
 
 Optional path to service account json
 If nonempty, and groups claim is made, will use authentication from file to
@@ -712,7 +712,7 @@ check groups with the admin directory api
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `adminEmail` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-adminEmail}
+#### `adminEmail` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-adminEmail}
 
 Required if ServiceAccountFilePath
 The email of a GSuite super user which the service account will impersonate
@@ -732,7 +732,7 @@ when listing groups
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `microsoft` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft}
+### `microsoft` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft}
 
 Microsoft holds microsoft authentication configuration
 
@@ -789,7 +789,7 @@ loft redirect uri. Usually https://loft.my.domain/auth/microsoft/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tenant` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-tenant}
+#### `tenant` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-tenant}
 
 tenant configuration parameter controls what kinds of accounts may be authenticated in loft.
 By default, all types of Microsoft accounts (consumers and organizations) can authenticate in loft via Microsoft.
@@ -811,7 +811,7 @@ tenant uuid or tenant name - only accounts belonging to specific tenant identifi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-groups}
+#### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-groups}
 
 It is possible to require a user to be a member of a particular group in order to be successfully authenticated in loft.
 
@@ -826,7 +826,7 @@ It is possible to require a user to be a member of a particular group in order t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `onlySecurityGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-onlySecurityGroups}
+#### `onlySecurityGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-onlySecurityGroups}
 
 configuration option restricts the list to include only security groups. By default all groups (security, Office 365, mailing lists) are included.
 
@@ -841,7 +841,7 @@ configuration option restricts the list to include only security groups. By defa
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-useGroupsAsWhitelist}
+#### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-useGroupsAsWhitelist}
 
 Restrict the groups claims to include only the user’s groups that are in the configured groups
 
@@ -859,7 +859,7 @@ Restrict the groups claims to include only the user’s groups that are in the c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `saml` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml}
+### `saml` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml}
 
 SAML holds saml authentication configuration
 
@@ -871,7 +871,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-redirectURI}
+#### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -888,7 +888,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoURL}
+#### `ssoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -903,7 +903,7 @@ SSO URL used for POST value.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caData` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-caData}
+#### `caData` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-caData}
 
 CAData is a base64 encoded string that holds the ca certificate for validating the signature of the SAML response.
 Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
@@ -919,7 +919,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-usernameAttr}
+#### `usernameAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -934,7 +934,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-emailAttr}
+#### `emailAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -949,7 +949,7 @@ Name of attribute in the returned assertions to map to email
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-groupsAttr}
+#### `groupsAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-groupsAttr}
 
 Name of attribute in the returned assertions to map to groups
 
@@ -964,7 +964,7 @@ Name of attribute in the returned assertions to map to groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ca` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ca}
+#### `ca` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ca}
 
 CA to use when validating the signature of the SAML response.
 
@@ -979,7 +979,7 @@ CA to use when validating the signature of the SAML response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-insecureSkipSignatureValidation}
+#### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-insecureSkipSignatureValidation}
 
 Ignore the ca cert
 
@@ -994,7 +994,7 @@ Ignore the ca cert
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `entityIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-entityIssuer}
+#### `entityIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-entityIssuer}
 
 When provided Loft will include this as the Issuer value during AuthnRequest.
 It will also override the redirectURI as the required audience when evaluating
@@ -1011,7 +1011,7 @@ AudienceRestriction elements in the response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ssoIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoIssuer}
+#### `ssoIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoIssuer}
 
 Issuer value expected in the SAML response. Optional.
 
@@ -1026,7 +1026,7 @@ Issuer value expected in the SAML response. Optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsDelim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-groupsDelim}
+#### `groupsDelim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-groupsDelim}
 
 If GroupsDelim is supplied the connector assumes groups are returned as a
 single string instead of multiple attribute values. This delimiter will be
@@ -1043,7 +1043,7 @@ used split the groups string.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allowedGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-allowedGroups}
+#### `allowedGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-allowedGroups}
 
 List of groups to filter access based on membership
 
@@ -1058,7 +1058,7 @@ List of groups to filter access based on membership
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `filterGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-filterGroups}
+#### `filterGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-filterGroups}
 
 If used with allowed groups, only forwards the allowed groups and not all
 groups specified.
@@ -1074,7 +1074,7 @@ groups specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nameIDPolicyFormat` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-nameIDPolicyFormat}
+#### `nameIDPolicyFormat` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-nameIDPolicyFormat}
 
 Requested format of the NameID. The NameID value is is mapped to the ID Token
 'sub' claim.
@@ -1103,7 +1103,7 @@ If no value is specified, this value defaults to:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password}
+### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password}
 
 Password holds password authentication relevant information
 
@@ -1115,7 +1115,7 @@ Password holds password authentication relevant information
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password-disabled}
+#### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password-disabled}
 
 If true login via password is disabled
 
@@ -1133,7 +1133,7 @@ If true login via password is disabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `connectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors}
+### `connectors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors}
 
 Connectors are optional additional connectors for Loft.
 
@@ -1145,7 +1145,7 @@ Connectors are optional additional connectors for Loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `id` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-id}
+#### `id` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-id}
 
 ID is the id that should show up in the url
 
@@ -1160,7 +1160,7 @@ ID is the id that should show up in the url
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-displayName}
 
 DisplayName is the name that should show up in the ui
 
@@ -1175,7 +1175,7 @@ DisplayName is the name that should show up in the ui
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc}
+#### `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc}
 
 OIDC holds oidc authentication configuration
 
@@ -1187,7 +1187,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -1210,7 +1210,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -1230,7 +1230,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -1245,7 +1245,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -1260,7 +1260,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-postLogoutRedirectURI}
+##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-postLogoutRedirectURI}
 
 Loft URI to be redirected to after successful logout by OIDC Provider
 
@@ -1275,7 +1275,7 @@ Loft URI to be redirected to after successful logout by OIDC Provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-caFile}
 
 Path to a PEM encoded root certificate of the provider. Optional
 
@@ -1290,7 +1290,7 @@ Path to a PEM encoded root certificate of the provider. Optional
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureCa` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-insecureCa}
+##### `insecureCa` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-insecureCa}
 
 Specify whether to communicate without validating SSL certificates
 
@@ -1305,7 +1305,7 @@ Specify whether to communicate without validating SSL certificates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `preferredUsername` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-preferredUsername}
+##### `preferredUsername` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-preferredUsername}
 
 Configurable key which contains the preferred username claims
 
@@ -1320,7 +1320,7 @@ Configurable key which contains the preferred username claims
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `loftUsernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-loftUsernameClaim}
+##### `loftUsernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-loftUsernameClaim}
 
 LoftUsernameClaim is the JWT field to use as the user's username.
 
@@ -1335,7 +1335,7 @@ LoftUsernameClaim is the JWT field to use as the user's username.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-usernameClaim}
+##### `usernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-usernameClaim}
 
 UsernameClaim is the JWT field to use as the user's id.
 
@@ -1350,7 +1350,7 @@ UsernameClaim is the JWT field to use as the user's id.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-emailClaim}
+##### `emailClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-emailClaim}
 
 EmailClaim is the JWT field to use as the user's email.
 
@@ -1365,7 +1365,7 @@ EmailClaim is the JWT field to use as the user's email.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedExtraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-allowedExtraClaims}
+##### `allowedExtraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-allowedExtraClaims}
 
 AllowedExtraClaims are claims of interest that are not part of User by default but may be provided by the OIDC provider.
 
@@ -1380,7 +1380,7 @@ AllowedExtraClaims are claims of interest that are not part of User by default b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernamePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-usernamePrefix}
+##### `usernamePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-usernamePrefix}
 
 UsernamePrefix, if specified, causes claims mapping to username to be prefix with
 the provided value. A value "oidc:" would result in usernames like "oidc:john".
@@ -1396,7 +1396,7 @@ the provided value. A value "oidc:" would result in usernames like "oidc:john".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groupsClaim}
+##### `groupsClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groupsClaim}
 
 GroupsClaim, if specified, causes the OIDCAuthenticator to try to populate the user's
 groups with an ID Token field. If the GroupsClaim field is present in an ID Token the value
@@ -1413,7 +1413,7 @@ must be a string or list of strings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groups}
 
 If required groups is non empty, access is denied if the user is not part of at least one
 of the specified groups.
@@ -1429,7 +1429,7 @@ of the specified groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-scopes}
 
 Scopes that should be sent to the server. If empty, defaults to "email" and "profile".
 
@@ -1444,7 +1444,7 @@ Scopes that should be sent to the server. If empty, defaults to "email" and "pro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `getUserInfo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-getUserInfo}
+##### `getUserInfo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-getUserInfo}
 
 GetUserInfo, if specified, tells the OIDCAuthenticator to try to populate the user's
 information from the UserInfo.
@@ -1460,7 +1460,7 @@ information from the UserInfo.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsPrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groupsPrefix}
+##### `groupsPrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groupsPrefix}
 
 GroupsPrefix, if specified, causes claims mapping to group names to be prefixed with the
 value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:marketing".
@@ -1476,7 +1476,7 @@ value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-type}
 
 Type of the OIDC to show in the UI. Only for displaying purposes
 
@@ -1491,7 +1491,7 @@ Type of the OIDC to show in the UI. Only for displaying purposes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-resource}
+##### `resource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-resource}
 
 Resource, if specified, is the value that is set for the "resource" URL parameter when making a request to the /token endpoint of the
 OIDC provider.
@@ -1510,7 +1510,7 @@ OIDC provider.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `github` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github}
+#### `github` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github}
 
 Github holds github authentication configuration
 
@@ -1522,7 +1522,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-clientId}
 
 ClientID holds the github client id
 
@@ -1567,7 +1567,7 @@ RedirectURI holds the redirect URI. Should be https://loft.domain.tld/auth/githu
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `orgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs}
+##### `orgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs}
 
 Loft queries the following organizations for group information.
 Group claims are formatted as "(org):(team)".
@@ -1585,7 +1585,7 @@ authenticate with loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs-name}
 
 Organization name in github (not slug, full name). Only users in this github
 organization can authenticate.
@@ -1601,7 +1601,7 @@ organization can authenticate.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs-teams}
 
 Names of teams in a github organization. A user will be able to
 authenticate if they are members of at least one of these teams. Users
@@ -1622,7 +1622,7 @@ config file.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-hostName}
+##### `hostName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-hostName}
 
 Required ONLY for GitHub Enterprise.
 This is the Hostname of the GitHub Enterprise account listed on the
@@ -1639,7 +1639,7 @@ management console. Ensure this domain is routable on your network.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rootCA` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-rootCA}
+##### `rootCA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-rootCA}
 
 ONLY for GitHub Enterprise. Optional field.
 Used to support self-signed or untrusted CA root certificates.
@@ -1658,7 +1658,7 @@ Used to support self-signed or untrusted CA root certificates.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gitlab` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab}
+#### `gitlab` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab}
 
 Gitlab holds gitlab authentication configuration
 
@@ -1715,7 +1715,7 @@ Redirect URI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `baseURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab-baseURL}
+##### `baseURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab-baseURL}
 
 BaseURL is optional, default = https://gitlab.com
 
@@ -1730,7 +1730,7 @@ BaseURL is optional, default = https://gitlab.com
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab-groups}
 
 Optional groups whitelist, communicated through the "groups" scope.
 If `groups` is omitted, all of the user's GitLab groups are returned.
@@ -1750,7 +1750,7 @@ If `groups` is provided, this acts as a whitelist - only the user's GitLab group
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `google` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google}
+#### `google` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google}
 
 Google holds google authentication configuration
 
@@ -1807,7 +1807,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/google/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-scopes}
 
 defaults to "profile" and "email"
 
@@ -1822,7 +1822,7 @@ defaults to "profile" and "email"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostedDomains` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-hostedDomains}
+##### `hostedDomains` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-hostedDomains}
 
 Optional list of whitelisted domains
 If this field is nonempty, only users from a listed domain will be allowed to log in
@@ -1838,7 +1838,7 @@ If this field is nonempty, only users from a listed domain will be allowed to lo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-groups}
 
 Optional list of whitelisted groups
 If this field is nonempty, only users from a listed group will be allowed to log in
@@ -1854,7 +1854,7 @@ If this field is nonempty, only users from a listed group will be allowed to log
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `serviceAccountFilePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-serviceAccountFilePath}
+##### `serviceAccountFilePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-serviceAccountFilePath}
 
 Optional path to service account json
 If nonempty, and groups claim is made, will use authentication from file to
@@ -1871,7 +1871,7 @@ check groups with the admin directory api
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `adminEmail` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-adminEmail}
+##### `adminEmail` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-adminEmail}
 
 Required if ServiceAccountFilePath
 The email of a GSuite super user which the service account will impersonate
@@ -1891,7 +1891,7 @@ when listing groups
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `microsoft` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft}
+#### `microsoft` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft}
 
 Microsoft holds microsoft authentication configuration
 
@@ -1948,7 +1948,7 @@ loft redirect uri. Usually https://loft.my.domain/auth/microsoft/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tenant` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-tenant}
+##### `tenant` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-tenant}
 
 tenant configuration parameter controls what kinds of accounts may be authenticated in loft.
 By default, all types of Microsoft accounts (consumers and organizations) can authenticate in loft via Microsoft.
@@ -1970,7 +1970,7 @@ tenant uuid or tenant name - only accounts belonging to specific tenant identifi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-groups}
 
 It is possible to require a user to be a member of a particular group in order to be successfully authenticated in loft.
 
@@ -1985,7 +1985,7 @@ It is possible to require a user to be a member of a particular group in order t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `onlySecurityGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-onlySecurityGroups}
+##### `onlySecurityGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-onlySecurityGroups}
 
 configuration option restricts the list to include only security groups. By default all groups (security, Office 365, mailing lists) are included.
 
@@ -2000,7 +2000,7 @@ configuration option restricts the list to include only security groups. By defa
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-useGroupsAsWhitelist}
+##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-useGroupsAsWhitelist}
 
 Restrict the groups claims to include only the user’s groups that are in the configured groups
 
@@ -2018,7 +2018,7 @@ Restrict the groups claims to include only the user’s groups that are in the c
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `saml` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml}
+#### `saml` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml}
 
 SAML holds saml authentication configuration
 
@@ -2030,7 +2030,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -2047,7 +2047,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -2062,7 +2062,7 @@ SSO URL used for POST value.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caData` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-caData}
+##### `caData` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-caData}
 
 CAData is a base64 encoded string that holds the ca certificate for validating the signature of the SAML response.
 Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
@@ -2078,7 +2078,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -2093,7 +2093,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -2108,7 +2108,7 @@ Name of attribute in the returned assertions to map to email
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-groupsAttr}
+##### `groupsAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-groupsAttr}
 
 Name of attribute in the returned assertions to map to groups
 
@@ -2123,7 +2123,7 @@ Name of attribute in the returned assertions to map to groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ca` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ca}
+##### `ca` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ca}
 
 CA to use when validating the signature of the SAML response.
 
@@ -2138,7 +2138,7 @@ CA to use when validating the signature of the SAML response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-insecureSkipSignatureValidation}
+##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-insecureSkipSignatureValidation}
 
 Ignore the ca cert
 
@@ -2153,7 +2153,7 @@ Ignore the ca cert
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `entityIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-entityIssuer}
+##### `entityIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-entityIssuer}
 
 When provided Loft will include this as the Issuer value during AuthnRequest.
 It will also override the redirectURI as the required audience when evaluating
@@ -2170,7 +2170,7 @@ AudienceRestriction elements in the response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoIssuer}
+##### `ssoIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoIssuer}
 
 Issuer value expected in the SAML response. Optional.
 
@@ -2185,7 +2185,7 @@ Issuer value expected in the SAML response. Optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsDelim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-groupsDelim}
+##### `groupsDelim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-groupsDelim}
 
 If GroupsDelim is supplied the connector assumes groups are returned as a
 single string instead of multiple attribute values. This delimiter will be
@@ -2202,7 +2202,7 @@ used split the groups string.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-allowedGroups}
+##### `allowedGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-allowedGroups}
 
 List of groups to filter access based on membership
 
@@ -2217,7 +2217,7 @@ List of groups to filter access based on membership
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `filterGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-filterGroups}
+##### `filterGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-filterGroups}
 
 If used with allowed groups, only forwards the allowed groups and not all
 groups specified.
@@ -2233,7 +2233,7 @@ groups specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-nameIDPolicyFormat}
+##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-nameIDPolicyFormat}
 
 Requested format of the NameID. The NameID value is is mapped to the ID Token
 'sub' claim.
@@ -2265,7 +2265,7 @@ If no value is specified, this value defaults to:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableTeamCreation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-disableTeamCreation}
+### `disableTeamCreation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-disableTeamCreation}
 
 Prevents from team creation for the new groups associated with the user at the time of logging in through sso,
 Default behaviour is false, this means that teams will be created for new groups.
@@ -2281,7 +2281,7 @@ Default behaviour is false, this means that teams will be created for new groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableUserCreation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-disableUserCreation}
+### `disableUserCreation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-disableUserCreation}
 
 DisableUserCreation prevents the SSO connectors from creating a new user on a users initial signin through sso.
 Default behaviour is false, this means that a new user object will be created once a user without
@@ -2298,7 +2298,7 @@ a Kubernetes user object logs in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `accessKeyMaxTTLSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-accessKeyMaxTTLSeconds}
+### `accessKeyMaxTTLSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-accessKeyMaxTTLSeconds}
 
 AccessKeyMaxTTLSeconds is the global maximum lifespan of an accesskey in seconds.
 Leaving it 0 or unspecified will disable it.
@@ -2315,7 +2315,7 @@ Specifying 2592000 will mean all keys have a Time-To-Live of 30 days.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `loginAccessKeyTTLSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-loginAccessKeyTTLSeconds}
+### `loginAccessKeyTTLSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-loginAccessKeyTTLSeconds}
 
 LoginAccessKeyTTLSeconds is the time in seconds an access key is kept
 until it is deleted.
@@ -2334,7 +2334,7 @@ Specifying 2592000 will mean all keys have a  default Time-To-Live of 30 days.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `customHttpHeaders` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-customHttpHeaders}
+### `customHttpHeaders` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-customHttpHeaders}
 
 CustomHttpHeaders are additional headers that should be set for the authentication endpoints
 
@@ -2349,7 +2349,7 @@ CustomHttpHeaders are additional headers that should be set for the authenticati
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groupsFilters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-groupsFilters}
+### `groupsFilters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-groupsFilters}
 
 GroupsFilters is a regex expression to only save matching sso groups into the user resource
 
@@ -2367,7 +2367,7 @@ GroupsFilters is a regex expression to only save matching sso groups into the us
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc}
+## `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc}
 
 DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secret. By default, vCluster Platform as an OIDC Provider is enabled but does not function without OIDC clients.
 
@@ -2379,7 +2379,7 @@ DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-enabled}
 
 If true indicates that loft will act as an OIDC server
 
@@ -2394,7 +2394,7 @@ If true indicates that loft will act as an OIDC server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `wildcardRedirect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-wildcardRedirect}
+### `wildcardRedirect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-wildcardRedirect}
 
 If true indicates that loft will allow wildcard '*' in client redirectURIs
 
@@ -2409,7 +2409,7 @@ If true indicates that loft will allow wildcard '*' in client redirectURIs
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clients` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients}
+### `clients` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients}
 
 The clients that are allowed to request loft tokens
 
@@ -2421,7 +2421,7 @@ The clients that are allowed to request loft tokens
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-name}
 
 The client name
 
@@ -2436,7 +2436,7 @@ The client name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientId}
+#### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientId}
 
 The client id of the client
 
@@ -2451,7 +2451,7 @@ The client id of the client
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientSecret}
+#### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientSecret}
 
 The client secret of the client
 
@@ -2488,7 +2488,7 @@ requested to redirect to MUST match one of these values, unless the client is "p
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps}
+## `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps}
 
 Apps holds configuration around apps
 
@@ -2500,7 +2500,7 @@ Apps holds configuration around apps
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `noDefault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-noDefault}
+### `noDefault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-noDefault}
 
 If this option is true, loft will not try to parse the default apps
 
@@ -2515,7 +2515,7 @@ If this option is true, loft will not try to parse the default apps
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `repositories` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories}
+### `repositories` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories}
 
 These are additional repositories that are parsed by loft
 
@@ -2527,7 +2527,7 @@ These are additional repositories that are parsed by loft
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-name}
 
 Name is the name of the repository
 
@@ -2542,7 +2542,7 @@ Name is the name of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-url}
+#### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-url}
 
 URL is the repository url
 
@@ -2557,7 +2557,7 @@ URL is the repository url
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-username}
 
 Username of the repository
 
@@ -2572,7 +2572,7 @@ Username of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-password}
+#### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-password}
 
 Password of the repository
 
@@ -2587,7 +2587,7 @@ Password of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-insecure}
+#### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-insecure}
 
 Insecure specifies if the chart should be retrieved without TLS
 verification
@@ -2606,7 +2606,7 @@ verification
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `predefinedApps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps}
+### `predefinedApps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps}
 
 Predefined apps that can be selected in the Spaces ) Space menu
 
@@ -2618,7 +2618,7 @@ Predefined apps that can be selected in the Spaces ) Space menu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-chart}
+#### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-chart}
 
 Chart holds the repo/chart name of the predefined app
 
@@ -2633,7 +2633,7 @@ Chart holds the repo/chart name of the predefined app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `initialVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-initialVersion}
+#### `initialVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-initialVersion}
 
 InitialVersion holds the initial version of this app.
 This version will be selected automatically.
@@ -2649,7 +2649,7 @@ This version will be selected automatically.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `initialValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-initialValues}
+#### `initialValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-initialValues}
 
 InitialValues holds the initial values for this app.
 The values will be prefilled automatically. There are certain
@@ -2667,7 +2667,7 @@ by the loft UI automatically.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-clusters}
+#### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-clusters}
 
 Holds the cluster names where to display this app
 
@@ -2682,7 +2682,7 @@ Holds the cluster names where to display this app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `title` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-title}
+#### `title` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-title}
 
 Title is the name that should be displayed for the predefined app.
 If empty the chart name is used.
@@ -2698,7 +2698,7 @@ If empty the chart name is used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `iconUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-iconUrl}
+#### `iconUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-iconUrl}
 
 IconURL specifies an url to the icon that should be displayed for this app.
 If none is specified the icon from the chart metadata is used.
@@ -2714,7 +2714,7 @@ If none is specified the icon from the chart metadata is used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `readmeUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-readmeUrl}
+#### `readmeUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-readmeUrl}
 
 ReadmeURL specifies an url to the readme page of this predefined app. If empty
 an url will be constructed to artifact hub.
@@ -2736,7 +2736,7 @@ an url will be constructed to artifact hub.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `audit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit}
+## `audit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit}
 
 Audit holds audit configuration
 
@@ -2748,7 +2748,7 @@ Audit holds audit configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-enabled}
 
 If audit is enabled and incoming api requests will be logged based on the supplied policy.
 
@@ -2763,7 +2763,7 @@ If audit is enabled and incoming api requests will be logged based on the suppli
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableAgentSyncBack` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-disableAgentSyncBack}
+### `disableAgentSyncBack` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-disableAgentSyncBack}
 
 If true, the agent will not send back any audit logs to Loft itself.
 
@@ -2778,7 +2778,7 @@ If true, the agent will not send back any audit logs to Loft itself.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-level}
+### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-level}
 
 Level is an optional log level for audit logs. Cannot be used together with policy
 
@@ -2793,7 +2793,7 @@ Level is an optional log level for audit logs. Cannot be used together with poli
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `policy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy}
+### `policy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy}
 
 The audit policy to use and log requests. By default loft will not log anything
 
@@ -2805,7 +2805,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -2835,7 +2835,7 @@ The Level that requests matching this rule are recorded at.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-users}
 
 The users (by authenticated user name) this rule applies to.
 An empty list implies every user.
@@ -2851,7 +2851,7 @@ An empty list implies every user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `userGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-userGroups}
+##### `userGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-userGroups}
 
 The user groups this rule applies to. A user is considered matching
 if it is a member of any of the UserGroups.
@@ -2868,7 +2868,7 @@ An empty list implies every user group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -2884,7 +2884,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -2896,7 +2896,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -2912,7 +2912,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -2939,7 +2939,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -2959,7 +2959,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-namespaces}
+##### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -2976,7 +2976,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be audited.
 *s are allowed, but only as the full, final step in the path.
@@ -2995,7 +2995,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-omitStages}
+##### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified policy wide in which case the union of both are omitted.
@@ -3012,7 +3012,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-requestTargets}
+##### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-requestTargets}
 
 RequestTargets is a list of request targets for which events are created.
 An empty list implies every request.
@@ -3028,7 +3028,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-clusters}
+##### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-clusters}
 
 Clusters that this rule matches. Only applies to cluster requests.
 If this is set, no events for non cluster requests will be created.
@@ -3048,7 +3048,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-omitStages}
+#### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified per rule in which case the union of both are omitted.
@@ -3067,7 +3067,7 @@ be specified per rule in which case the union of both are omitted.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataStoreEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-dataStoreEndpoint}
+### `dataStoreEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-dataStoreEndpoint}
 
 DataStoreEndpoint is an endpoint to store events in.
 
@@ -3082,7 +3082,7 @@ DataStoreEndpoint is an endpoint to store events in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataStoreTTL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-dataStoreTTL}
+### `dataStoreTTL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-dataStoreTTL}
 
 DataStoreMaxAge is the maximum number of hours to retain old log events in the datastore
 
@@ -3097,7 +3097,7 @@ DataStoreMaxAge is the maximum number of hours to retain old log events in the d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-path}
+### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-path}
 
 The path where to save the audit log files. This is required if audit is enabled. Backup log files will
 be retained in the same directory.
@@ -3113,7 +3113,7 @@ be retained in the same directory.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `maxAge` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxAge}
+### `maxAge` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxAge}
 
 MaxAge is the maximum number of days to retain old log files based on the
 timestamp encoded in their filename.  Note that a day is defined as 24
@@ -3132,7 +3132,7 @@ based on age.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `maxBackups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxBackups}
+### `maxBackups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxBackups}
 
 MaxBackups is the maximum number of old log files to retain.  The default
 is to retain all old log files (though MaxAge may still cause them to get
@@ -3149,7 +3149,7 @@ deleted.)
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `maxSize` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxSize}
+### `maxSize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxSize}
 
 MaxSize is the maximum size in megabytes of the log file before it gets
 rotated. It defaults to 100 megabytes.
@@ -3165,7 +3165,7 @@ rotated. It defaults to 100 megabytes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `compress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-compress}
+### `compress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-compress}
 
 Compress determines if the rotated log files should be compressed
 using gzip. The default is not to perform compression.
@@ -3184,7 +3184,7 @@ using gzip. The default is not to perform compression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `loftHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#loftHost}
+## `loftHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#loftHost}
 
 LoftHost holds the domain where the loft instance is hosted. This should not include https or http. E.g. loft.my-domain.com
 
@@ -3199,7 +3199,7 @@ LoftHost holds the domain where the loft instance is hosted. This should not inc
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `projectNamespacePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#projectNamespacePrefix}
+## `projectNamespacePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#projectNamespacePrefix}
 
 ProjectNamespacePrefix holds the prefix for loft project namespaces. Omitted defaults to "p-"
 
@@ -3214,7 +3214,7 @@ ProjectNamespacePrefix holds the prefix for loft project namespaces. Omitted def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `devPodSubDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#devPodSubDomain}
+## `devPodSubDomain` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#devPodSubDomain}
 
 DEPRECATED: DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.com
 DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.com
@@ -3230,7 +3230,7 @@ DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.co
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `uiSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings}
+## `uiSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings}
 
 UISettings holds the settings for modifying the Loft user interface
 
@@ -3242,7 +3242,7 @@ UISettings holds the settings for modifying the Loft user interface
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `loftVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-loftVersion}
+### `loftVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-loftVersion}
 
 LoftVersion holds the current loft version
 
@@ -3257,7 +3257,7 @@ LoftVersion holds the current loft version
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `logoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-logoURL}
+### `logoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-logoURL}
 
 LogoURL is url pointing to the logo to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3273,7 +3273,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `faviconURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-faviconURL}
+### `faviconURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-faviconURL}
 
 FaviconURL is url pointing to the favicon to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3289,7 +3289,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `smallLogoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-smallLogoURL}
+### `smallLogoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-smallLogoURL}
 
 SmallLogoURL is url pointing to the small logo to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3305,7 +3305,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `logoBackgroundColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-logoBackgroundColor}
+### `logoBackgroundColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-logoBackgroundColor}
 
 LogoBackgroundColor is the color value (ex: "#12345") to use as the background color for the logo
 
@@ -3320,7 +3320,7 @@ LogoBackgroundColor is the color value (ex: "#12345") to use as the background c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `legalTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-legalTemplate}
+### `legalTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-legalTemplate}
 
 LegalTemplate is a text (html) string containing the legal template to prompt to users when authenticating to Loft
 
@@ -3335,7 +3335,7 @@ LegalTemplate is a text (html) string containing the legal template to prompt to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `primaryColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-primaryColor}
+### `primaryColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-primaryColor}
 
 PrimaryColor is the color value (ex: "#12345") to use as the primary color
 
@@ -3350,7 +3350,7 @@ PrimaryColor is the color value (ex: "#12345") to use as the primary color
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `sidebarColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-sidebarColor}
+### `sidebarColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-sidebarColor}
 
 SidebarColor is the color value (ex: "#12345") to use for the sidebar
 
@@ -3365,7 +3365,7 @@ SidebarColor is the color value (ex: "#12345") to use for the sidebar
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `accentColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-accentColor}
+### `accentColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-accentColor}
 
 AccentColor is the color value (ex: "#12345") to use for the accent
 
@@ -3380,7 +3380,7 @@ AccentColor is the color value (ex: "#12345") to use for the accent
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `customCss` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-customCss}
+### `customCss` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-customCss}
 
 CustomCSS holds URLs with custom css files that should be included when loading the UI
 
@@ -3395,7 +3395,7 @@ CustomCSS holds URLs with custom css files that should be included when loading 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `customJavaScript` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-customJavaScript}
+### `customJavaScript` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-customJavaScript}
 
 CustomJavaScript holds URLs with custom js files that should be included when loading the UI
 
@@ -3410,7 +3410,7 @@ CustomJavaScript holds URLs with custom js files that should be included when lo
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `navBarButtons` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons}
+### `navBarButtons` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons}
 
 NavBarButtons holds extra nav bar buttons
 
@@ -3422,7 +3422,7 @@ NavBarButtons holds extra nav bar buttons
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `position` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-position}
+#### `position` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-position}
 
 Position holds the position of the button, can be one of:
 TopStart, TopEnd, BottomStart, BottomEnd. Defaults to BottomEnd
@@ -3438,7 +3438,7 @@ TopStart, TopEnd, BottomStart, BottomEnd. Defaults to BottomEnd
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `text` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-text}
+#### `text` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-text}
 
 Text holds text for the button
 
@@ -3453,7 +3453,7 @@ Text holds text for the button
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `link` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-link}
+#### `link` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-link}
 
 Link holds the link of the navbar button
 
@@ -3468,7 +3468,7 @@ Link holds the link of the navbar button
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-icon}
 
 Icon holds the url of the icon to display
 
@@ -3486,7 +3486,7 @@ Icon holds the url of the icon to display
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `externalURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs}
+### `externalURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs}
 
 External URLs that can be called from the UI
 
@@ -3498,7 +3498,7 @@ External URLs that can be called from the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `block` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs-block}
+#### `block` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs-block}
 
 Block determines if requests to external URLs from the UI should be blocked
 
@@ -3513,7 +3513,7 @@ Block determines if requests to external URLs from the UI should be blocked
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs-allow}
+#### `allow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs-allow}
 
 Allow specifies which external URLs can be called. In addition to the predefined modules,
 - "vcluster" (license page, feature descriptions, ...)
@@ -3539,7 +3539,7 @@ This is only active when Block is true.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `vault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault}
+## `vault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault}
 
 VaultIntegration holds the vault integration configuration
 
@@ -3551,7 +3551,7 @@ VaultIntegration holds the vault integration configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-enabled}
 
 Enabled indicates if the Vault Integration is enabled for the project -- this knob only
 enables the syncing of secrets to or from Vault, but does not setup Kubernetes authentication
@@ -3568,7 +3568,7 @@ methods or Kubernetes secrets engines for vclusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `address` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-address}
+### `address` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-address}
 
 Address defines the address of the Vault instance to use for this project.
 Will default to the `VAULT_ADDR` environment variable if not provided.
@@ -3584,7 +3584,7 @@ Will default to the `VAULT_ADDR` environment variable if not provided.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `skipTLSVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-skipTLSVerify}
+### `skipTLSVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-skipTLSVerify}
 
 SkipTLSVerify defines if TLS verification should be skipped when connecting to Vault.
 
@@ -3599,7 +3599,7 @@ SkipTLSVerify defines if TLS verification should be skipped when connecting to V
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-namespace}
+### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-namespace}
 
 Namespace defines the namespace to use when storing secrets in Vault.
 
@@ -3614,7 +3614,7 @@ Namespace defines the namespace to use when storing secrets in Vault.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth}
+### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth}
 
 Auth defines the authentication method to use for this project.
 
@@ -3626,7 +3626,7 @@ Auth defines the authentication method to use for this project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-token}
+#### `token` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-token}
 
 Token defines the token to use for authentication.
 
@@ -3641,7 +3641,7 @@ Token defines the token to use for authentication.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `tokenSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef}
+#### `tokenSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef}
 
 TokenSecretRef defines the Kubernetes secret to use for token authentication.
 Will be used if `token` is not provided.
@@ -3656,7 +3656,7 @@ Secret data should contain the `token` key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef-name}
 
 Name of the referent.
 This field is effectively required, but due to backwards compatibility is
@@ -3691,7 +3691,7 @@ The key of the secret to select from.  Must be a valid secret key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef-optional}
+##### `optional` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef-optional}
 
 Specify whether the Secret or its key must be defined
 
@@ -3712,7 +3712,7 @@ Specify whether the Secret or its key must be defined
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `syncInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-syncInterval}
+### `syncInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-syncInterval}
 
 SyncInterval defines the interval at which to sync secrets from Vault.
 Defaults to `1m.`
@@ -3732,7 +3732,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `disableConfigEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableConfigEndpoint}
+## `disableConfigEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableConfigEndpoint}
 
 DisableLoftConfigEndpoint will disable setting config via the UI and config.management.loft.sh endpoint
 
@@ -3747,7 +3747,7 @@ DisableLoftConfigEndpoint will disable setting config via the UI and config.mana
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `authenticateVersionEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#authenticateVersionEndpoint}
+## `authenticateVersionEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#authenticateVersionEndpoint}
 
 AuthenticateVersionEndpoint will force authentication for the '/version' endpoint. Will only work with vCluster v0.27 & later
 
@@ -3762,7 +3762,7 @@ AuthenticateVersionEndpoint will force authentication for the '/version' endpoin
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `cloud` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud}
+## `cloud` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud}
 
 Cloud holds the settings to be used exclusively in vCluster Cloud based
 environments and deployments.
@@ -3775,7 +3775,7 @@ environments and deployments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `releaseChannel` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-releaseChannel}
+### `releaseChannel` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-releaseChannel}
 
 ReleaseChannel specifies the release channel for the cloud configuration.
 This can be used to determine which updates or versions are applied.
@@ -3791,7 +3791,7 @@ This can be used to determine which updates or versions are applied.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `maintenanceWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow}
+### `maintenanceWindow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow}
 
 MaintenanceWindow specifies the maintenance window for the cloud configuration.
 This is a structured representation of the time window during which maintenance can occur.
@@ -3804,7 +3804,7 @@ This is a structured representation of the time window during which maintenance 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dayOfWeek` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-dayOfWeek}
+#### `dayOfWeek` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-dayOfWeek}
 
 DayOfWeek specifies the day of the week for the maintenance window.
 It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
@@ -3820,7 +3820,7 @@ It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timeWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-timeWindow}
+#### `timeWindow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-timeWindow}
 
 TimeWindow specifies the time window for the maintenance.
 It should be a string representing the time range in 24-hour format, in UTC, e.g., "02:00-03:00".
@@ -3842,7 +3842,7 @@ It should be a string representing the time range in 24-hour format, in UTC, e.g
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `costControl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl}
+## `costControl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl}
 
 CostControl holds the settings related to the Cost Control ROI dashboard and its metrics gathering infrastructure
 
@@ -3854,7 +3854,7 @@ CostControl holds the settings related to the Cost Control ROI dashboard and its
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-enabled}
 
 Enabled specifies whether the ROI dashboard should be available in the UI, and if the metrics infrastructure
 that provides dashboard data is deployed
@@ -3870,7 +3870,7 @@ that provides dashboard data is deployed
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `global` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global}
+### `global` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global}
 
 Global are settings for globally managed components
 
@@ -3882,7 +3882,7 @@ Global are settings for globally managed components
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics}
+#### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics}
 
 Metrics these settings apply to metric infrastructure used to aggregate metrics across all connected clusters
 
@@ -3894,7 +3894,7 @@ Metrics these settings apply to metric infrastructure used to aggregate metrics 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -3909,7 +3909,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -3921,7 +3921,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -3937,7 +3937,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -3955,7 +3955,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -3991,7 +3991,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4015,7 +4015,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4030,7 +4030,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage}
 
 
 
@@ -4042,7 +4042,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4059,7 +4059,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4083,7 +4083,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster}
+### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster}
 
 Cluster are settings for each cluster's managed components. These settings apply to all connected clusters
 unless overridden by modifying the Cluster's spec
@@ -4096,7 +4096,7 @@ unless overridden by modifying the Cluster's spec
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics}
+#### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics}
 
 Metrics are settings applied to metric infrastructure in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4109,7 +4109,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4124,7 +4124,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4136,7 +4136,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4152,7 +4152,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4170,7 +4170,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4206,7 +4206,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4230,7 +4230,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4245,7 +4245,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage}
 
 
 
@@ -4257,7 +4257,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4274,7 +4274,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4295,7 +4295,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost}
+#### `opencost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost}
 
 OpenCost are settings applied to OpenCost deployments in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4308,7 +4308,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4323,7 +4323,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -4335,7 +4335,7 @@ Resources are compute resource required by the OpenCost backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4351,7 +4351,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4369,7 +4369,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4405,7 +4405,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4435,7 +4435,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `settings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings}
+### `settings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings}
 
 Settings specify price-related settings that are taken into account for the ROI dashboard calculations.
 
@@ -4447,7 +4447,7 @@ Settings specify price-related settings that are taken into account for the ROI 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priceCurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-priceCurrency}
+#### `priceCurrency` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-priceCurrency}
 
 PriceCurrency specifies the currency.
 
@@ -4462,7 +4462,7 @@ PriceCurrency specifies the currency.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `averageCPUPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode}
+#### `averageCPUPricePerNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode}
 
 AvgCPUPricePerNode specifies the average CPU price per node.
 
@@ -4474,7 +4474,7 @@ AvgCPUPricePerNode specifies the average CPU price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-price}
 
 Price specifies the price.
 
@@ -4489,7 +4489,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4507,7 +4507,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `averageRAMPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode}
+#### `averageRAMPricePerNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode}
 
 AvgRAMPricePerNode specifies the average RAM price per node.
 
@@ -4519,7 +4519,7 @@ AvgRAMPricePerNode specifies the average RAM price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-price}
 
 Price specifies the price.
 
@@ -4534,7 +4534,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4552,7 +4552,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gpuSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings}
+#### `gpuSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings}
 
 GPUSettings specifies GPU related settings.
 
@@ -4564,7 +4564,7 @@ GPUSettings specifies GPU related settings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-enabled}
 
 Enabled specifies whether GPU settings should be available in the UI.
 
@@ -4579,7 +4579,7 @@ Enabled specifies whether GPU settings should be available in the UI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageGPUPrice` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice}
+##### `averageGPUPrice` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice}
 
 AvgGPUPrice specifies the average GPU price.
 
@@ -4591,7 +4591,7 @@ AvgGPUPrice specifies the average GPU price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-price}
 
 Price specifies the price.
 
@@ -4606,7 +4606,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4627,7 +4627,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster}
+#### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster}
 
 ControlPlanePricePerCluster specifies the price of one physical cluster.
 
@@ -4639,7 +4639,7 @@ ControlPlanePricePerCluster specifies the price of one physical cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-price}
 
 Price specifies the price.
 
@@ -4654,7 +4654,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4678,7 +4678,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `platformDB` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB}
+## `platformDB` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB}
 
 PlatformDB holds the settings related to the postgres database that platform uses to store data
 
@@ -4690,7 +4690,7 @@ PlatformDB holds the settings related to the postgres database that platform use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB-storageClass}
+### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB-storageClass}
 
 StorageClass sets the storage class for the PersistentVolumeClaim used by the platform database statefulSet.
 
@@ -4708,7 +4708,7 @@ StorageClass sets the storage class for the PersistentVolumeClaim used by the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `imageBuilder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder}
+## `imageBuilder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder}
 
 ImageBuilder holds the settings related to the image builder
 
@@ -4720,7 +4720,7 @@ ImageBuilder holds the settings related to the image builder
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-enabled}
 
 Enabled specifies whether the remote image builder should be available.
 If it's not available building ad-hoc images from a devcontainer.json is not supported
@@ -4736,7 +4736,7 @@ If it's not available building ad-hoc images from a devcontainer.json is not sup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-replicas}
+### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4751,7 +4751,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources}
+### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources}
 
 Resources are compute resource required by the buildkit containers
 
@@ -4763,7 +4763,7 @@ Resources are compute resource required by the buildkit containers
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-limits}
+#### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4779,7 +4779,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-requests}
+#### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4797,7 +4797,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-claims}
+#### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4833,7 +4833,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4860,7 +4860,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database}
+## `database` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database}
 
 Database represents the database connection settings when deploying the platform with an embedded Kubernetes backed by kine
 
@@ -4872,7 +4872,7 @@ Database represents the database connection settings when deploying the platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-enabled}
 
 Enabled defines if the database should be used.
 
@@ -4887,7 +4887,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -4905,7 +4905,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-identityProvider}
+### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -4922,7 +4922,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -4937,7 +4937,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-certFile}
+### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -4952,7 +4952,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-caFile}
+### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -4967,7 +4967,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/platform/api/_partials/resources/config/status_reference.mdx
+++ b/platform/api/_partials/resources/config/status_reference.mdx
@@ -28,7 +28,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `issuerUrl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-issuerUrl}
+#### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -51,7 +51,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientId}
+#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -71,7 +71,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientSecret}
+#### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -86,7 +86,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-redirectURI}
+#### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -363,7 +363,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-clientId}
+#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-clientId}
 
 ClientID holds the github client id
 
@@ -871,7 +871,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-redirectURI}
+#### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -888,7 +888,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ssoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoURL}
+#### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -919,7 +919,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `usernameAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-usernameAttr}
+#### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -934,7 +934,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `emailAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-emailAttr}
+#### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -1115,7 +1115,7 @@ Password holds password authentication relevant information
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password-disabled}
+#### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password-disabled}
 
 If true login via password is disabled
 
@@ -1187,7 +1187,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -1210,7 +1210,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -1230,7 +1230,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -1245,7 +1245,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -1522,7 +1522,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-clientId}
 
 ClientID holds the github client id
 
@@ -2030,7 +2030,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -2047,7 +2047,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -2078,7 +2078,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -2093,7 +2093,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -2349,7 +2349,7 @@ CustomHttpHeaders are additional headers that should be set for the authenticati
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groupsFilters` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-groupsFilters}
+### `groupsFilters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-groupsFilters}
 
 GroupsFilters is a regex expression to only save matching sso groups into the user resource
 
@@ -2379,7 +2379,7 @@ DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-enabled}
 
 If true indicates that loft will act as an OIDC server
 
@@ -2394,7 +2394,7 @@ If true indicates that loft will act as an OIDC server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `wildcardRedirect` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-wildcardRedirect}
+### `wildcardRedirect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-wildcardRedirect}
 
 If true indicates that loft will allow wildcard '*' in client redirectURIs
 
@@ -2409,7 +2409,7 @@ If true indicates that loft will allow wildcard '*' in client redirectURIs
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clients` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients}
+### `clients` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients}
 
 The clients that are allowed to request loft tokens
 
@@ -2421,7 +2421,7 @@ The clients that are allowed to request loft tokens
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-name}
 
 The client name
 
@@ -2436,7 +2436,7 @@ The client name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientId}
+#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientId}
 
 The client id of the client
 
@@ -2451,7 +2451,7 @@ The client id of the client
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientSecret}
+#### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientSecret}
 
 The client secret of the client
 
@@ -2805,7 +2805,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules}
+#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -3732,7 +3732,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `disableConfigEndpoint` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableConfigEndpoint}
+## `disableConfigEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableConfigEndpoint}
 
 DisableLoftConfigEndpoint will disable setting config via the UI and config.management.loft.sh endpoint
 
@@ -3747,7 +3747,7 @@ DisableLoftConfigEndpoint will disable setting config via the UI and config.mana
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `authenticateVersionEndpoint` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#authenticateVersionEndpoint}
+## `authenticateVersionEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#authenticateVersionEndpoint}
 
 AuthenticateVersionEndpoint will force authentication for the '/version' endpoint. Will only work with vCluster v0.27 & later
 
@@ -3762,7 +3762,7 @@ AuthenticateVersionEndpoint will force authentication for the '/version' endpoin
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `cloud` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud}
+## `cloud` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud}
 
 Cloud holds the settings to be used exclusively in vCluster Cloud based
 environments and deployments.
@@ -3775,7 +3775,7 @@ environments and deployments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `releaseChannel` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-releaseChannel}
+### `releaseChannel` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-releaseChannel}
 
 ReleaseChannel specifies the release channel for the cloud configuration.
 This can be used to determine which updates or versions are applied.
@@ -3791,7 +3791,7 @@ This can be used to determine which updates or versions are applied.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `maintenanceWindow` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow}
+### `maintenanceWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow}
 
 MaintenanceWindow specifies the maintenance window for the cloud configuration.
 This is a structured representation of the time window during which maintenance can occur.
@@ -3804,7 +3804,7 @@ This is a structured representation of the time window during which maintenance 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dayOfWeek` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-dayOfWeek}
+#### `dayOfWeek` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-dayOfWeek}
 
 DayOfWeek specifies the day of the week for the maintenance window.
 It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
@@ -3820,7 +3820,7 @@ It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timeWindow` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-timeWindow}
+#### `timeWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-timeWindow}
 
 TimeWindow specifies the time window for the maintenance.
 It should be a string representing the time range in 24-hour format, in UTC, e.g., "02:00-03:00".
@@ -3842,7 +3842,7 @@ It should be a string representing the time range in 24-hour format, in UTC, e.g
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `costControl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl}
+## `costControl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl}
 
 CostControl holds the settings related to the Cost Control ROI dashboard and its metrics gathering infrastructure
 
@@ -3854,7 +3854,7 @@ CostControl holds the settings related to the Cost Control ROI dashboard and its
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-enabled}
 
 Enabled specifies whether the ROI dashboard should be available in the UI, and if the metrics infrastructure
 that provides dashboard data is deployed
@@ -3870,7 +3870,7 @@ that provides dashboard data is deployed
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `global` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global}
+### `global` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global}
 
 Global are settings for globally managed components
 
@@ -3882,7 +3882,7 @@ Global are settings for globally managed components
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics}
+#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics}
 
 Metrics these settings apply to metric infrastructure used to aggregate metrics across all connected clusters
 
@@ -3894,7 +3894,7 @@ Metrics these settings apply to metric infrastructure used to aggregate metrics 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -3909,7 +3909,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4015,7 +4015,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4030,7 +4030,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage}
 
 
 
@@ -4042,7 +4042,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4059,7 +4059,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4083,7 +4083,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cluster` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster}
+### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster}
 
 Cluster are settings for each cluster's managed components. These settings apply to all connected clusters
 unless overridden by modifying the Cluster's spec
@@ -4096,7 +4096,7 @@ unless overridden by modifying the Cluster's spec
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics}
+#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics}
 
 Metrics are settings applied to metric infrastructure in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4109,7 +4109,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4124,7 +4124,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4230,7 +4230,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4245,7 +4245,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage}
 
 
 
@@ -4257,7 +4257,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4274,7 +4274,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4295,7 +4295,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `opencost` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost}
+#### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost}
 
 OpenCost are settings applied to OpenCost deployments in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4308,7 +4308,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4323,7 +4323,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -4435,7 +4435,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `settings` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings}
+### `settings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings}
 
 Settings specify price-related settings that are taken into account for the ROI dashboard calculations.
 
@@ -4447,7 +4447,7 @@ Settings specify price-related settings that are taken into account for the ROI 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priceCurrency` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-priceCurrency}
+#### `priceCurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-priceCurrency}
 
 PriceCurrency specifies the currency.
 
@@ -4462,7 +4462,7 @@ PriceCurrency specifies the currency.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `averageCPUPricePerNode` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode}
+#### `averageCPUPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode}
 
 AvgCPUPricePerNode specifies the average CPU price per node.
 
@@ -4474,7 +4474,7 @@ AvgCPUPricePerNode specifies the average CPU price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-price}
 
 Price specifies the price.
 
@@ -4489,7 +4489,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4507,7 +4507,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `averageRAMPricePerNode` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode}
+#### `averageRAMPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode}
 
 AvgRAMPricePerNode specifies the average RAM price per node.
 
@@ -4519,7 +4519,7 @@ AvgRAMPricePerNode specifies the average RAM price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-price}
 
 Price specifies the price.
 
@@ -4534,7 +4534,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4552,7 +4552,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gpuSettings` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings}
+#### `gpuSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings}
 
 GPUSettings specifies GPU related settings.
 
@@ -4564,7 +4564,7 @@ GPUSettings specifies GPU related settings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-enabled}
 
 Enabled specifies whether GPU settings should be available in the UI.
 
@@ -4579,7 +4579,7 @@ Enabled specifies whether GPU settings should be available in the UI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageGPUPrice` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice}
+##### `averageGPUPrice` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice}
 
 AvgGPUPrice specifies the average GPU price.
 
@@ -4591,7 +4591,7 @@ AvgGPUPrice specifies the average GPU price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-price}
 
 Price specifies the price.
 
@@ -4606,7 +4606,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4627,7 +4627,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controlPlanePricePerCluster` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster}
+#### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster}
 
 ControlPlanePricePerCluster specifies the price of one physical cluster.
 
@@ -4639,7 +4639,7 @@ ControlPlanePricePerCluster specifies the price of one physical cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-price}
 
 Price specifies the price.
 
@@ -4654,7 +4654,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4678,7 +4678,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `platformDB` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB}
+## `platformDB` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB}
 
 PlatformDB holds the settings related to the postgres database that platform uses to store data
 
@@ -4690,7 +4690,7 @@ PlatformDB holds the settings related to the postgres database that platform use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB-storageClass}
+### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB-storageClass}
 
 StorageClass sets the storage class for the PersistentVolumeClaim used by the platform database statefulSet.
 
@@ -4708,7 +4708,7 @@ StorageClass sets the storage class for the PersistentVolumeClaim used by the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `imageBuilder` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder}
+## `imageBuilder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder}
 
 ImageBuilder holds the settings related to the image builder
 
@@ -4720,7 +4720,7 @@ ImageBuilder holds the settings related to the image builder
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-enabled}
 
 Enabled specifies whether the remote image builder should be available.
 If it's not available building ad-hoc images from a devcontainer.json is not supported
@@ -4736,7 +4736,7 @@ If it's not available building ad-hoc images from a devcontainer.json is not sup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-replicas}
+### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4751,7 +4751,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources}
 
 Resources are compute resource required by the buildkit containers
 
@@ -4860,7 +4860,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `database` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database}
+## `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database}
 
 Database represents the database connection settings when deploying the platform with an embedded Kubernetes backed by kine
 
@@ -4872,7 +4872,7 @@ Database represents the database connection settings when deploying the platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-enabled}
 
 Enabled defines if the database should be used.
 
@@ -4887,7 +4887,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -4905,7 +4905,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `identityProvider` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-identityProvider}
+### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -4922,7 +4922,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -4937,7 +4937,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-certFile}
+### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -4952,7 +4952,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-caFile}
+### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -4967,7 +4967,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/platform/api/_partials/resources/directclusterendpointtokens/reference.mdx
+++ b/platform/api/_partials/resources/directclusterendpointtokens/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ttl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttl}
+### `ttl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttl}
 
 The time to live for this access token in seconds
 
@@ -35,7 +35,7 @@ The time to live for this access token in seconds
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope}
+### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope}
 
 Scope is the optional scope of the direct cluster endpoint
 
@@ -47,7 +47,7 @@ Scope is the optional scope of the direct cluster endpoint
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `roles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles}
+#### `roles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles}
 
 Roles is a set of managed permissions to apply to the access key.
 
@@ -59,7 +59,7 @@ Roles is a set of managed permissions to apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-role}
 
 Role is the name of the role to apply to the access key scope.
 
@@ -74,7 +74,7 @@ Role is the name of the role to apply to the access key scope.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-projects}
+##### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -89,7 +89,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -107,7 +107,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects}
+#### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -119,7 +119,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects-project}
 
 Project is the name of the project. You can specify * to select all projects.
 
@@ -137,7 +137,7 @@ Project is the name of the project. You can specify * to select all projects.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces}
+#### `spaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces}
 
 Spaces specifies the spaces the access key is allowed to access.
 
@@ -149,7 +149,7 @@ Spaces specifies the spaces the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-project}
 
 Project is the name of the project.
 
@@ -164,7 +164,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `space` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-space}
+##### `space` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-space}
 
 Space is the name of the space. You can specify * to select all spaces.
 
@@ -182,7 +182,7 @@ Space is the name of the space. You can specify * to select all spaces.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters}
+#### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -194,7 +194,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-project}
 
 Project is the name of the project.
 
@@ -209,7 +209,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-virtualCluster}
+##### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-virtualCluster}
 
 VirtualCluster is the name of the tenant cluster to access. You can specify * to select all tenant clusters.
 
@@ -227,7 +227,7 @@ VirtualCluster is the name of the tenant cluster to access. You can specify * to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters}
+#### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters}
 
 Clusters specifies the project cluster the access key is allowed to access.
 
@@ -239,7 +239,7 @@ Clusters specifies the project cluster the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters-cluster}
 
 Cluster is the name of the cluster to access. You can specify * to select all clusters.
 
@@ -257,7 +257,7 @@ Cluster is the name of the cluster to access. You can specify * to select all cl
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules}
 
 DEPRECATED: Use Projects, Spaces and VirtualClusters instead
 Rules specifies the rules that should apply to the access key.
@@ -270,7 +270,7 @@ Rules specifies the rules that should apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -286,7 +286,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -298,7 +298,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -314,7 +314,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -341,7 +341,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -361,7 +361,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-namespaces}
+##### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -378,7 +378,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be checked.
 *s are allowed, but only as the full, final step in the path.
@@ -397,7 +397,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-requestTargets}
+##### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-requestTargets}
 
 RequestTargets is a list of request targets that are allowed.
 An empty list implies every request.
@@ -413,7 +413,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-cluster}
 
 Cluster that this rule matches. Only applies to cluster requests.
 If this is set, no requests for non cluster requests are allowed.
@@ -430,7 +430,7 @@ An empty cluster means no restrictions will apply.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters}
 
 VirtualClusters that this rule matches. Only applies to tenant cluster requests.
 An empty list means no restrictions will apply.
@@ -443,7 +443,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-name}
 
 Name of the tenant cluster. Empty means all tenant clusters.
 
@@ -458,7 +458,7 @@ Name of the tenant cluster. Empty means all tenant clusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-namespace}
 
 Namespace of the tenant cluster. Empty means all namespaces.
 
@@ -479,7 +479,7 @@ Namespace of the tenant cluster. Empty means all namespaces.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allowLoftCli` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-allowLoftCli}
+#### `allowLoftCli` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-allowLoftCli}
 
 AllowLoftCLI allows certain read-only management requests to
 make sure loft cli works correctly with this specific access key.
@@ -508,7 +508,7 @@ Deprecated: Use the `roles` field instead
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -520,7 +520,7 @@ Deprecated: Use the `roles` field instead
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-token}
+### `token` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-token}
 
 
 

--- a/platform/api/_partials/resources/metadata/reference.mdx
+++ b/platform/api/_partials/resources/metadata/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kind}
+## `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -23,7 +23,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiVersion}
+## `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -41,7 +41,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata}
+## `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata}
 
 
 
@@ -53,7 +53,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -73,7 +73,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-generateName}
+### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -99,7 +99,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-namespace}
+### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -121,7 +121,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-selfLink}
+### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -136,7 +136,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-uid}
+### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -157,7 +157,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-resourceVersion}
+### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -181,7 +181,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-generation}
+### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -197,7 +197,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-creationTimestamp}
+### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -219,7 +219,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-deletionTimestamp}
+### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -251,7 +251,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-deletionGracePeriodSeconds}
+### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -269,7 +269,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -287,7 +287,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -305,7 +305,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences}
+### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -383,7 +383,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences-controller}
+#### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -398,7 +398,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences-blockOwnerDeletion}
+#### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -423,7 +423,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-finalizers}
+### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -450,7 +450,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields}
+### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -469,7 +469,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-manager}
+#### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -484,7 +484,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-operation}
+#### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -500,7 +500,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -518,7 +518,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-time}
+#### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -537,7 +537,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsType}
+#### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -553,7 +553,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsV1}
+#### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -568,7 +568,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-subresource}
+#### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The

--- a/platform/api/_partials/resources/metadata/reference.mdx
+++ b/platform/api/_partials/resources/metadata/reference.mdx
@@ -469,7 +469,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-manager}
+#### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -484,7 +484,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-operation}
+#### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -500,7 +500,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -537,7 +537,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsType}
+#### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -568,7 +568,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-subresource}
+#### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The

--- a/platform/api/_partials/resources/nodeproviders/reference.mdx
+++ b/platform/api/_partials/resources/nodeproviders/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-properties}
+### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-properties}
 
 Properties are global properties that are applied to all node claims and environments managed by this provider.
 
@@ -35,7 +35,7 @@ Properties are global properties that are applied to all node claims and environ
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `bcm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm}
+### `bcm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm}
 
 BCM configures a node provider for BCM Bare Metal Cloud environments.
 
@@ -107,7 +107,7 @@ Endpoint is an address for head node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -119,7 +119,7 @@ NodeTypes define NodeTypes that should be automatically created for this provide
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `providerRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-providerRef}
+##### `providerRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-providerRef}
 
 ProviderRef is the node provider to use for this node type.
 
@@ -134,7 +134,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -149,7 +149,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -164,7 +164,7 @@ Resources lists the full resources for a single node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `overhead` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-overhead}
+##### `overhead` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-overhead}
 
 Overhead defines the resource overhead for this node type.
 
@@ -176,7 +176,7 @@ Overhead defines the resource overhead for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeReserved` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-overhead-kubeReserved}
+##### `kubeReserved` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-overhead-kubeReserved}
 
 KubeReserved is the resource overhead for kubelet and other Kubernetes system daemons.
 
@@ -194,7 +194,7 @@ KubeReserved is the resource overhead for kubelet and other Kubernetes system da
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-cost}
+##### `cost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-cost}
 
 Cost is the instance cost. The higher the cost, the less likely it is to be selected. If empty, cost is automatically calculated
 from the resources specified.
@@ -210,7 +210,7 @@ from the resources specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -240,7 +240,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -252,7 +252,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -267,7 +267,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -285,7 +285,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodes}
+##### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodes}
 
 Nodes specifies nodes.
 
@@ -300,7 +300,7 @@ Nodes specifies nodes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodeGroups}
+##### `nodeGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodeGroups}
 
 NodeGroups is the name of the node groups to use for this provider.
 
@@ -321,7 +321,7 @@ NodeGroups is the name of the node groups to use for this provider.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt}
+### `kubeVirt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt}
 
 Kubevirt configures a node provider using KubeVirt, enabling virtual machines
 to be provisioned as nodes within a vCluster.
@@ -334,7 +334,7 @@ to be provisioned as nodes within a vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -361,7 +361,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -379,7 +379,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy}
+#### `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy}
 
 Deploy configures components deployed into the connected control plane cluster.
 
@@ -391,7 +391,7 @@ Deploy configures components deployed into the connected control plane cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubevirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt}
+##### `kubevirt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt}
 
 KubeVirt configures the KubeVirt operator deployment.
 
@@ -418,7 +418,7 @@ Enabled controls whether the KubeVirt operator is deployed into the cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chartRepo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-chartRepo}
+##### `chartRepo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-chartRepo}
 
 ChartRepo overrides the Helm chart repository used to install the KubeVirt operator.
 
@@ -433,7 +433,7 @@ ChartRepo overrides the Helm chart repository used to install the KubeVirt opera
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-chart}
 
 Chart overrides the Helm chart name used to install the KubeVirt operator.
 
@@ -448,7 +448,7 @@ Chart overrides the Helm chart name used to install the KubeVirt operator.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-version}
 
 Version overrides the Helm chart version used to install the KubeVirt operator.
 
@@ -463,7 +463,7 @@ Version overrides the Helm chart version used to install the KubeVirt operator.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `helmValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-helmValues}
+##### `helmValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-helmValues}
 
 HelmValues is raw YAML that will be passed as values to the KubeVirt Helm chart.
 
@@ -484,7 +484,7 @@ HelmValues is raw YAML that will be passed as values to the KubeVirt Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-virtualMachineTemplate}
+#### `virtualMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-virtualMachineTemplate}
 
 VirtualMachineTemplate is a KubeVirt VirtualMachine template to use by NodeTypes managed by this NodeProvider
 
@@ -511,7 +511,7 @@ NodeTypes define NodeTypes that should be automatically created for this provide
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `providerRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-providerRef}
+##### `providerRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-providerRef}
 
 ProviderRef is the node provider to use for this node type.
 
@@ -526,7 +526,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -541,7 +541,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -556,7 +556,7 @@ Resources lists the full resources for a single node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `overhead` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-overhead}
+##### `overhead` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-overhead}
 
 Overhead defines the resource overhead for this node type.
 
@@ -568,7 +568,7 @@ Overhead defines the resource overhead for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeReserved` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-overhead-kubeReserved}
+##### `kubeReserved` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-overhead-kubeReserved}
 
 KubeReserved is the resource overhead for kubelet and other Kubernetes system daemons.
 
@@ -586,7 +586,7 @@ KubeReserved is the resource overhead for kubelet and other Kubernetes system da
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-cost}
+##### `cost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-cost}
 
 Cost is the instance cost. The higher the cost, the less likely it is to be selected. If empty, cost is automatically calculated
 from the resources specified.
@@ -602,7 +602,7 @@ from the resources specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -632,7 +632,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -644,7 +644,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -659,7 +659,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -677,7 +677,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-virtualMachineTemplate}
+##### `virtualMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-virtualMachineTemplate}
 
 VirtualMachineTemplate is a full KubeVirt VirtualMachine template to use for this NodeType.
 This is mutually exclusive with MergeVirtualMachineTemplate
@@ -693,7 +693,7 @@ This is mutually exclusive with MergeVirtualMachineTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeVirtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-mergeVirtualMachineTemplate}
+##### `mergeVirtualMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-mergeVirtualMachineTemplate}
 
 MergeVirtualMachineTemplate will be merged into base VirtualMachine template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -710,7 +710,7 @@ This is mutually exclusive with VirtualMachineTemplate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -731,7 +731,7 @@ MaxCapacity is the maximum number of nodes that can be created for this NodeType
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `terraform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform}
+### `terraform` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform}
 
 Terraform configures a node provider using Terraform, enabling nodes to be provisioned using Terraform.
 
@@ -743,7 +743,7 @@ Terraform configures a node provider using Terraform, enabling nodes to be provi
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate}
+#### `nodeTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate}
 
 NodeTemplate is the template to use for this node provider.
 
@@ -755,7 +755,7 @@ NodeTemplate is the template to use for this node provider.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -770,7 +770,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git}
+##### `git` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -782,7 +782,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -797,7 +797,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -812,7 +812,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -827,7 +827,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -842,7 +842,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -857,7 +857,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -869,7 +869,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-secretName}
 
 
 
@@ -884,7 +884,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-secretNamespace}
 
 
 
@@ -899,7 +899,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-key}
 
 
 
@@ -917,7 +917,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -932,7 +932,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -950,7 +950,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -968,7 +968,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeEnvironmentTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate}
+#### `nodeEnvironmentTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate}
 
 NodeEnvironmentTemplate is the template to use for this node environment.
 
@@ -980,7 +980,7 @@ NodeEnvironmentTemplate is the template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -995,7 +995,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git}
+##### `git` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -1007,7 +1007,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -1022,7 +1022,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -1037,7 +1037,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1052,7 +1052,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1067,7 +1067,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1082,7 +1082,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1094,7 +1094,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-secretName}
 
 
 
@@ -1109,7 +1109,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-secretNamespace}
 
 
 
@@ -1124,7 +1124,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-key}
 
 
 
@@ -1142,7 +1142,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1157,7 +1157,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1175,7 +1175,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1190,7 +1190,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `infrastructure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure}
+##### `infrastructure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure}
 
 Infrastructure is the infrastructure template to use for this node environment.
 
@@ -1202,7 +1202,7 @@ Infrastructure is the infrastructure template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1217,7 +1217,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git}
+##### `git` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git}
 
 Git is the git repository to use for this node type.
 
@@ -1229,7 +1229,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-repository}
 
 Repository is the repository to clone
 
@@ -1244,7 +1244,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-branch}
+##### `branch` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-branch}
 
 Branch is the branch to use
 
@@ -1259,7 +1259,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-commit}
+##### `commit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1274,7 +1274,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1289,7 +1289,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1304,7 +1304,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1316,7 +1316,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-secretName}
 
 
 
@@ -1331,7 +1331,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-secretNamespace}
 
 
 
@@ -1346,7 +1346,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-key}
 
 
 
@@ -1364,7 +1364,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1379,7 +1379,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1397,7 +1397,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1415,7 +1415,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubernetes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes}
+##### `kubernetes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes}
 
 Kubernetes is the kubernetes template to use for this node environment.
 
@@ -1427,7 +1427,7 @@ Kubernetes is the kubernetes template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1442,7 +1442,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git}
+##### `git` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git}
 
 Git is the git repository to use for this node type.
 
@@ -1454,7 +1454,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-repository}
 
 Repository is the repository to clone
 
@@ -1469,7 +1469,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-branch}
+##### `branch` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-branch}
 
 Branch is the branch to use
 
@@ -1484,7 +1484,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-commit}
+##### `commit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1499,7 +1499,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1514,7 +1514,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1529,7 +1529,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1541,7 +1541,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-secretName}
 
 
 
@@ -1556,7 +1556,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-secretNamespace}
 
 
 
@@ -1571,7 +1571,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-key}
 
 
 
@@ -1589,7 +1589,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1604,7 +1604,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1622,7 +1622,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1643,7 +1643,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -1655,7 +1655,7 @@ NodeTypes define NodeTypes that should be automatically created for this provide
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `providerRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-providerRef}
+##### `providerRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-providerRef}
 
 ProviderRef is the node provider to use for this node type.
 
@@ -1670,7 +1670,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -1685,7 +1685,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -1700,7 +1700,7 @@ Resources lists the full resources for a single node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `overhead` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-overhead}
+##### `overhead` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-overhead}
 
 Overhead defines the resource overhead for this node type.
 
@@ -1712,7 +1712,7 @@ Overhead defines the resource overhead for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeReserved` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-overhead-kubeReserved}
+##### `kubeReserved` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-overhead-kubeReserved}
 
 KubeReserved is the resource overhead for kubelet and other Kubernetes system daemons.
 
@@ -1730,7 +1730,7 @@ KubeReserved is the resource overhead for kubelet and other Kubernetes system da
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-cost}
+##### `cost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-cost}
 
 Cost is the instance cost. The higher the cost, the less likely it is to be selected. If empty, cost is automatically calculated
 from the resources specified.
@@ -1746,7 +1746,7 @@ from the resources specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -1776,7 +1776,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -1788,7 +1788,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -1803,7 +1803,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -1821,7 +1821,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate}
+##### `nodeTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate}
 
 NodeTemplate is the template to use for this node type.
 
@@ -1833,7 +1833,7 @@ NodeTemplate is the template to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1848,7 +1848,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git}
+##### `git` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -1860,7 +1860,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -1875,7 +1875,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -1890,7 +1890,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1905,7 +1905,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1920,7 +1920,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1935,7 +1935,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1947,7 +1947,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-secretName}
 
 
 
@@ -1962,7 +1962,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-secretNamespace}
 
 
 
@@ -1977,7 +1977,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-key}
 
 
 
@@ -1995,7 +1995,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -2010,7 +2010,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -2028,7 +2028,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -2046,7 +2046,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -2067,7 +2067,7 @@ MaxCapacity is the maximum number of nodes that can be created for this NodeType
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterAPI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI}
+### `clusterAPI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI}
 
 ClusterAPI configures a node provider using Cluster API, enabling nodes to be provisioned using Cluster API.
 This requires the vCluster to be deployed with Cluster API as well.
@@ -2080,7 +2080,7 @@ This requires the vCluster to be deployed with Cluster API as well.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-infrastructureMachineTemplate}
+#### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-infrastructureMachineTemplate}
 
 InfrastructureMachineTemplate is a template for the infrastructure machine, e.g. AWSMachine
 
@@ -2095,7 +2095,7 @@ InfrastructureMachineTemplate is a template for the infrastructure machine, e.g.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-bootstrapConfigTemplate}
+#### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-bootstrapConfigTemplate}
 
 BootstrapConfigTemplate is a template for the bootstrap config. Currently only KubeadmConfig is supported.
 
@@ -2110,7 +2110,7 @@ BootstrapConfigTemplate is a template for the bootstrap config. Currently only K
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -2137,7 +2137,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -2155,7 +2155,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -2167,7 +2167,7 @@ NodeTypes define NodeTypes that should be automatically created for this provide
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `providerRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-providerRef}
+##### `providerRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-providerRef}
 
 ProviderRef is the node provider to use for this node type.
 
@@ -2182,7 +2182,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -2197,7 +2197,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -2212,7 +2212,7 @@ Resources lists the full resources for a single node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `overhead` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-overhead}
+##### `overhead` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-overhead}
 
 Overhead defines the resource overhead for this node type.
 
@@ -2224,7 +2224,7 @@ Overhead defines the resource overhead for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeReserved` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-overhead-kubeReserved}
+##### `kubeReserved` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-overhead-kubeReserved}
 
 KubeReserved is the resource overhead for kubelet and other Kubernetes system daemons.
 
@@ -2242,7 +2242,7 @@ KubeReserved is the resource overhead for kubelet and other Kubernetes system da
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-cost}
+##### `cost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-cost}
 
 Cost is the instance cost. The higher the cost, the less likely it is to be selected. If empty, cost is automatically calculated
 from the resources specified.
@@ -2258,7 +2258,7 @@ from the resources specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -2288,7 +2288,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -2300,7 +2300,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -2315,7 +2315,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -2333,7 +2333,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-infrastructureMachineTemplate}
+##### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-infrastructureMachineTemplate}
 
 InfrastructureMachineTemplate is a template for the infrastructure machine, e.g. AWSMachine
 
@@ -2348,7 +2348,7 @@ InfrastructureMachineTemplate is a template for the infrastructure machine, e.g.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-bootstrapConfigTemplate}
+##### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-bootstrapConfigTemplate}
 
 BootstrapConfigTemplate is a template for the bootstrap config. Currently only KubeadmConfig is supported.
 
@@ -2363,7 +2363,7 @@ BootstrapConfigTemplate is a template for the bootstrap config. Currently only K
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeInfrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeInfrastructureMachineTemplate}
+##### `mergeInfrastructureMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeInfrastructureMachineTemplate}
 
 MergeInfrastructureMachineTemplate will be merged into base InfrastructureMachine template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -2380,7 +2380,7 @@ This is mutually exclusive with InfrastructureMachineTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeBootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeBootstrapConfigTemplate}
+##### `mergeBootstrapConfigTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeBootstrapConfigTemplate}
 
 MergeBootstrapConfigTemplate will be merged into base BootstrapConfig template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -2397,7 +2397,7 @@ This is mutually exclusive with BootstrapConfigTemplate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -2418,7 +2418,7 @@ MaxCapacity is the maximum number of nodes that can be created for this NodeType
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metal3` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3}
+### `metal3` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3}
 
 Metal3 configures a node provider using metal3.io BareMetalHost resources.
 
@@ -2430,7 +2430,7 @@ Metal3 configures a node provider using metal3.io BareMetalHost resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -2457,7 +2457,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -2475,7 +2475,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy}
+#### `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy}
 
 
 
@@ -2487,7 +2487,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `multus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-multus}
+##### `multus` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-multus}
 
 Multus configures the Multus CNI deployment.
 
@@ -2514,7 +2514,7 @@ Enabled controls whether Multus CNI is deployed into the cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `helmValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-multus-helmValues}
+##### `helmValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-multus-helmValues}
 
 HelmValues is raw YAML that will be passed as values to the Multus Helm chart.
 
@@ -2532,7 +2532,7 @@ HelmValues is raw YAML that will be passed as values to the Multus Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `dhcp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp}
+##### `dhcp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp}
 
 DHCP configures the DHCP server deployment.
 
@@ -2559,7 +2559,7 @@ Enabled controls whether the DHCP server is deployed into the cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chartRepo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-chartRepo}
+##### `chartRepo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-chartRepo}
 
 ChartRepo overrides the Helm chart repository used to install the DHCP server.
 
@@ -2574,7 +2574,7 @@ ChartRepo overrides the Helm chart repository used to install the DHCP server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-chart}
 
 Chart overrides the Helm chart name used to install the DHCP server.
 
@@ -2589,7 +2589,7 @@ Chart overrides the Helm chart name used to install the DHCP server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-version}
 
 Version overrides the Helm chart version used to install the DHCP server.
 
@@ -2604,7 +2604,7 @@ Version overrides the Helm chart version used to install the DHCP server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `helmValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-helmValues}
+##### `helmValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-helmValues}
 
 HelmValues is raw YAML that will be passed as values to the DHCP Helm chart.
 
@@ -2622,7 +2622,7 @@ HelmValues is raw YAML that will be passed as values to the DHCP Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metal3` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3}
+##### `metal3` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3}
 
 Metal3 configures the Metal3/Ironic deployment.
 
@@ -2649,7 +2649,7 @@ Enabled controls whether Metal3 and Ironic are deployed into the cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chartRepo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-chartRepo}
+##### `chartRepo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-chartRepo}
 
 ChartRepo overrides the Helm chart repository used to install Metal3.
 
@@ -2664,7 +2664,7 @@ ChartRepo overrides the Helm chart repository used to install Metal3.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-chart}
 
 Chart overrides the Helm chart name used to install Metal3.
 
@@ -2679,7 +2679,7 @@ Chart overrides the Helm chart name used to install Metal3.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-version}
 
 Version overrides the Helm chart version used to install Metal3.
 
@@ -2694,7 +2694,7 @@ Version overrides the Helm chart version used to install Metal3.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `helmValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-helmValues}
+##### `helmValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-helmValues}
 
 HelmValues is raw YAML that will be passed as values to the Metal3 Helm chart.
 
@@ -2715,7 +2715,7 @@ HelmValues is raw YAML that will be passed as values to the Metal3 Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -2727,7 +2727,7 @@ NodeTypes define NodeTypes that should be automatically created for this provide
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `providerRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-providerRef}
+##### `providerRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-providerRef}
 
 ProviderRef is the node provider to use for this node type.
 
@@ -2742,7 +2742,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -2757,7 +2757,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -2772,7 +2772,7 @@ Resources lists the full resources for a single node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `overhead` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-overhead}
+##### `overhead` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-overhead}
 
 Overhead defines the resource overhead for this node type.
 
@@ -2784,7 +2784,7 @@ Overhead defines the resource overhead for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeReserved` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-overhead-kubeReserved}
+##### `kubeReserved` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-overhead-kubeReserved}
 
 KubeReserved is the resource overhead for kubelet and other Kubernetes system daemons.
 
@@ -2802,7 +2802,7 @@ KubeReserved is the resource overhead for kubelet and other Kubernetes system da
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-cost}
+##### `cost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-cost}
 
 Cost is the instance cost. The higher the cost, the less likely it is to be selected. If empty, cost is automatically calculated
 from the resources specified.
@@ -2818,7 +2818,7 @@ from the resources specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -2848,7 +2848,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -2860,7 +2860,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -2875,7 +2875,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -2893,7 +2893,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `bareMetalHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts}
+##### `bareMetalHosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts}
 
 BareMetalHosts is a list of BareMetalHosts to use for this NodeType.
 
@@ -2905,7 +2905,7 @@ BareMetalHosts is a list of BareMetalHosts to use for this NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector}
 
 Selector is a label selector to select the BareMetalHosts to use for this NodeType.
 
@@ -2917,7 +2917,7 @@ Selector is a label selector to select the BareMetalHosts to use for this NodeTy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchLabels}
 
 matchLabels is a map of &#123;key,value&#125; pairs. A single &#123;key,value&#125; in the matchLabels
 map is equivalent to an element of matchExpressions, whose key field is "key", the
@@ -2934,7 +2934,7 @@ operator is "In", and the values array contains only "value". The requirements a
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchExpressions}
 
 matchExpressions is a list of label selector requirements. The requirements are ANDed.
 
@@ -2977,7 +2977,7 @@ Valid operators are In, NotIn, Exists and DoesNotExist.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchExpressions-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchExpressions-values}
 
 values is an array of string values. If the operator is In or NotIn,
 the values array must be non-empty. If the operator is Exists or DoesNotExist,
@@ -3010,7 +3010,7 @@ merge patch.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -3028,7 +3028,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -3040,7 +3040,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions describe the current state of the platform NodeProvider.
 
@@ -3055,7 +3055,7 @@ Conditions describe the current state of the platform NodeProvider.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `reason` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
+### `reason` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
 
 Reason describes the reason in machine-readable form
 
@@ -3070,7 +3070,7 @@ Reason describes the reason in machine-readable form
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `phase` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
+### `phase` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
 
 Phase is the current lifecycle phase of the NodeProvider.
 
@@ -3085,7 +3085,7 @@ Phase is the current lifecycle phase of the NodeProvider.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `message` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
+### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
 
 Message is a human-readable message indicating details about why the NodeProvider is in its current state.
 

--- a/platform/api/_partials/resources/nodeproviders/reference.mdx
+++ b/platform/api/_partials/resources/nodeproviders/reference.mdx
@@ -107,7 +107,7 @@ Endpoint is an address for head node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -134,7 +134,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -149,7 +149,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -240,7 +240,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -252,7 +252,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -267,7 +267,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -285,7 +285,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodes}
+##### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodes}
 
 Nodes specifies nodes.
 
@@ -300,7 +300,7 @@ Nodes specifies nodes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeGroups` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodeGroups}
+##### `nodeGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodeGroups}
 
 NodeGroups is the name of the node groups to use for this provider.
 
@@ -334,7 +334,7 @@ to be provisioned as nodes within a vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -361,7 +361,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -484,7 +484,7 @@ HelmValues is raw YAML that will be passed as values to the KubeVirt Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-virtualMachineTemplate}
+#### `virtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-virtualMachineTemplate}
 
 VirtualMachineTemplate is a KubeVirt VirtualMachine template to use by NodeTypes managed by this NodeProvider
 
@@ -526,7 +526,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -541,7 +541,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -632,7 +632,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -644,7 +644,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -659,7 +659,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -677,7 +677,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-virtualMachineTemplate}
+##### `virtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-virtualMachineTemplate}
 
 VirtualMachineTemplate is a full KubeVirt VirtualMachine template to use for this NodeType.
 This is mutually exclusive with MergeVirtualMachineTemplate
@@ -693,7 +693,7 @@ This is mutually exclusive with MergeVirtualMachineTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeVirtualMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-mergeVirtualMachineTemplate}
+##### `mergeVirtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-mergeVirtualMachineTemplate}
 
 MergeVirtualMachineTemplate will be merged into base VirtualMachine template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -710,7 +710,7 @@ This is mutually exclusive with VirtualMachineTemplate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -743,7 +743,7 @@ Terraform configures a node provider using Terraform, enabling nodes to be provi
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate}
+#### `nodeTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate}
 
 NodeTemplate is the template to use for this node provider.
 
@@ -755,7 +755,7 @@ NodeTemplate is the template to use for this node provider.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -770,7 +770,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git}
+##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -782,7 +782,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -797,7 +797,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -812,7 +812,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -827,7 +827,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -842,7 +842,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -857,7 +857,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -917,7 +917,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -932,7 +932,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -950,7 +950,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -968,7 +968,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeEnvironmentTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate}
+#### `nodeEnvironmentTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate}
 
 NodeEnvironmentTemplate is the template to use for this node environment.
 
@@ -980,7 +980,7 @@ NodeEnvironmentTemplate is the template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -995,7 +995,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git}
+##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -1007,7 +1007,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -1022,7 +1022,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -1037,7 +1037,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1052,7 +1052,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1067,7 +1067,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1082,7 +1082,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1142,7 +1142,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1157,7 +1157,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1175,7 +1175,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1190,7 +1190,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `infrastructure` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure}
+##### `infrastructure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure}
 
 Infrastructure is the infrastructure template to use for this node environment.
 
@@ -1202,7 +1202,7 @@ Infrastructure is the infrastructure template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-inline}
+##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1217,7 +1217,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git}
+##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git}
 
 Git is the git repository to use for this node type.
 
@@ -1229,7 +1229,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-repository}
 
 Repository is the repository to clone
 
@@ -1244,7 +1244,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-branch}
+##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-branch}
 
 Branch is the branch to use
 
@@ -1259,7 +1259,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-commit}
+##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1274,7 +1274,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1289,7 +1289,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1304,7 +1304,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1364,7 +1364,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1379,7 +1379,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1397,7 +1397,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1415,7 +1415,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubernetes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes}
+##### `kubernetes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes}
 
 Kubernetes is the kubernetes template to use for this node environment.
 
@@ -1427,7 +1427,7 @@ Kubernetes is the kubernetes template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-inline}
+##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1442,7 +1442,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git}
+##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git}
 
 Git is the git repository to use for this node type.
 
@@ -1454,7 +1454,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-repository}
 
 Repository is the repository to clone
 
@@ -1469,7 +1469,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-branch}
+##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-branch}
 
 Branch is the branch to use
 
@@ -1484,7 +1484,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-commit}
+##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1499,7 +1499,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1514,7 +1514,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1529,7 +1529,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1589,7 +1589,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1604,7 +1604,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1622,7 +1622,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1643,7 +1643,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -1670,7 +1670,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -1685,7 +1685,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -1776,7 +1776,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -1788,7 +1788,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -1803,7 +1803,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -1821,7 +1821,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate}
+##### `nodeTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate}
 
 NodeTemplate is the template to use for this node type.
 
@@ -1833,7 +1833,7 @@ NodeTemplate is the template to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1848,7 +1848,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git}
+##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -1860,7 +1860,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -1875,7 +1875,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -1890,7 +1890,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1905,7 +1905,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1920,7 +1920,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1935,7 +1935,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1995,7 +1995,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -2010,7 +2010,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -2028,7 +2028,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -2046,7 +2046,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -2080,7 +2080,7 @@ This requires the vCluster to be deployed with Cluster API as well.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `infrastructureMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-infrastructureMachineTemplate}
+#### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-infrastructureMachineTemplate}
 
 InfrastructureMachineTemplate is a template for the infrastructure machine, e.g. AWSMachine
 
@@ -2095,7 +2095,7 @@ InfrastructureMachineTemplate is a template for the infrastructure machine, e.g.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `bootstrapConfigTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-bootstrapConfigTemplate}
+#### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-bootstrapConfigTemplate}
 
 BootstrapConfigTemplate is a template for the bootstrap config. Currently only KubeadmConfig is supported.
 
@@ -2110,7 +2110,7 @@ BootstrapConfigTemplate is a template for the bootstrap config. Currently only K
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -2137,7 +2137,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -2155,7 +2155,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -2182,7 +2182,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -2197,7 +2197,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -2288,7 +2288,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -2300,7 +2300,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -2315,7 +2315,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -2333,7 +2333,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `infrastructureMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-infrastructureMachineTemplate}
+##### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-infrastructureMachineTemplate}
 
 InfrastructureMachineTemplate is a template for the infrastructure machine, e.g. AWSMachine
 
@@ -2348,7 +2348,7 @@ InfrastructureMachineTemplate is a template for the infrastructure machine, e.g.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `bootstrapConfigTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-bootstrapConfigTemplate}
+##### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-bootstrapConfigTemplate}
 
 BootstrapConfigTemplate is a template for the bootstrap config. Currently only KubeadmConfig is supported.
 
@@ -2363,7 +2363,7 @@ BootstrapConfigTemplate is a template for the bootstrap config. Currently only K
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeInfrastructureMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeInfrastructureMachineTemplate}
+##### `mergeInfrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeInfrastructureMachineTemplate}
 
 MergeInfrastructureMachineTemplate will be merged into base InfrastructureMachine template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -2380,7 +2380,7 @@ This is mutually exclusive with InfrastructureMachineTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeBootstrapConfigTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeBootstrapConfigTemplate}
+##### `mergeBootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeBootstrapConfigTemplate}
 
 MergeBootstrapConfigTemplate will be merged into base BootstrapConfig template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -2397,7 +2397,7 @@ This is mutually exclusive with BootstrapConfigTemplate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -2430,7 +2430,7 @@ Metal3 configures a node provider using metal3.io BareMetalHost resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -2457,7 +2457,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -2475,7 +2475,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy}
+#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy}
 
 
 
@@ -2715,7 +2715,7 @@ HelmValues is raw YAML that will be passed as values to the Metal3 Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -2742,7 +2742,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -2757,7 +2757,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -2848,7 +2848,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -2860,7 +2860,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -2875,7 +2875,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 

--- a/platform/api/_partials/resources/ownedaccesskeys/reference.mdx
+++ b/platform/api/_partials/resources/ownedaccesskeys/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 The display name shown in the UI
 
@@ -35,7 +35,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes an app
 
@@ -50,7 +50,7 @@ Description describes an app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-user}
+### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-user}
 
 The user this access key refers to
 
@@ -65,7 +65,7 @@ The user this access key refers to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-team}
+### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-team}
 
 The team this access key refers to
 
@@ -80,7 +80,7 @@ The team this access key refers to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
+### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
 
 Subject is a generic subject that can be used
 instead of user or team
@@ -96,7 +96,7 @@ instead of user or team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
+### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
 
 Groups specifies extra groups to apply when using
 this access key
@@ -112,7 +112,7 @@ this access key
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-key}
+### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-key}
 
 The actual access key that will be used as a bearer token
 
@@ -127,7 +127,7 @@ The actual access key that will be used as a bearer token
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-disabled}
+### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-disabled}
 
 If this field is true, the access key is still allowed to exist,
 however will not work to access the api
@@ -143,7 +143,7 @@ however will not work to access the api
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ttl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttl}
+### `ttl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttl}
 
 The time to live for this access key
 
@@ -158,7 +158,7 @@ The time to live for this access key
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ttlAfterLastActivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttlAfterLastActivity}
+### `ttlAfterLastActivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttlAfterLastActivity}
 
 If this is specified, the time to live for this access key will
 start after the lastActivity instead of creation timestamp
@@ -174,7 +174,7 @@ start after the lastActivity instead of creation timestamp
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope}
+### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope}
 
 Scope defines the scope of the access key.
 
@@ -186,7 +186,7 @@ Scope defines the scope of the access key.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `roles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles}
+#### `roles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles}
 
 Roles is a set of managed permissions to apply to the access key.
 
@@ -198,7 +198,7 @@ Roles is a set of managed permissions to apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-role}
 
 Role is the name of the role to apply to the access key scope.
 
@@ -213,7 +213,7 @@ Role is the name of the role to apply to the access key scope.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-projects}
+##### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -228,7 +228,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -246,7 +246,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects}
+#### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -258,7 +258,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects-project}
 
 Project is the name of the project. You can specify * to select all projects.
 
@@ -276,7 +276,7 @@ Project is the name of the project. You can specify * to select all projects.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces}
+#### `spaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces}
 
 Spaces specifies the spaces the access key is allowed to access.
 
@@ -288,7 +288,7 @@ Spaces specifies the spaces the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-project}
 
 Project is the name of the project.
 
@@ -303,7 +303,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `space` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-space}
+##### `space` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-space}
 
 Space is the name of the space. You can specify * to select all spaces.
 
@@ -321,7 +321,7 @@ Space is the name of the space. You can specify * to select all spaces.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters}
+#### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -333,7 +333,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-project}
 
 Project is the name of the project.
 
@@ -348,7 +348,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-virtualCluster}
+##### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-virtualCluster}
 
 VirtualCluster is the name of the tenant cluster to access. You can specify * to select all tenant clusters.
 
@@ -366,7 +366,7 @@ VirtualCluster is the name of the tenant cluster to access. You can specify * to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters}
+#### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters}
 
 Clusters specifies the project cluster the access key is allowed to access.
 
@@ -378,7 +378,7 @@ Clusters specifies the project cluster the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters-cluster}
 
 Cluster is the name of the cluster to access. You can specify * to select all clusters.
 
@@ -396,7 +396,7 @@ Cluster is the name of the cluster to access. You can specify * to select all cl
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules}
 
 DEPRECATED: Use Projects, Spaces and VirtualClusters instead
 Rules specifies the rules that should apply to the access key.
@@ -409,7 +409,7 @@ Rules specifies the rules that should apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -425,7 +425,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -437,7 +437,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -453,7 +453,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -480,7 +480,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -500,7 +500,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-namespaces}
+##### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -517,7 +517,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be checked.
 *s are allowed, but only as the full, final step in the path.
@@ -536,7 +536,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-requestTargets}
+##### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-requestTargets}
 
 RequestTargets is a list of request targets that are allowed.
 An empty list implies every request.
@@ -552,7 +552,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-cluster}
 
 Cluster that this rule matches. Only applies to cluster requests.
 If this is set, no requests for non cluster requests are allowed.
@@ -569,7 +569,7 @@ An empty cluster means no restrictions will apply.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters}
 
 VirtualClusters that this rule matches. Only applies to tenant cluster requests.
 An empty list means no restrictions will apply.
@@ -582,7 +582,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-name}
 
 Name of the tenant cluster. Empty means all tenant clusters.
 
@@ -597,7 +597,7 @@ Name of the tenant cluster. Empty means all tenant clusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-namespace}
 
 Namespace of the tenant cluster. Empty means all namespaces.
 
@@ -618,7 +618,7 @@ Namespace of the tenant cluster. Empty means all namespaces.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allowLoftCli` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-allowLoftCli}
+#### `allowLoftCli` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-allowLoftCli}
 
 AllowLoftCLI allows certain read-only management requests to
 make sure loft cli works correctly with this specific access key.
@@ -644,7 +644,7 @@ Deprecated: Use the `roles` field instead
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-type}
+### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-type}
 
 The type of an access key, which basically describes if the access
 key is user managed or managed by loft itself.
@@ -660,7 +660,7 @@ key is user managed or managed by loft itself.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `identity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity}
+### `identity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity}
 
 If available, contains information about the sso login data for this
 access key
@@ -673,7 +673,7 @@ access key
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `userId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-userId}
+#### `userId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-userId}
 
 The subject of the user
 
@@ -688,7 +688,7 @@ The subject of the user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-username}
 
 The username
 
@@ -703,7 +703,7 @@ The username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preferredUsername` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-preferredUsername}
+#### `preferredUsername` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-preferredUsername}
 
 The preferred username / display name
 
@@ -718,7 +718,7 @@ The preferred username / display name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-email}
 
 The user email
 
@@ -733,7 +733,7 @@ The user email
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `emailVerified` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-emailVerified}
+#### `emailVerified` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-emailVerified}
 
 If the user email was verified
 
@@ -748,7 +748,7 @@ If the user email was verified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-extraClaims}
+#### `extraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-extraClaims}
 
 ExtraClaims are claims that are not otherwise contained in this struct but may be provided by the OIDC
 provider. Only extra claims that are allowed by the auth config are included.
@@ -764,7 +764,7 @@ provider. Only extra claims that are allowed by the auth config are included.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-groups}
+#### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-groups}
 
 The groups from the identity provider
 
@@ -779,7 +779,7 @@ The groups from the identity provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-connector}
+#### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-connector}
 
 Connector is the name of the connector this access key was created from
 
@@ -794,7 +794,7 @@ Connector is the name of the connector this access key was created from
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `connectorData` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-connectorData}
+#### `connectorData` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-connectorData}
 
 ConnectorData holds data used by the connector for subsequent requests after initial
 authentication, such as access tokens for upstream providers.
@@ -815,7 +815,7 @@ This data is never shared with end users, OAuth clients, or through the API.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `identityRefresh` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identityRefresh}
+### `identityRefresh` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identityRefresh}
 
 The last time the identity was refreshed
 
@@ -830,7 +830,7 @@ The last time the identity was refreshed
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `oidcProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider}
+### `oidcProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider}
 
 If the token is a refresh token, contains information about it
 
@@ -842,7 +842,7 @@ If the token is a refresh token, contains information about it
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-clientId}
+#### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-clientId}
 
 ClientId the token was generated for
 
@@ -857,7 +857,7 @@ ClientId the token was generated for
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nonce` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-nonce}
+#### `nonce` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-nonce}
 
 Nonce to use
 
@@ -872,7 +872,7 @@ Nonce to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `redirectUri` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-redirectUri}
+#### `redirectUri` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-redirectUri}
 
 RedirectUri to use
 
@@ -887,7 +887,7 @@ RedirectUri to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-scopes}
+#### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-scopes}
 
 Scopes to use
 
@@ -905,7 +905,7 @@ Scopes to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `parent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parent}
+### `parent` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parent}
 
 DEPRECATED: do not use anymore
 Parent is used to share OIDC and external token information
@@ -928,7 +928,7 @@ an OIDC token.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `oidcLogin` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin}
+### `oidcLogin` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin}
 
 DEPRECATED: Use identity instead
 If available, contains information about the oidc login data for this
@@ -942,7 +942,7 @@ access key
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `idToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-idToken}
+#### `idToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-idToken}
 
 The current id token that was created during login
 
@@ -957,7 +957,7 @@ The current id token that was created during login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `accessToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-accessToken}
+#### `accessToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-accessToken}
 
 The current access token that was created during login
 
@@ -972,7 +972,7 @@ The current access token that was created during login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `refreshToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-refreshToken}
+#### `refreshToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-refreshToken}
 
 The current refresh token that was created during login
 
@@ -987,7 +987,7 @@ The current refresh token that was created during login
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `lastRefresh` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-lastRefresh}
+#### `lastRefresh` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-lastRefresh}
 
 The last time the id token was refreshed
 
@@ -1008,7 +1008,7 @@ The last time the id token was refreshed
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -1020,7 +1020,7 @@ The last time the id token was refreshed
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `lastActivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-lastActivity}
+### `lastActivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-lastActivity}
 
 The last time this access key was used to access the api
 

--- a/platform/api/_partials/resources/projects/clusters/reference.mdx
+++ b/platform/api/_partials/resources/projects/clusters/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `clusters` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters}
+## `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters}
 
 Clusters holds all the allowed clusters
 
@@ -53,7 +53,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata}
+### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata}
 
 
 
@@ -481,7 +481,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -496,7 +496,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -512,7 +512,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -549,7 +549,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -580,7 +580,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -607,7 +607,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec}
 
 
 
@@ -904,7 +904,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics}
+#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics}
 
 Metrics holds the cluster's metrics backend configuration
 
@@ -916,7 +916,7 @@ Metrics holds the cluster's metrics backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -931,7 +931,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -1037,7 +1037,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -1052,7 +1052,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage}
 
 
 
@@ -1064,7 +1064,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -1081,7 +1081,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -1102,7 +1102,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `opencost` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost}
+#### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost}
 
 OpenCost holds the cluster's OpenCost backend configuration
 
@@ -1114,7 +1114,7 @@ OpenCost holds the cluster's OpenCost backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -1129,7 +1129,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -1286,7 +1286,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status}
+### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status}
 
 
 

--- a/platform/api/_partials/resources/projects/clusters/reference.mdx
+++ b/platform/api/_partials/resources/projects/clusters/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters}
+## `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters}
 
 Clusters holds all the allowed clusters
 
@@ -16,7 +16,7 @@ Clusters holds all the allowed clusters
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-kind}
+### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -35,7 +35,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-apiVersion}
+### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -53,7 +53,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata}
+### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata}
 
 
 
@@ -65,7 +65,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -85,7 +85,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-generateName}
+#### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -111,7 +111,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -133,7 +133,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-selfLink}
+#### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -148,7 +148,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-uid}
+#### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -169,7 +169,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-resourceVersion}
+#### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -193,7 +193,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-generation}
+#### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -209,7 +209,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-creationTimestamp}
+#### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -231,7 +231,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-deletionTimestamp}
+#### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -263,7 +263,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-deletionGracePeriodSeconds}
+#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -281,7 +281,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -299,7 +299,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -317,7 +317,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences}
+#### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -395,7 +395,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -410,7 +410,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -435,7 +435,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-finalizers}
+#### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -462,7 +462,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields}
+#### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -481,7 +481,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -496,7 +496,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -512,7 +512,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -530,7 +530,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -549,7 +549,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -565,7 +565,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -580,7 +580,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -607,7 +607,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec}
+### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec}
 
 
 
@@ -619,7 +619,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-displayName}
 
 If specified this name is displayed in the UI instead of the metadata name
 
@@ -634,7 +634,7 @@ If specified this name is displayed in the UI instead of the metadata name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-description}
 
 Description describes a cluster access object
 
@@ -649,7 +649,7 @@ Description describes a cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner}
+#### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner}
 
 Owner holds the owner of this object
 
@@ -661,7 +661,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner-user}
 
 User specifies a Loft user.
 
@@ -676,7 +676,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner-team}
+##### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -694,7 +694,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config}
+#### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config}
 
 Holds a reference to a secret that holds the kube config to access this cluster
 
@@ -706,7 +706,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-secretName}
 
 
 
@@ -721,7 +721,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-secretNamespace}
 
 
 
@@ -736,7 +736,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-key}
 
 
 
@@ -754,7 +754,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `local` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-local}
+#### `local` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-local}
 
 Local specifies if it is the local cluster that should be connected, when this is specified, config is optional
 
@@ -769,7 +769,7 @@ Local specifies if it is the local cluster that should be connected, when this i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `networkPeer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-networkPeer}
+#### `networkPeer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-networkPeer}
 
 NetworkPeer specifies if the cluster is connected via tailscale, when this is specified, config is optional
 
@@ -784,7 +784,7 @@ NetworkPeer specifies if the cluster is connected via tailscale, when this is sp
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `managementNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-managementNamespace}
+#### `managementNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-managementNamespace}
 
 The namespace where the cluster components will be installed in
 
@@ -799,7 +799,7 @@ The namespace where the cluster components will be installed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `unusable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-unusable}
+#### `unusable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-unusable}
 
 If unusable is true, no spaces or tenant clusters can be scheduled on this cluster.
 
@@ -814,7 +814,7 @@ If unusable is true, no spaces or tenant clusters can be scheduled on this clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access}
 
 Access holds the access rights for users and teams
 
@@ -826,7 +826,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -856,7 +856,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-subresources}
+##### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -871,7 +871,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -886,7 +886,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -904,7 +904,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics}
+#### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics}
 
 Metrics holds the cluster's metrics backend configuration
 
@@ -916,7 +916,7 @@ Metrics holds the cluster's metrics backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -931,7 +931,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -943,7 +943,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -959,7 +959,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -977,7 +977,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -1013,7 +1013,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -1037,7 +1037,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -1052,7 +1052,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage}
 
 
 
@@ -1064,7 +1064,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -1081,7 +1081,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -1102,7 +1102,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost}
+#### `opencost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost}
 
 OpenCost holds the cluster's OpenCost backend configuration
 
@@ -1114,7 +1114,7 @@ OpenCost holds the cluster's OpenCost backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -1129,7 +1129,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -1141,7 +1141,7 @@ Resources are compute resource required by the OpenCost backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -1157,7 +1157,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -1175,7 +1175,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -1211,7 +1211,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -1238,7 +1238,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `argoCD` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD}
+#### `argoCD` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD}
 
 ArgoCD holds the cluster's argo cd configuration
 
@@ -1250,7 +1250,7 @@ ArgoCD holds the cluster's argo cd configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD-enabled}
 
 Enabled defines if argo cd is enabled
 
@@ -1265,7 +1265,7 @@ Enabled defines if argo cd is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD-connector}
+##### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD-connector}
 
 Connector specifies the argo cd connector name
 
@@ -1286,7 +1286,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status}
+### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status}
 
 
 
@@ -1298,22 +1298,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `phase` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-phase}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-#### `reason` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-reason}
+#### `phase` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-phase}
 
 
 
@@ -1328,7 +1313,22 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `message` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-message}
+#### `reason` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-reason}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-message}
 
 
 
@@ -1343,7 +1343,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-conditions}
+#### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-conditions}
 
 Conditions holds several conditions the cluster might be in
 
@@ -1358,7 +1358,7 @@ Conditions holds several conditions the cluster might be in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `online` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-online}
+#### `online` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-online}
 
 Online is whether the cluster is currently connected to the coordination
 server.

--- a/platform/api/_partials/resources/projects/importspace/reference.mdx
+++ b/platform/api/_partials/resources/projects/importspace/reference.mdx
@@ -16,7 +16,7 @@ SourceSpace is the space to import into this project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-name}
 
 Name of the space to import
 
@@ -31,7 +31,7 @@ Name of the space to import
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-cluster}
+### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-cluster}
 
 Cluster name of the cluster the space is running on
 
@@ -46,7 +46,7 @@ Cluster name of the cluster the space is running on
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `importName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-importName}
+### `importName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-importName}
 
 ImportName is an optional name to use as the spaceinstance name, if not provided the space
 name will be used

--- a/platform/api/_partials/resources/projects/importspace/reference.mdx
+++ b/platform/api/_partials/resources/projects/importspace/reference.mdx
@@ -16,7 +16,7 @@ SourceSpace is the space to import into this project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-name}
 
 Name of the space to import
 
@@ -31,7 +31,7 @@ Name of the space to import
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `cluster` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-cluster}
+### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-cluster}
 
 Cluster name of the cluster the space is running on
 

--- a/platform/api/_partials/resources/projects/members/reference.mdx
+++ b/platform/api/_partials/resources/projects/members/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `teams` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams}
+## `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams}
 
 Teams holds all the teams that have access to the cluster
 
@@ -28,7 +28,7 @@ Info about the user or team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-name}
 
 Name is the kubernetes name of the object
 
@@ -124,7 +124,7 @@ The user subject
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `users` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users}
+## `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users}
 
 Users holds all the users that have access to the cluster
 
@@ -148,7 +148,7 @@ Info about the user or team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-name}
 
 Name is the kubernetes name of the object
 

--- a/platform/api/_partials/resources/projects/members/reference.mdx
+++ b/platform/api/_partials/resources/projects/members/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams}
+## `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams}
 
 Teams holds all the teams that have access to the cluster
 
@@ -16,7 +16,7 @@ Teams holds all the teams that have access to the cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `info` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info}
+### `info` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info}
 
 Info about the user or team
 
@@ -28,7 +28,7 @@ Info about the user or team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-name}
 
 Name is the kubernetes name of the object
 
@@ -43,7 +43,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-displayName}
 
 The display name shown in the UI
 
@@ -58,7 +58,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-icon}
 
 Icon is the icon of the user / team
 
@@ -73,7 +73,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-username}
 
 The username that is used to login
 
@@ -88,7 +88,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-email}
 
 The users email address
 
@@ -103,7 +103,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-subject}
+#### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-subject}
 
 The user subject
 
@@ -124,7 +124,7 @@ The user subject
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users}
+## `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users}
 
 Users holds all the users that have access to the cluster
 
@@ -136,7 +136,7 @@ Users holds all the users that have access to the cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `info` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info}
+### `info` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info}
 
 Info about the user or team
 
@@ -148,7 +148,7 @@ Info about the user or team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-name}
 
 Name is the kubernetes name of the object
 
@@ -163,7 +163,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-displayName}
 
 The display name shown in the UI
 
@@ -178,7 +178,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-icon}
 
 Icon is the icon of the user / team
 
@@ -193,7 +193,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-username}
 
 The username that is used to login
 
@@ -208,7 +208,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-email}
 
 The users email address
 
@@ -223,7 +223,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-subject}
+#### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-subject}
 
 The user subject
 

--- a/platform/api/_partials/resources/projects/migratespaceinstance/reference.mdx
+++ b/platform/api/_partials/resources/projects/migratespaceinstance/reference.mdx
@@ -16,7 +16,7 @@ SourceSpaceInstance is the spaceinstance to migrate into this project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-name}
 
 Name of the spaceinstance to migrate
 
@@ -31,7 +31,7 @@ Name of the spaceinstance to migrate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-namespace}
+### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-namespace}
 
 Namespace of the spaceinstance to migrate
 

--- a/platform/api/_partials/resources/projects/migratespaceinstance/reference.mdx
+++ b/platform/api/_partials/resources/projects/migratespaceinstance/reference.mdx
@@ -16,7 +16,7 @@ SourceSpaceInstance is the spaceinstance to migrate into this project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-name}
 
 Name of the spaceinstance to migrate
 
@@ -31,7 +31,7 @@ Name of the spaceinstance to migrate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-namespace}
 
 Namespace of the spaceinstance to migrate
 

--- a/platform/api/_partials/resources/projects/migratevirtualclusterinstance/reference.mdx
+++ b/platform/api/_partials/resources/projects/migratevirtualclusterinstance/reference.mdx
@@ -16,7 +16,7 @@ SourceVirtualClusterInstance is the tenant cluster instance to migrate into this
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-name}
 
 Name of the tenant cluster instance to migrate
 
@@ -31,7 +31,7 @@ Name of the tenant cluster instance to migrate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-namespace}
+### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-namespace}
 
 Namespace of the tenant cluster instance to migrate
 

--- a/platform/api/_partials/resources/projects/migratevirtualclusterinstance/reference.mdx
+++ b/platform/api/_partials/resources/projects/migratevirtualclusterinstance/reference.mdx
@@ -16,7 +16,7 @@ SourceVirtualClusterInstance is the tenant cluster instance to migrate into this
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-name}
 
 Name of the tenant cluster instance to migrate
 
@@ -31,7 +31,7 @@ Name of the tenant cluster instance to migrate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-namespace}
 
 Namespace of the tenant cluster instance to migrate
 

--- a/platform/api/_partials/resources/projects/reference.mdx
+++ b/platform/api/_partials/resources/projects/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes an app
 
@@ -50,7 +50,7 @@ Description describes an app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `quotas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas}
+### `quotas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas}
 
 Quotas define the quotas inside the project
 
@@ -107,7 +107,7 @@ Quotas define the quotas inside the project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-project}
+#### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-project}
 
 Project holds the quotas for the whole project
 
@@ -122,7 +122,7 @@ Project holds the quotas for the whole project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-user}
 
 User holds the quotas per user / team
 
@@ -140,7 +140,7 @@ User holds the quotas per user / team
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `allowedClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedClusters}
+### `allowedClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedClusters}
 
 AllowedClusters are target clusters that are allowed to target with
 environments.
@@ -153,7 +153,7 @@ environments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedClusters-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedClusters-name}
 
 Name is the name of the cluster that is allowed to create an environment in.
 
@@ -171,7 +171,7 @@ Name is the name of the cluster that is allowed to create an environment in.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `allowedRunners` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedRunners}
+### `allowedRunners` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedRunners}
 
 AllowedRunners are target runners that are allowed to target with
 
@@ -183,7 +183,7 @@ AllowedRunners are target runners that are allowed to target with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedRunners-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedRunners-name}
 
 Name is the name of the runner that is allowed to create an environment in.
 
@@ -201,7 +201,7 @@ Name is the name of the runner that is allowed to create an environment in.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `allowedTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates}
+### `allowedTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates}
 
 AllowedTemplates are the templates that are allowed to use in this
 project.
@@ -214,7 +214,7 @@ project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-kind}
 
 Kind of the template that is allowed. Currently only supports DevPodWorkspaceTemplate, VirtualClusterTemplate & SpaceTemplate
 
@@ -229,7 +229,7 @@ Kind of the template that is allowed. Currently only supports DevPodWorkspaceTem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-group}
+#### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-group}
 
 Group of the template that is allowed. Currently only supports storage.loft.sh
 
@@ -244,7 +244,7 @@ Group of the template that is allowed. Currently only supports storage.loft.sh
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-name}
 
 Name of the template
 
@@ -259,7 +259,7 @@ Name of the template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `isDefault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-isDefault}
+#### `isDefault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-isDefault}
 
 IsDefault specifies if the template should be used as a default
 
@@ -277,7 +277,7 @@ IsDefault specifies if the template should be used as a default
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `allowedNodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">array|null</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedNodeTypes}
+### `allowedNodeTypes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">array|null</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedNodeTypes}
 
 AllowedNodeTypes restricts which NodeTypes can be referenced by
 NodeClaims in this project. An entry can be an exact name
@@ -295,7 +295,7 @@ all NodeTypes are allowed; an empty list disallows all NodeTypes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `requireTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requireTemplate}
+### `requireTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requireTemplate}
 
 RequireTemplate configures if a template is required for instance creation.
 
@@ -307,7 +307,7 @@ RequireTemplate configures if a template is required for instance creation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requireTemplate-disabled}
+#### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requireTemplate-disabled}
 
 If true, all users within the project will be allowed to create a new instance without a template.
 By default, only admins are allowed to create a new instance without a template.
@@ -326,7 +326,7 @@ By default, only admins are allowed to create a new instance without a template.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `requirePreset` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirePreset}
+### `requirePreset` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirePreset}
 
 RequirePreset configures if a preset is required for instance creation.
 
@@ -338,7 +338,7 @@ RequirePreset configures if a preset is required for instance creation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirePreset-disabled}
+#### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirePreset-disabled}
 
 If true, all users within the project will not be allowed to create a new instance without a preset.
 By default, all users are allowed to create a new instance without a preset.
@@ -357,7 +357,7 @@ By default, all users are allowed to create a new instance without a preset.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `members` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members}
+### `members` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members}
 
 Members are the users and teams that are part of this project
 
@@ -369,7 +369,7 @@ Members are the users and teams that are part of this project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-kind}
 
 Kind is the kind of the member. Currently either User or Team
 
@@ -384,7 +384,7 @@ Kind is the kind of the member. Currently either User or Team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-group}
+#### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-group}
 
 Group of the member. Currently only supports storage.loft.sh
 
@@ -399,7 +399,7 @@ Group of the member. Currently only supports storage.loft.sh
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-name}
 
 Name of the member
 
@@ -432,7 +432,7 @@ ClusterRole is the assigned role for the above member
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -444,7 +444,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -474,7 +474,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -489,7 +489,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -504,7 +504,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -522,7 +522,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `namespaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate}
+### `namespaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate}
 
 NamespaceTemplate defines metadata that should be applied to the project's namespace on creation.
 This is useful for environments where admission controllers (e.g., Kyverno)
@@ -536,7 +536,7 @@ require specific labels or annotations on namespaces.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata}
 
 
 
@@ -548,7 +548,7 @@ require specific labels or annotations on namespaces.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -563,7 +563,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -584,7 +584,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `namespacePattern` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern}
+### `namespacePattern` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern}
 
 NamespacePattern specifies template patterns to use for creating each space or tenant cluster's namespace
 
@@ -596,7 +596,7 @@ NamespacePattern specifies template patterns to use for creating each space or t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `space` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern-space}
+#### `space` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern-space}
 
 Space holds the namespace pattern to use for space instances
 
@@ -611,7 +611,7 @@ Space holds the namespace pattern to use for space instances
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern-virtualCluster}
+#### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern-virtualCluster}
 
 VirtualCluster holds the namespace pattern to use for tenant cluster instances
 
@@ -629,7 +629,7 @@ VirtualCluster holds the namespace pattern to use for tenant cluster instances
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `argoCD` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD}
+### `argoCD` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD}
 
 ArgoIntegration holds information about ArgoCD Integration
 
@@ -641,7 +641,7 @@ ArgoIntegration holds information about ArgoCD Integration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-enabled}
 
 Enabled indicates if the ArgoCD Integration is enabled for the project -- this knob only
 enables the syncing of virtualclusters, but does not enable SSO integration or project
@@ -658,7 +658,7 @@ creation (see subsequent spec sections!).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-cluster}
+#### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-cluster}
 
 Cluster defines the name of the cluster that ArgoCD is deployed into -- if not provided this
 will default to 'loft-cluster'.
@@ -674,7 +674,7 @@ will default to 'loft-cluster'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualClusterInstance` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-virtualClusterInstance}
+#### `virtualClusterInstance` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-virtualClusterInstance}
 
 VirtualClusterInstance defines the name of *tenant cluster* (instance) that ArgoCD is
 deployed into. If provided, Cluster will be ignored and Loft will assume that ArgoCD is
@@ -691,7 +691,7 @@ running in the specified tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-namespace}
 
 Namespace defines the namespace in which ArgoCD is running in the cluster.
 
@@ -706,7 +706,7 @@ Namespace defines the namespace in which ArgoCD is running in the cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sso` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso}
+#### `sso` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso}
 
 SSO defines single-sign-on related values for the ArgoCD Integration. Enabling SSO will allow
 users to authenticate to ArgoCD via Loft.
@@ -719,7 +719,7 @@ users to authenticate to ArgoCD via Loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-enabled}
 
 Enabled indicates if the ArgoCD SSO Integration is enabled for this project. Enabling this
 will cause Loft to configure SSO authentication via Loft in ArgoCD. If Projects are *not*
@@ -737,7 +737,7 @@ enabled, all users associated with this Project will be assigned either the 'rea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-host}
+##### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-host}
 
 Host defines the ArgoCD host address that will be used for OIDC authentication between loft
 and ArgoCD. If not specified OIDC integration will be skipped, but vclusters/spaces will
@@ -754,7 +754,7 @@ still be synced to ArgoCD.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `assignedRoles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-assignedRoles}
+##### `assignedRoles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-assignedRoles}
 
 AssignedRoles is a list of roles to assign for users who authenticate via Loft -- by default
 this will be the `read-only` role. If any roles are provided this will override the default
@@ -774,7 +774,7 @@ setting.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project}
+#### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project}
 
 Project defines project related values for the ArgoCD Integration. Enabling Project
 integration will cause Loft to generate and manage an ArgoCD appProject that corresponds to
@@ -788,7 +788,7 @@ the Loft Project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-enabled}
 
 Enabled indicates if the ArgoCD Project Integration is enabled for this project. Enabling
 this will cause Loft to create an appProject in ArgoCD that is associated with the Loft
@@ -806,7 +806,7 @@ set in the SSO integration spec.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata}
 
 Metadata defines additional metadata to attach to the loft created project in ArgoCD.
 
@@ -818,7 +818,7 @@ Metadata defines additional metadata to attach to the loft created project in Ar
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraAnnotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-extraAnnotations}
+##### `extraAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-extraAnnotations}
 
 ExtraAnnotations are optional annotations that can be attached to the project in ArgoCD.
 
@@ -833,7 +833,7 @@ ExtraAnnotations are optional annotations that can be attached to the project in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-extraLabels}
+##### `extraLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-extraLabels}
 
 ExtraLabels are optional labels that can be attached to the project in ArgoCD.
 
@@ -848,7 +848,7 @@ ExtraLabels are optional labels that can be attached to the project in ArgoCD.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-description}
 
 Description to add to the ArgoCD project.
 
@@ -866,7 +866,7 @@ Description to add to the ArgoCD project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sourceRepos` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-sourceRepos}
+##### `sourceRepos` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-sourceRepos}
 
 SourceRepos is a list of source repositories to attach/allow on the project, if not specified
 will be "*" indicating all source repositories.
@@ -882,7 +882,7 @@ will be "*" indicating all source repositories.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations}
+##### `destinations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations}
 
 Destinations contains list of destinations available for deployment
 
@@ -894,7 +894,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-server}
 
 
 
@@ -909,7 +909,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-namespace}
 
 
 
@@ -924,7 +924,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-name}
 
 
 
@@ -942,7 +942,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `roles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles}
+##### `roles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles}
 
 Roles is a list of roles that should be attached to the ArgoCD project. If roles are provided
 no loft default roles will be set. If no roles are provided *and* SSO is enabled, loft will
@@ -956,7 +956,7 @@ configure sane default values.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-name}
 
 Name of the ArgoCD role to attach to the project.
 
@@ -971,7 +971,7 @@ Name of the ArgoCD role to attach to the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-description}
 
 Description to add to the ArgoCD project.
 
@@ -986,7 +986,7 @@ Description to add to the ArgoCD project.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules}
 
 Rules ist a list of policy rules to attach to the role.
 
@@ -998,7 +998,7 @@ Rules ist a list of policy rules to attach to the role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `action` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-action}
+##### `action` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-action}
 
 Action is one of "*", "get", "create", "update", "delete", "sync", or "override".
 
@@ -1013,7 +1013,7 @@ Action is one of "*", "get", "create", "update", "delete", "sync", or "override"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `application` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-application}
+##### `application` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-application}
 
 Application is the ArgoCD project/repository to apply the rule to.
 DEPRECATED: Wasn't used. Kind provides a more flexible way to specify the resource type.
@@ -1029,7 +1029,7 @@ DEPRECATED: Wasn't used. Kind provides a more flexible way to specify the resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-kind}
+##### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-kind}
 
 Kind is the kind to apply the rule to
 
@@ -1044,7 +1044,7 @@ Kind is the kind to apply the rule to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `permission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-permission}
+##### `permission` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-permission}
 
 Allow applies the "allow" permission to the rule, if allow is not set, the permission will
 always be set to "deny".
@@ -1063,7 +1063,7 @@ always be set to "deny".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-groups}
 
 Groups is a list of OIDC group names to bind to the role.
 
@@ -1081,7 +1081,7 @@ Groups is a list of OIDC group names to bind to the role.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterResourceWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist}
+##### `clusterResourceWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist}
 
 ClusterResourceWhitelist contains a list of whitelisted cluster level resources
 If not specified or empty, deny all cluster-scope resources.
@@ -1124,7 +1124,7 @@ If not specified or empty, deny all cluster-scope resources.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist-name}
 
 
 
@@ -1142,7 +1142,7 @@ If not specified or empty, deny all cluster-scope resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceResourceWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-namespaceResourceWhitelist}
+##### `namespaceResourceWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-namespaceResourceWhitelist}
 
 NamespaceResourceWhitelist contains a list of whitelisted namespace level resources
 If not specified or empty, allow all namespace-scope resources.
@@ -1188,7 +1188,7 @@ If not specified or empty, allow all namespace-scope resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterResourceBlacklist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist}
+##### `clusterResourceBlacklist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist}
 
 ClusterResourceBlacklist contains a list of blacklisted cluster level resources
 
@@ -1230,7 +1230,7 @@ ClusterResourceBlacklist contains a list of blacklisted cluster level resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist-name}
 
 
 
@@ -1248,7 +1248,7 @@ ClusterResourceBlacklist contains a list of blacklisted cluster level resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceResourceBlacklist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-namespaceResourceBlacklist}
+##### `namespaceResourceBlacklist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-namespaceResourceBlacklist}
 
 NamespaceResourceBlacklist contains a list of blacklisted namespace level resources
 
@@ -1293,7 +1293,7 @@ NamespaceResourceBlacklist contains a list of blacklisted namespace level resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sourceNamespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-sourceNamespaces}
+##### `sourceNamespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-sourceNamespaces}
 
 SourceNamespaces defines the namespaces application resources are allowed to be created in
 
@@ -1314,7 +1314,7 @@ SourceNamespaces defines the namespaces application resources are allowed to be 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault}
+### `vault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault}
 
 VaultIntegration holds information about Vault Integration
 
@@ -1326,7 +1326,7 @@ VaultIntegration holds information about Vault Integration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-enabled}
 
 Enabled indicates if the Vault Integration is enabled for the project -- this knob only
 enables the syncing of secrets to or from Vault, but does not setup Kubernetes authentication
@@ -1343,7 +1343,7 @@ methods or Kubernetes secrets engines for vclusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `address` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-address}
+#### `address` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-address}
 
 Address defines the address of the Vault instance to use for this project.
 Will default to the `VAULT_ADDR` environment variable if not provided.
@@ -1359,7 +1359,7 @@ Will default to the `VAULT_ADDR` environment variable if not provided.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `skipTLSVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-skipTLSVerify}
+#### `skipTLSVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-skipTLSVerify}
 
 SkipTLSVerify defines if TLS verification should be skipped when connecting to Vault.
 
@@ -1374,7 +1374,7 @@ SkipTLSVerify defines if TLS verification should be skipped when connecting to V
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-namespace}
 
 Namespace defines the namespace to use when storing secrets in Vault.
 
@@ -1389,7 +1389,7 @@ Namespace defines the namespace to use when storing secrets in Vault.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth}
+#### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth}
 
 Auth defines the authentication method to use for this project.
 
@@ -1401,7 +1401,7 @@ Auth defines the authentication method to use for this project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-token}
+##### `token` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-token}
 
 Token defines the token to use for authentication.
 
@@ -1416,7 +1416,7 @@ Token defines the token to use for authentication.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tokenSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef}
+##### `tokenSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef}
 
 TokenSecretRef defines the Kubernetes secret to use for token authentication.
 Will be used if `token` is not provided.
@@ -1431,7 +1431,7 @@ Secret data should contain the `token` key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef-name}
 
 Name of the referent.
 This field is effectively required, but due to backwards compatibility is
@@ -1466,7 +1466,7 @@ The key of the secret to select from.  Must be a valid secret key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef-optional}
+##### `optional` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef-optional}
 
 Specify whether the Secret or its key must be defined
 
@@ -1487,7 +1487,7 @@ Specify whether the Secret or its key must be defined
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-syncInterval}
+#### `syncInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-syncInterval}
 
 SyncInterval defines the interval at which to sync secrets from Vault.
 Defaults to `1m.`
@@ -1510,7 +1510,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -1522,7 +1522,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `quotas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas}
+### `quotas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas}
 
 Quotas holds the quota status
 
@@ -1534,7 +1534,7 @@ Quotas holds the quota status
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project}
+#### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project}
 
 Project is the quota status for the whole project
 
@@ -1546,7 +1546,7 @@ Project is the quota status for the whole project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-limit}
+##### `limit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-limit}
 
 Limit is the amount limited, copied from spec.quotas.project
 
@@ -1561,7 +1561,7 @@ Limit is the amount limited, copied from spec.quotas.project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `used` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-used}
+##### `used` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-used}
 
 Used is the amount currently used across all clusters
 
@@ -1576,7 +1576,7 @@ Used is the amount currently used across all clusters
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-clusters}
+##### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-clusters}
 
 Clusters holds the used amount per cluster. Maps cluster name to used resources
 
@@ -1588,7 +1588,7 @@ Clusters holds the used amount per cluster. Maps cluster name to used resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `used` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-clusters-used}
+##### `used` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-clusters-used}
 
 Used is the amount currently used. Maps resource name, such as pods, to their
 used amount.
@@ -1610,7 +1610,7 @@ used amount.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user}
 
 User is the quota status for each user / team. An example status
 could look like this:
@@ -1643,7 +1643,7 @@ status:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-limit}
+##### `limit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-limit}
 
 Limit is the amount limited per user / team
 
@@ -1658,7 +1658,7 @@ Limit is the amount limited per user / team
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `used` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used}
+##### `used` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used}
 
 Used is the used amount per user / team
 
@@ -1670,7 +1670,7 @@ Used is the used amount per user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used-users}
 
 Users is a mapping of users to used resources
 
@@ -1685,7 +1685,7 @@ Users is a mapping of users to used resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used-teams}
 
 Teams is a mapping of teams to used resources
 
@@ -1703,7 +1703,7 @@ Teams is a mapping of teams to used resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters}
+##### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters}
 
 Clusters holds the used amount per cluster. Maps cluster name to used resources
 
@@ -1715,7 +1715,7 @@ Clusters holds the used amount per cluster. Maps cluster name to used resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters-users}
 
 Users is a mapping of users to used resources
 
@@ -1730,7 +1730,7 @@ Users is a mapping of users to used resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters-teams}
 
 Teams is a mapping of teams to used resources
 
@@ -1754,7 +1754,7 @@ Teams is a mapping of teams to used resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions holds several conditions the project might be in
 

--- a/platform/api/_partials/resources/projects/reference.mdx
+++ b/platform/api/_partials/resources/projects/reference.mdx
@@ -122,7 +122,7 @@ Project holds the quotas for the whole project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-user}
+#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-user}
 
 User holds the quotas per user / team
 
@@ -274,10 +274,10 @@ IsDefault specifies if the template should be used as a default
 
 
 
-<details className="config-field" data-expandable="true">
+<details className="config-field" data-expandable="false" open>
 <summary>
 
-### `allowedNodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedNodeTypes}
+### `allowedNodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">array|null</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedNodeTypes}
 
 AllowedNodeTypes restricts which NodeTypes can be referenced by
 NodeClaims in this project. An entry can be an exact name
@@ -286,22 +286,6 @@ all NodeTypes are allowed; an empty list disallows all NodeTypes.
 
 </summary>
 
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedNodeTypes-name}
-
-Name of the NodeType, or "(provider).*" to allow all NodeTypes
-of the given provider.
-
-</summary>
-
-
-
-</details>
 
 
 </details>
@@ -552,7 +536,7 @@ require specific labels or annotations on namespaces.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata}
 
 
 
@@ -898,7 +882,7 @@ will be "*" indicating all source repositories.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations}
+##### `destinations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations}
 
 Destinations contains list of destinations available for deployment
 
@@ -910,7 +894,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-server}
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-server}
 
 
 
@@ -925,7 +909,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-namespace}
 
 
 
@@ -940,7 +924,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-name}
 
 
 
@@ -972,7 +956,7 @@ configure sane default values.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-name}
 
 Name of the ArgoCD role to attach to the project.
 
@@ -1002,7 +986,7 @@ Description to add to the ArgoCD project.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules}
 
 Rules ist a list of policy rules to attach to the role.
 
@@ -1079,7 +1063,7 @@ always be set to "deny".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-groups}
+##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-groups}
 
 Groups is a list of OIDC group names to bind to the role.
 
@@ -1140,7 +1124,7 @@ If not specified or empty, deny all cluster-scope resources.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist-name}
 
 
 
@@ -1246,7 +1230,7 @@ ClusterResourceBlacklist contains a list of blacklisted cluster level resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist-name}
 
 
 

--- a/platform/api/_partials/resources/projects/spec/vault.mdx
+++ b/platform/api/_partials/resources/projects/spec/vault.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#enabled}
+## `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#enabled}
 
 Enabled indicates if the Vault Integration is enabled for the project -- this knob only
 enables the syncing of secrets to or from Vault, but does not setup Kubernetes authentication
@@ -21,7 +21,7 @@ methods or Kubernetes secrets engines for vclusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `address` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#address}
+## `address` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#address}
 
 Address defines the address of the Vault instance to use for this project.
 Will default to the `VAULT_ADDR` environment variable if not provided.
@@ -37,7 +37,7 @@ Will default to the `VAULT_ADDR` environment variable if not provided.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `skipTLSVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#skipTLSVerify}
+## `skipTLSVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#skipTLSVerify}
 
 SkipTLSVerify defines if TLS verification should be skipped when connecting to Vault.
 
@@ -52,7 +52,7 @@ SkipTLSVerify defines if TLS verification should be skipped when connecting to V
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#namespace}
+## `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#namespace}
 
 Namespace defines the namespace to use when storing secrets in Vault.
 
@@ -67,7 +67,7 @@ Namespace defines the namespace to use when storing secrets in Vault.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth}
+## `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth}
 
 Auth defines the authentication method to use for this project.
 
@@ -79,7 +79,7 @@ Auth defines the authentication method to use for this project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-token}
+### `token` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-token}
 
 Token defines the token to use for authentication.
 
@@ -94,7 +94,7 @@ Token defines the token to use for authentication.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `tokenSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef}
+### `tokenSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef}
 
 TokenSecretRef defines the Kubernetes secret to use for token authentication.
 Will be used if `token` is not provided.
@@ -109,7 +109,7 @@ Secret data should contain the `token` key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef-name}
 
 Name of the referent.
 This field is effectively required, but due to backwards compatibility is
@@ -144,7 +144,7 @@ The key of the secret to select from.  Must be a valid secret key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef-optional}
+#### `optional` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef-optional}
 
 Specify whether the Secret or its key must be defined
 
@@ -165,7 +165,7 @@ Specify whether the Secret or its key must be defined
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `syncInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncInterval}
+## `syncInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncInterval}
 
 SyncInterval defines the interval at which to sync secrets from Vault.
 Defaults to `1m.`

--- a/platform/api/_partials/resources/projects/templates/reference.mdx
+++ b/platform/api/_partials/resources/projects/templates/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultVirtualClusterTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultVirtualClusterTemplate}
+## `defaultVirtualClusterTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultVirtualClusterTemplate}
 
 DefaultVirtualClusterTemplate is the default template for the project
 
@@ -19,7 +19,7 @@ DefaultVirtualClusterTemplate is the default template for the project
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualClusterTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates}
+## `virtualClusterTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates}
 
 VirtualClusterTemplates holds all the allowed tenant cluster templates
 
@@ -31,7 +31,7 @@ VirtualClusterTemplates holds all the allowed tenant cluster templates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-kind}
+### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -50,7 +50,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-apiVersion}
+### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -68,7 +68,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata}
+### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata}
 
 
 
@@ -80,7 +80,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -100,7 +100,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-generateName}
+#### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -126,7 +126,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -148,7 +148,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-selfLink}
+#### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -163,7 +163,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-uid}
+#### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -184,7 +184,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-resourceVersion}
+#### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -208,7 +208,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-generation}
+#### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -224,7 +224,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-creationTimestamp}
+#### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -246,7 +246,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-deletionTimestamp}
+#### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -278,7 +278,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-deletionGracePeriodSeconds}
+#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -296,7 +296,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -314,7 +314,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -332,7 +332,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences}
+#### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -410,7 +410,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -425,7 +425,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -450,7 +450,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-finalizers}
+#### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -477,7 +477,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields}
+#### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -496,7 +496,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -511,7 +511,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -527,7 +527,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -545,7 +545,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -564,7 +564,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -580,7 +580,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -595,7 +595,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -622,7 +622,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec}
+### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec}
 
 
 
@@ -634,7 +634,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-displayName}
 
 DisplayName is the name that is shown in the UI
 
@@ -649,7 +649,7 @@ DisplayName is the name that is shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-description}
 
 Description describes the tenant cluster template
 
@@ -664,7 +664,7 @@ Description describes the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner}
+#### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner}
 
 Owner holds the owner of this object
 
@@ -676,7 +676,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner-user}
 
 User specifies a Loft user.
 
@@ -691,7 +691,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner-team}
+##### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -709,7 +709,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template}
+#### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template}
 
 Template holds the tenant cluster template
 
@@ -721,7 +721,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata}
 
 
 
@@ -733,7 +733,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -748,7 +748,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -766,7 +766,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -778,7 +778,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata}
 
 
 
@@ -790,7 +790,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -805,7 +805,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -826,7 +826,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -838,7 +838,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-name}
 
 Name of the target app
 
@@ -853,7 +853,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -869,7 +869,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -884,7 +884,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-version}
 
 Version of the app
 
@@ -899,7 +899,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -914,7 +914,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -932,7 +932,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -944,7 +944,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -959,7 +959,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -974,7 +974,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -989,7 +989,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -1004,7 +1004,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1016,7 +1016,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1028,7 +1028,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1043,7 +1043,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1058,7 +1058,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1079,7 +1079,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -1094,7 +1094,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1106,7 +1106,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1118,7 +1118,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1133,7 +1133,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1148,7 +1148,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1169,7 +1169,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1184,7 +1184,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1199,7 +1199,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1214,7 +1214,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1229,7 +1229,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1244,7 +1244,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1262,7 +1262,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -1277,7 +1277,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -1289,7 +1289,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -1305,7 +1305,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -1319,7 +1319,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -1334,7 +1334,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -1349,7 +1349,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -1370,7 +1370,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-pro}
+##### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -1382,7 +1382,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -1400,7 +1400,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease}
+##### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -1412,7 +1412,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -1424,7 +1424,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -1439,7 +1439,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -1454,7 +1454,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -1469,7 +1469,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -1484,7 +1484,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -1499,7 +1499,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -1517,7 +1517,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-values}
 
 the values for the given chart
 
@@ -1535,7 +1535,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint}
+##### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -1548,7 +1548,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -1560,7 +1560,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -1583,7 +1583,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-forwardToken}
+##### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -1599,7 +1599,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate}
+##### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -1611,7 +1611,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata}
 
 
 
@@ -1623,7 +1623,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1638,7 +1638,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1656,7 +1656,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -1671,7 +1671,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1683,7 +1683,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -1698,7 +1698,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -1713,7 +1713,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -1728,7 +1728,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -1743,7 +1743,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1755,7 +1755,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1767,7 +1767,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1782,7 +1782,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1797,7 +1797,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1818,7 +1818,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -1833,7 +1833,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1845,7 +1845,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1857,7 +1857,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1872,7 +1872,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1887,7 +1887,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1908,7 +1908,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1923,7 +1923,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1938,7 +1938,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1953,7 +1953,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1968,7 +1968,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1983,7 +1983,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -2001,7 +2001,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -2013,7 +2013,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -2028,7 +2028,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -2044,7 +2044,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -2059,7 +2059,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -2074,7 +2074,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -2089,7 +2089,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -2113,7 +2113,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -2125,7 +2125,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -2140,7 +2140,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -2155,7 +2155,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -2170,7 +2170,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -2186,7 +2186,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -2201,7 +2201,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -2216,7 +2216,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -2231,7 +2231,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -2246,7 +2246,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -2261,7 +2261,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -2276,7 +2276,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -2291,7 +2291,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -2306,7 +2306,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -2324,7 +2324,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `versions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions}
+#### `versions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions}
 
 Versions are different versions of the template that can be referenced as well
 
@@ -2336,7 +2336,7 @@ Versions are different versions of the template that can be referenced as well
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template}
+##### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template}
 
 Template holds the space template
 
@@ -2348,7 +2348,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata}
 
 
 
@@ -2360,7 +2360,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -2375,7 +2375,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -2393,7 +2393,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -2405,7 +2405,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -2417,7 +2417,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -2432,7 +2432,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -2453,7 +2453,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -2465,7 +2465,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-name}
 
 Name of the target app
 
@@ -2480,7 +2480,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -2496,7 +2496,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -2511,7 +2511,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-version}
 
 Version of the app
 
@@ -2526,7 +2526,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -2541,7 +2541,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -2559,7 +2559,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -2571,7 +2571,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -2586,7 +2586,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -2601,7 +2601,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -2616,7 +2616,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-username}
 
 The username that is required for this repository
 
@@ -2631,7 +2631,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -2643,7 +2643,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2655,7 +2655,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2670,7 +2670,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2685,7 +2685,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2706,7 +2706,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-password}
 
 The password that is required for this repository
 
@@ -2721,7 +2721,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -2733,7 +2733,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2745,7 +2745,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2760,7 +2760,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2775,7 +2775,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2796,7 +2796,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -2811,7 +2811,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -2826,7 +2826,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -2841,7 +2841,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -2856,7 +2856,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -2871,7 +2871,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -2889,7 +2889,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -2904,7 +2904,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -2916,7 +2916,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -2932,7 +2932,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -2946,7 +2946,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -2961,7 +2961,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -2976,7 +2976,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -2997,7 +2997,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-pro}
+##### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -3009,7 +3009,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -3027,7 +3027,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease}
+##### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -3039,7 +3039,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -3051,7 +3051,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -3066,7 +3066,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -3081,7 +3081,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -3096,7 +3096,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -3111,7 +3111,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -3126,7 +3126,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -3144,7 +3144,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-values}
 
 the values for the given chart
 
@@ -3162,7 +3162,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint}
+##### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -3175,7 +3175,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -3187,7 +3187,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -3210,7 +3210,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-forwardToken}
+##### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -3226,7 +3226,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate}
+##### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -3238,7 +3238,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata}
 
 
 
@@ -3250,7 +3250,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -3265,7 +3265,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -3283,7 +3283,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -3298,7 +3298,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -3310,7 +3310,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -3325,7 +3325,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -3340,7 +3340,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -3355,7 +3355,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -3370,7 +3370,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -3382,7 +3382,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -3394,7 +3394,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -3409,7 +3409,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -3424,7 +3424,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -3445,7 +3445,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -3460,7 +3460,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -3472,7 +3472,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -3484,7 +3484,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -3499,7 +3499,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -3514,7 +3514,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -3535,7 +3535,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -3550,7 +3550,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -3565,7 +3565,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -3580,7 +3580,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -3595,7 +3595,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -3610,7 +3610,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -3628,7 +3628,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -3640,7 +3640,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -3655,7 +3655,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -3671,7 +3671,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -3686,7 +3686,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -3701,7 +3701,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -3716,7 +3716,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -3740,7 +3740,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -3752,7 +3752,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -3767,7 +3767,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -3782,7 +3782,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -3797,7 +3797,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -3813,7 +3813,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -3828,7 +3828,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -3843,7 +3843,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -3858,7 +3858,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -3873,7 +3873,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -3888,7 +3888,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -3903,7 +3903,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -3918,7 +3918,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -3933,7 +3933,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -3951,7 +3951,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-version}
 
 Version is the version. Needs to be in X.X.X format.
 
@@ -3969,7 +3969,7 @@ Version is the version. Needs to be in X.X.X format.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access}
 
 Access holds the access rights for users and teams
 
@@ -3981,7 +3981,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -4011,7 +4011,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-subresources}
+##### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -4026,7 +4026,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -4041,7 +4041,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -4059,7 +4059,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaceTemplateRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-spaceTemplateRef}
+#### `spaceTemplateRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-spaceTemplateRef}
 
 DEPRECATED: SpaceTemplate to use to create the tenant cluster space if it does not exist
 
@@ -4071,7 +4071,7 @@ DEPRECATED: SpaceTemplate to use to create the tenant cluster space if it does n
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-spaceTemplateRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-spaceTemplateRef-name}
 
 Name of the space template
 
@@ -4092,7 +4092,7 @@ Name of the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status}
+### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status}
 
 
 
@@ -4104,7 +4104,7 @@ Name of the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps}
 
 
 
@@ -4116,7 +4116,7 @@ Name of the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-name}
 
 Name is the kubernetes name of the object
 
@@ -4131,7 +4131,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-displayName}
 
 The display name shown in the UI
 
@@ -4146,7 +4146,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-icon}
+##### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-icon}
 
 Icon is the icon of the user / team
 
@@ -4161,7 +4161,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-username}
 
 The username that is used to login
 
@@ -4176,7 +4176,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-email}
+##### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-email}
 
 The users email address
 
@@ -4191,7 +4191,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-subject}
+##### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-subject}
 
 The user subject
 
@@ -4215,7 +4215,7 @@ The user subject
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultSpaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultSpaceTemplate}
+## `defaultSpaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultSpaceTemplate}
 
 DefaultSpaceTemplate
 
@@ -4230,7 +4230,7 @@ DefaultSpaceTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spaceTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates}
+## `spaceTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates}
 
 SpaceTemplates holds all the allowed space templates
 
@@ -4242,7 +4242,7 @@ SpaceTemplates holds all the allowed space templates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-kind}
+### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -4261,7 +4261,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-apiVersion}
+### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -4279,7 +4279,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata}
+### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata}
 
 
 
@@ -4291,7 +4291,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -4311,7 +4311,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-generateName}
+#### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -4337,7 +4337,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -4359,7 +4359,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-selfLink}
+#### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -4374,7 +4374,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-uid}
+#### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -4395,7 +4395,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-resourceVersion}
+#### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -4419,7 +4419,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-generation}
+#### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -4435,7 +4435,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-creationTimestamp}
+#### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -4457,7 +4457,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-deletionTimestamp}
+#### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -4489,7 +4489,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-deletionGracePeriodSeconds}
+#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -4507,7 +4507,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -4525,7 +4525,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -4543,7 +4543,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences}
+#### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -4621,7 +4621,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -4636,7 +4636,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -4661,7 +4661,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-finalizers}
+#### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -4688,7 +4688,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields}
+#### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -4707,7 +4707,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -4722,7 +4722,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -4738,7 +4738,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -4756,7 +4756,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -4775,7 +4775,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -4791,7 +4791,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -4806,7 +4806,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -4833,7 +4833,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec}
+### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec}
 
 
 
@@ -4845,7 +4845,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-displayName}
 
 DisplayName is the name that is shown in the UI
 
@@ -4860,7 +4860,7 @@ DisplayName is the name that is shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-description}
 
 Description describes the space template
 
@@ -4875,7 +4875,7 @@ Description describes the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner}
+#### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner}
 
 Owner holds the owner of this object
 
@@ -4887,7 +4887,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner-user}
 
 User specifies a Loft user.
 
@@ -4902,7 +4902,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner-team}
+##### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -4920,7 +4920,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template}
+#### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template}
 
 Template holds the space template
 
@@ -4932,7 +4932,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata}
 
 
 
@@ -4944,7 +4944,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -4959,7 +4959,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -4977,7 +4977,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -4989,7 +4989,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata}
 
 
 
@@ -5001,7 +5001,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -5016,7 +5016,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -5037,7 +5037,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -5052,7 +5052,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -5064,7 +5064,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -5079,7 +5079,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -5094,7 +5094,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -5109,7 +5109,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -5124,7 +5124,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -5136,7 +5136,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -5148,7 +5148,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -5163,7 +5163,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -5178,7 +5178,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -5199,7 +5199,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -5214,7 +5214,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -5226,7 +5226,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -5238,7 +5238,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -5253,7 +5253,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -5268,7 +5268,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -5289,7 +5289,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -5304,7 +5304,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -5319,7 +5319,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -5334,7 +5334,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -5349,7 +5349,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -5364,7 +5364,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -5382,7 +5382,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -5394,7 +5394,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-name}
 
 Name of the target app
 
@@ -5409,7 +5409,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -5425,7 +5425,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -5440,7 +5440,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-version}
 
 Version of the app
 
@@ -5455,7 +5455,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -5470,7 +5470,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -5488,7 +5488,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access}
 
 The space access
 
@@ -5500,7 +5500,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -5516,7 +5516,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -5530,7 +5530,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -5545,7 +5545,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -5560,7 +5560,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -5584,7 +5584,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -5596,7 +5596,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -5611,7 +5611,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -5626,7 +5626,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -5641,7 +5641,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -5657,7 +5657,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -5672,7 +5672,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -5687,7 +5687,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -5702,7 +5702,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -5717,7 +5717,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -5732,7 +5732,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -5747,7 +5747,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -5762,7 +5762,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -5777,7 +5777,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -5795,7 +5795,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `versions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions}
+#### `versions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions}
 
 Versions are different space template versions that can be referenced as well
 
@@ -5807,7 +5807,7 @@ Versions are different space template versions that can be referenced as well
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template}
+##### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template}
 
 Template holds the space template
 
@@ -5819,7 +5819,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata}
 
 
 
@@ -5831,7 +5831,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -5846,7 +5846,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -5864,7 +5864,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -5876,7 +5876,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -5888,7 +5888,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -5903,7 +5903,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -5924,7 +5924,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -5939,7 +5939,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -5951,7 +5951,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -5966,7 +5966,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -5981,7 +5981,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -5996,7 +5996,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-username}
 
 The username that is required for this repository
 
@@ -6011,7 +6011,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -6023,7 +6023,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -6035,7 +6035,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -6050,7 +6050,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -6065,7 +6065,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -6086,7 +6086,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-password}
 
 The password that is required for this repository
 
@@ -6101,7 +6101,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -6113,7 +6113,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -6125,7 +6125,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -6140,7 +6140,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -6155,7 +6155,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -6176,7 +6176,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -6191,7 +6191,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -6206,7 +6206,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -6221,7 +6221,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -6236,7 +6236,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -6251,7 +6251,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -6269,7 +6269,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -6281,7 +6281,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-name}
 
 Name of the target app
 
@@ -6296,7 +6296,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -6312,7 +6312,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -6327,7 +6327,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-version}
 
 Version of the app
 
@@ -6342,7 +6342,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -6357,7 +6357,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -6375,7 +6375,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access}
 
 The space access
 
@@ -6387,7 +6387,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -6403,7 +6403,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -6417,7 +6417,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -6432,7 +6432,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -6447,7 +6447,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -6471,7 +6471,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -6483,7 +6483,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -6498,7 +6498,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -6513,7 +6513,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -6528,7 +6528,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -6544,7 +6544,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -6559,7 +6559,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -6574,7 +6574,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -6589,7 +6589,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -6604,7 +6604,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -6619,7 +6619,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -6634,7 +6634,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -6649,7 +6649,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -6664,7 +6664,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -6682,7 +6682,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-version}
 
 Version is the version. Needs to be in X.X.X format.
 
@@ -6700,7 +6700,7 @@ Version is the version. Needs to be in X.X.X format.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access}
 
 Access holds the access rights for users and teams
 
@@ -6712,7 +6712,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -6742,7 +6742,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-subresources}
+##### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -6757,7 +6757,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -6772,7 +6772,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -6793,7 +6793,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status}
+### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status}
 
 
 
@@ -6805,7 +6805,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps}
 
 
 
@@ -6817,7 +6817,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-name}
 
 Name is the kubernetes name of the object
 
@@ -6832,7 +6832,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-displayName}
 
 The display name shown in the UI
 
@@ -6847,7 +6847,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-icon}
+##### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-icon}
 
 Icon is the icon of the user / team
 
@@ -6862,7 +6862,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-username}
 
 The username that is used to login
 
@@ -6877,7 +6877,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-email}
+##### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-email}
 
 The users email address
 
@@ -6892,7 +6892,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-subject}
+##### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-subject}
 
 The user subject
 

--- a/platform/api/_partials/resources/projects/templates/reference.mdx
+++ b/platform/api/_partials/resources/projects/templates/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultVirtualClusterTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultVirtualClusterTemplate}
+## `defaultVirtualClusterTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultVirtualClusterTemplate}
 
 DefaultVirtualClusterTemplate is the default template for the project
 
@@ -19,7 +19,7 @@ DefaultVirtualClusterTemplate is the default template for the project
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualClusterTemplates` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates}
+## `virtualClusterTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates}
 
 VirtualClusterTemplates holds all the allowed tenant cluster templates
 
@@ -68,7 +68,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata}
+### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata}
 
 
 
@@ -496,7 +496,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -511,7 +511,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -527,7 +527,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -564,7 +564,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -595,7 +595,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -622,7 +622,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec}
 
 
 
@@ -721,7 +721,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata}
 
 
 
@@ -778,7 +778,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata}
 
 
 
@@ -944,7 +944,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -1560,7 +1560,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -1611,7 +1611,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata}
 
 
 
@@ -1683,7 +1683,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -2348,7 +2348,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata}
 
 
 
@@ -2405,7 +2405,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -2571,7 +2571,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -3187,7 +3187,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -3238,7 +3238,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata}
 
 
 
@@ -3310,7 +3310,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -4092,7 +4092,7 @@ Name of the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status}
+### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status}
 
 
 
@@ -4116,7 +4116,7 @@ Name of the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-name}
 
 Name is the kubernetes name of the object
 
@@ -4215,7 +4215,7 @@ The user subject
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultSpaceTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultSpaceTemplate}
+## `defaultSpaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultSpaceTemplate}
 
 DefaultSpaceTemplate
 
@@ -4230,7 +4230,7 @@ DefaultSpaceTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spaceTemplates` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates}
+## `spaceTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates}
 
 SpaceTemplates holds all the allowed space templates
 
@@ -4279,7 +4279,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata}
+### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata}
 
 
 
@@ -4707,7 +4707,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -4722,7 +4722,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -4738,7 +4738,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -4775,7 +4775,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -4806,7 +4806,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -4833,7 +4833,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec}
 
 
 
@@ -4932,7 +4932,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata}
 
 
 
@@ -4989,7 +4989,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata}
 
 
 
@@ -5064,7 +5064,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -5819,7 +5819,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata}
 
 
 
@@ -5876,7 +5876,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -5951,7 +5951,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -6793,7 +6793,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status}
+### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status}
 
 
 
@@ -6817,7 +6817,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-name}
 
 Name is the kubernetes name of the object
 

--- a/platform/api/_partials/resources/selves/reference.mdx
+++ b/platform/api/_partials/resources/selves/reference.mdx
@@ -62,7 +62,7 @@ The name of the currently logged in user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-name}
 
 Name is the kubernetes name of the object
 
@@ -164,7 +164,7 @@ Teams are the teams the user is part of
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-name}
 
 Name is the kubernetes name of the object
 
@@ -272,7 +272,7 @@ The name of the currently logged in team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-name}
 
 Name is the kubernetes name of the object
 

--- a/platform/api/_partials/resources/selves/reference.mdx
+++ b/platform/api/_partials/resources/selves/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `accessKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-accessKey}
+### `accessKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-accessKey}
 
 AccessKey is an optional access key to use instead of the provided one
 
@@ -38,7 +38,7 @@ AccessKey is an optional access key to use instead of the provided one
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -50,7 +50,7 @@ AccessKey is an optional access key to use instead of the provided one
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user}
+### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user}
 
 The name of the currently logged in user
 
@@ -62,7 +62,7 @@ The name of the currently logged in user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-name}
 
 Name is the kubernetes name of the object
 
@@ -77,7 +77,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-displayName}
 
 The display name shown in the UI
 
@@ -92,7 +92,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-icon}
 
 Icon is the icon of the user / team
 
@@ -107,7 +107,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-username}
 
 The username that is used to login
 
@@ -122,7 +122,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-email}
 
 The users email address
 
@@ -137,7 +137,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-subject}
+#### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-subject}
 
 The user subject
 
@@ -152,7 +152,7 @@ The user subject
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams}
 
 Teams are the teams the user is part of
 
@@ -164,7 +164,7 @@ Teams are the teams the user is part of
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-name}
 
 Name is the kubernetes name of the object
 
@@ -179,7 +179,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-displayName}
 
 The display name shown in the UI
 
@@ -194,7 +194,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-icon}
+##### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-icon}
 
 Icon is the icon of the user / team
 
@@ -209,7 +209,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-username}
 
 The username that is used to login
 
@@ -224,7 +224,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-email}
+##### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-email}
 
 The users email address
 
@@ -239,7 +239,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-subject}
+##### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-subject}
 
 The user subject
 
@@ -260,7 +260,7 @@ The user subject
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team}
+### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team}
 
 The name of the currently logged in team
 
@@ -272,7 +272,7 @@ The name of the currently logged in team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-name}
 
 Name is the kubernetes name of the object
 
@@ -287,7 +287,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-displayName}
 
 The display name shown in the UI
 
@@ -302,7 +302,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-icon}
 
 Icon is the icon of the user / team
 
@@ -317,7 +317,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-username}
 
 The username that is used to login
 
@@ -332,7 +332,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-email}
 
 The users email address
 
@@ -347,7 +347,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-subject}
+#### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-subject}
 
 The user subject
 
@@ -365,7 +365,7 @@ The user subject
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `accessKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKey}
+### `accessKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKey}
 
 The name of the currently used access key
 
@@ -380,7 +380,7 @@ The name of the currently used access key
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `accessKeyScope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope}
+### `accessKeyScope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope}
 
 The scope of the currently used access key
 
@@ -392,7 +392,7 @@ The scope of the currently used access key
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `roles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles}
+#### `roles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles}
 
 Roles is a set of managed permissions to apply to the access key.
 
@@ -404,7 +404,7 @@ Roles is a set of managed permissions to apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-role}
 
 Role is the name of the role to apply to the access key scope.
 
@@ -419,7 +419,7 @@ Role is the name of the role to apply to the access key scope.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-projects}
+##### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -434,7 +434,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -452,7 +452,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-projects}
+#### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -464,7 +464,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-projects-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-projects-project}
 
 Project is the name of the project. You can specify * to select all projects.
 
@@ -482,7 +482,7 @@ Project is the name of the project. You can specify * to select all projects.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces}
+#### `spaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces}
 
 Spaces specifies the spaces the access key is allowed to access.
 
@@ -494,7 +494,7 @@ Spaces specifies the spaces the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces-project}
 
 Project is the name of the project.
 
@@ -509,7 +509,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `space` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces-space}
+##### `space` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces-space}
 
 Space is the name of the space. You can specify * to select all spaces.
 
@@ -527,7 +527,7 @@ Space is the name of the space. You can specify * to select all spaces.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters}
+#### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -539,7 +539,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters-project}
 
 Project is the name of the project.
 
@@ -554,7 +554,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters-virtualCluster}
+##### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters-virtualCluster}
 
 VirtualCluster is the name of the tenant cluster to access. You can specify * to select all tenant clusters.
 
@@ -572,7 +572,7 @@ VirtualCluster is the name of the tenant cluster to access. You can specify * to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-clusters}
+#### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-clusters}
 
 Clusters specifies the project cluster the access key is allowed to access.
 
@@ -584,7 +584,7 @@ Clusters specifies the project cluster the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-clusters-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-clusters-cluster}
 
 Cluster is the name of the cluster to access. You can specify * to select all clusters.
 
@@ -602,7 +602,7 @@ Cluster is the name of the cluster to access. You can specify * to select all cl
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules}
 
 DEPRECATED: Use Projects, Spaces and VirtualClusters instead
 Rules specifies the rules that should apply to the access key.
@@ -615,7 +615,7 @@ Rules specifies the rules that should apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -631,7 +631,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -643,7 +643,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -659,7 +659,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -686,7 +686,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -706,7 +706,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-namespaces}
+##### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -723,7 +723,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be checked.
 *s are allowed, but only as the full, final step in the path.
@@ -742,7 +742,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-requestTargets}
+##### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-requestTargets}
 
 RequestTargets is a list of request targets that are allowed.
 An empty list implies every request.
@@ -758,7 +758,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-cluster}
 
 Cluster that this rule matches. Only applies to cluster requests.
 If this is set, no requests for non cluster requests are allowed.
@@ -775,7 +775,7 @@ An empty cluster means no restrictions will apply.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters}
 
 VirtualClusters that this rule matches. Only applies to tenant cluster requests.
 An empty list means no restrictions will apply.
@@ -788,7 +788,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters-name}
 
 Name of the tenant cluster. Empty means all tenant clusters.
 
@@ -803,7 +803,7 @@ Name of the tenant cluster. Empty means all tenant clusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters-namespace}
 
 Namespace of the tenant cluster. Empty means all namespaces.
 
@@ -824,7 +824,7 @@ Namespace of the tenant cluster. Empty means all namespaces.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allowLoftCli` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-allowLoftCli}
+#### `allowLoftCli` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-allowLoftCli}
 
 AllowLoftCLI allows certain read-only management requests to
 make sure loft cli works correctly with this specific access key.
@@ -850,7 +850,7 @@ Deprecated: Use the `roles` field instead
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `accessKeyType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyType}
+### `accessKeyType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyType}
 
 The type of the currently used access key
 
@@ -865,7 +865,7 @@ The type of the currently used access key
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-subject}
+### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-subject}
 
 The subject of the currently logged in user
 
@@ -880,7 +880,7 @@ The subject of the currently logged in user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uid}
+### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uid}
 
 UID is the user uid
 
@@ -895,7 +895,7 @@ UID is the user uid
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-groups}
+### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-groups}
 
 The groups of the currently logged in user
 
@@ -910,7 +910,7 @@ The groups of the currently logged in user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `chatAuthToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-chatAuthToken}
+### `chatAuthToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-chatAuthToken}
 
 ChatAuthToken is the token used to authenticate with the in-product chat widget in the UI
 
@@ -925,7 +925,7 @@ ChatAuthToken is the token used to authenticate with the in-product chat widget 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `instanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-instanceID}
+### `instanceID` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-instanceID}
 
 InstanceID is the loft instance id
 
@@ -940,7 +940,7 @@ InstanceID is the loft instance id
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `loftHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-loftHost}
+### `loftHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-loftHost}
 
 LoftHost is the host of the loft instance
 
@@ -955,7 +955,7 @@ LoftHost is the host of the loft instance
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `projectNamespacePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-projectNamespacePrefix}
+### `projectNamespacePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-projectNamespacePrefix}
 
 ProjectNamespacePrefix is the prefix used to name project namespaces after defaulting has been applied
 

--- a/platform/api/_partials/resources/sharedsecrets/reference.mdx
+++ b/platform/api/_partials/resources/sharedsecrets/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a shared secret
 
@@ -50,7 +50,7 @@ Description describes a shared secret
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `data` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-data}
+### `data` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-data}
 
 Data contains the secret data. Each key must consist of alphanumeric
 characters, '-', '_' or '.'. The serialized form of the secret data is a
@@ -113,7 +113,7 @@ data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams which will be transformed
 to Roles and RoleBindings
@@ -126,7 +126,7 @@ to Roles and RoleBindings
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -156,7 +156,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -171,7 +171,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -186,7 +186,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -207,7 +207,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -219,7 +219,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions holds several conditions the project might be in
 

--- a/platform/api/_partials/resources/spaceinstances/reference.mdx
+++ b/platform/api/_partials/resources/spaceinstances/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a space instance
 
@@ -50,7 +50,7 @@ Description describes a space instance
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `templateRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef}
+### `templateRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef}
 
 TemplateRef holds the space template reference
 
@@ -107,7 +107,7 @@ TemplateRef holds the space template reference
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-name}
 
 Name holds the name of the template to reference.
 
@@ -122,7 +122,7 @@ Name holds the name of the template to reference.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-version}
 
 Version holds the template version to use. Version is expected to
 be in semantic versioning format. Alternatively, you can also exchange
@@ -140,7 +140,7 @@ the latest major, minor or patch version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncOnce` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-syncOnce}
+#### `syncOnce` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-syncOnce}
 
 SyncOnce tells the controller to sync the instance once with the template.
 This is useful if you want to sync an instance after a template was changed.
@@ -161,7 +161,7 @@ instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
+### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
 
 Template is the inline template to use for space creation. This is mutually
 exclusive with templateRef.
@@ -174,7 +174,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -186,7 +186,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -201,7 +201,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -219,7 +219,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -231,7 +231,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -243,7 +243,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -258,7 +258,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -279,7 +279,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -294,7 +294,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -306,7 +306,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -321,7 +321,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -336,7 +336,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -351,7 +351,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -366,7 +366,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -378,7 +378,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -390,7 +390,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -405,7 +405,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -420,7 +420,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -441,7 +441,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -456,7 +456,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -468,7 +468,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -480,7 +480,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -495,7 +495,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -510,7 +510,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -531,7 +531,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -546,7 +546,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -561,7 +561,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -576,7 +576,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -591,7 +591,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -606,7 +606,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -624,7 +624,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -636,7 +636,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
 
 Name of the target app
 
@@ -651,7 +651,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -667,7 +667,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -682,7 +682,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
 
 Version of the app
 
@@ -697,7 +697,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -712,7 +712,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -730,7 +730,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
 
 The space access
 
@@ -742,7 +742,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -758,7 +758,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -772,7 +772,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -787,7 +787,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -802,7 +802,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -826,7 +826,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef}
+### `clusterRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef}
 
 ClusterRef is the reference to the connected cluster holding
 this space
@@ -839,7 +839,7 @@ this space
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-cluster}
+#### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-cluster}
 
 Cluster is the connected cluster the space will be created in
 
@@ -854,7 +854,7 @@ Cluster is the connected cluster the space will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding the space
 
@@ -872,7 +872,7 @@ Namespace is the namespace inside the connected cluster holding the space
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
 
 Parameters are values to pass to the template.
 The values should be encoded as YAML string where each parameter is represented as a top-level field key.
@@ -888,7 +888,7 @@ The values should be encoded as YAML string where each parameter is represented 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `extraAccessRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules}
+### `extraAccessRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules}
 
 ExtraAccessRules defines extra rules which users and teams should have which access to the tenant
 cluster.
@@ -901,7 +901,7 @@ cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-users}
 
 Users this rule matches. * means all users.
 
@@ -916,7 +916,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-teams}
 
 Teams that this rule matches.
 
@@ -931,7 +931,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -949,7 +949,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -961,7 +961,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -991,7 +991,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -1006,7 +1006,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -1021,7 +1021,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -1042,7 +1042,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -1054,7 +1054,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `phase` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
+### `phase` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
 
 Phase describes the current phase the space instance is in
 
@@ -1069,7 +1069,7 @@ Phase describes the current phase the space instance is in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `reason` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
+### `reason` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
 
 Reason describes the reason in machine-readable form
 
@@ -1084,7 +1084,7 @@ Reason describes the reason in machine-readable form
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `message` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
+### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
 
 Message describes the reason in human-readable form
 
@@ -1099,7 +1099,7 @@ Message describes the reason in human-readable form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions holds several conditions the tenant cluster might be in
 
@@ -1114,7 +1114,7 @@ Conditions holds several conditions the tenant cluster might be in
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spaceObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects}
+### `spaceObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects}
 
 SpaceObjects are the objects that were applied within the tenant cluster space
 
@@ -1126,7 +1126,7 @@ SpaceObjects are the objects that were applied within the tenant cluster space
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `lastAppliedObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-lastAppliedObjects}
+#### `lastAppliedObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-lastAppliedObjects}
 
 LastAppliedObjects holds the status for the objects that were applied
 
@@ -1141,7 +1141,7 @@ LastAppliedObjects holds the status for the objects that were applied
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts}
 
 Charts are the charts that were applied
 
@@ -1153,7 +1153,7 @@ Charts are the charts that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-name}
 
 Name of the chart that was applied
 
@@ -1168,7 +1168,7 @@ Name of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-namespace}
 
 Namespace of the chart that was applied
 
@@ -1183,7 +1183,7 @@ Namespace of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-lastAppliedChartConfigHash}
+##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-lastAppliedChartConfigHash}
 
 LastAppliedChartConfigHash is the last applied configuration
 
@@ -1201,7 +1201,7 @@ LastAppliedChartConfigHash is the last applied configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps}
 
 Apps are the apps that were applied
 
@@ -1213,7 +1213,7 @@ Apps are the apps that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-name}
 
 Name of the target app
 
@@ -1228,7 +1228,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1244,7 +1244,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1259,7 +1259,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-version}
 
 Version of the app
 
@@ -1274,7 +1274,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1289,7 +1289,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-parameters}
 
 Parameters to use for the app
 
@@ -1310,7 +1310,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `space` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space}
+### `space` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space}
 
 Space is the template rendered with all the parameters
 
@@ -1322,7 +1322,7 @@ Space is the template rendered with all the parameters
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata}
 
 
 
@@ -1334,7 +1334,7 @@ Space is the template rendered with all the parameters
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata-labels}
 
 Labels are labels on the object
 
@@ -1349,7 +1349,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1367,7 +1367,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -1379,7 +1379,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata}
 
 
 
@@ -1391,7 +1391,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1406,7 +1406,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1427,7 +1427,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -1442,7 +1442,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1454,7 +1454,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-name}
 
 Name is the chart name in the repository
 
@@ -1469,7 +1469,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-version}
 
 Version is the chart version in the repository
 
@@ -1484,7 +1484,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -1499,7 +1499,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-username}
 
 The username that is required for this repository
 
@@ -1514,7 +1514,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1526,7 +1526,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1538,7 +1538,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1553,7 +1553,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1568,7 +1568,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1589,7 +1589,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-password}
 
 The password that is required for this repository
 
@@ -1604,7 +1604,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1616,7 +1616,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1628,7 +1628,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1643,7 +1643,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1658,7 +1658,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1679,7 +1679,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1694,7 +1694,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1709,7 +1709,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1724,7 +1724,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1739,7 +1739,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1754,7 +1754,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1772,7 +1772,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -1784,7 +1784,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-name}
 
 Name of the target app
 
@@ -1799,7 +1799,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1815,7 +1815,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1830,7 +1830,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-version}
 
 Version of the app
 
@@ -1845,7 +1845,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1860,7 +1860,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-parameters}
 
 Parameters to use for the app
 
@@ -1878,7 +1878,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access}
 
 The space access
 
@@ -1890,7 +1890,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -1906,7 +1906,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -1920,7 +1920,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -1935,7 +1935,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -1950,7 +1950,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -1974,7 +1974,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ignoreReconciliation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
+### `ignoreReconciliation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
 
 IgnoreReconciliation tells the controller to ignore reconciliation for this instance -- this
 is primarily used when migrating tenant cluster instances from project to project; this

--- a/platform/api/_partials/resources/spaceinstances/reference.mdx
+++ b/platform/api/_partials/resources/spaceinstances/reference.mdx
@@ -174,7 +174,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -231,7 +231,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -306,7 +306,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -1322,7 +1322,7 @@ Space is the template rendered with all the parameters
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata}
 
 
 
@@ -1379,7 +1379,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata}
 
 
 
@@ -1454,7 +1454,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-name}
 
 Name is the chart name in the repository
 
@@ -1974,7 +1974,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ignoreReconciliation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
+### `ignoreReconciliation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
 
 IgnoreReconciliation tells the controller to ignore reconciliation for this instance -- this
 is primarily used when migrating tenant cluster instances from project to project; this

--- a/platform/api/_partials/resources/spacetemplates/reference.mdx
+++ b/platform/api/_partials/resources/spacetemplates/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that is shown in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that is shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes the space template
 
@@ -50,7 +50,7 @@ Description describes the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
+### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
 
 Template holds the space template
 
@@ -107,7 +107,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -119,7 +119,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -134,7 +134,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -152,7 +152,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -164,7 +164,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -176,7 +176,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -191,7 +191,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -212,7 +212,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -227,7 +227,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -239,7 +239,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -254,7 +254,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -269,7 +269,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -284,7 +284,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -299,7 +299,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -311,7 +311,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -323,7 +323,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -338,7 +338,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -353,7 +353,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -374,7 +374,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -389,7 +389,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -401,7 +401,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -413,7 +413,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -428,7 +428,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -443,7 +443,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -464,7 +464,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -479,7 +479,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -494,7 +494,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -509,7 +509,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -524,7 +524,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -539,7 +539,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -557,7 +557,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -569,7 +569,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
 
 Name of the target app
 
@@ -584,7 +584,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -600,7 +600,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -615,7 +615,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
 
 Version of the app
 
@@ -630,7 +630,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -645,7 +645,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -663,7 +663,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
 
 The space access
 
@@ -675,7 +675,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -691,7 +691,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -705,7 +705,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -720,7 +720,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -735,7 +735,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -759,7 +759,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -771,7 +771,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
+#### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -786,7 +786,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
+#### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -801,7 +801,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -816,7 +816,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
+#### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -832,7 +832,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
+#### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -847,7 +847,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
+#### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -862,7 +862,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
+#### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -877,7 +877,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
+#### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -892,7 +892,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
+#### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -907,7 +907,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
+#### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -922,7 +922,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
+#### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -937,7 +937,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
+#### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -952,7 +952,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
+#### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -970,7 +970,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `versions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
+### `versions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
 
 Versions are different space template versions that can be referenced as well
 
@@ -982,7 +982,7 @@ Versions are different space template versions that can be referenced as well
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template}
+#### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template}
 
 Template holds the space template
 
@@ -994,7 +994,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
 
 
 
@@ -1006,7 +1006,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -1021,7 +1021,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1039,7 +1039,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -1051,7 +1051,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -1063,7 +1063,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1078,7 +1078,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1099,7 +1099,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -1114,7 +1114,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1126,7 +1126,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -1141,7 +1141,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -1156,7 +1156,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -1171,7 +1171,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-username}
 
 The username that is required for this repository
 
@@ -1186,7 +1186,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1198,7 +1198,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1210,7 +1210,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1225,7 +1225,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1240,7 +1240,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1261,7 +1261,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-password}
 
 The password that is required for this repository
 
@@ -1276,7 +1276,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1288,7 +1288,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1300,7 +1300,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1315,7 +1315,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1330,7 +1330,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1351,7 +1351,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1366,7 +1366,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1381,7 +1381,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1396,7 +1396,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1411,7 +1411,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1426,7 +1426,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1444,7 +1444,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -1456,7 +1456,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-name}
 
 Name of the target app
 
@@ -1471,7 +1471,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1487,7 +1487,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1502,7 +1502,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-version}
 
 Version of the app
 
@@ -1517,7 +1517,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1532,7 +1532,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -1550,7 +1550,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access}
 
 The space access
 
@@ -1562,7 +1562,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -1578,7 +1578,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -1592,7 +1592,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -1607,7 +1607,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -1622,7 +1622,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -1646,7 +1646,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -1658,7 +1658,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -1673,7 +1673,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -1688,7 +1688,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -1703,7 +1703,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -1719,7 +1719,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -1734,7 +1734,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -1749,7 +1749,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -1764,7 +1764,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -1779,7 +1779,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -1794,7 +1794,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -1809,7 +1809,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -1824,7 +1824,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -1839,7 +1839,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -1857,7 +1857,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
 
 Version is the version. Needs to be in X.X.X format.
 
@@ -1875,7 +1875,7 @@ Version is the version. Needs to be in X.X.X format.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -1887,7 +1887,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -1917,7 +1917,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -1932,7 +1932,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -1947,7 +1947,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -1968,7 +1968,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 

--- a/platform/api/_partials/resources/spacetemplates/reference.mdx
+++ b/platform/api/_partials/resources/spacetemplates/reference.mdx
@@ -107,7 +107,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -164,7 +164,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -239,7 +239,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -994,7 +994,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
 
 
 
@@ -1051,7 +1051,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -1126,7 +1126,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 

--- a/platform/api/_partials/resources/teams/reference.mdx
+++ b/platform/api/_partials/resources/teams/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 The display name shown in the UI
 
@@ -35,7 +35,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a cluster access object
 
@@ -50,7 +50,7 @@ Description describes a cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
+### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
 
 The username of the team that will be used for identification and docker registry namespace
 
@@ -110,7 +110,7 @@ The username of the team that will be used for identification and docker registr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-users}
+### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-users}
 
 The loft users that belong to a team
 
@@ -125,7 +125,7 @@ The loft users that belong to a team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
+### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
 
 The groups defined in a token that belong to a team
 
@@ -140,7 +140,7 @@ The groups defined in a token that belong to a team
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets}
 
 ImagePullSecrets holds secret references to image pull
 secrets the team has access to.
@@ -153,7 +153,7 @@ secrets the team has access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
+#### `apiGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
 
 APIGroup is the api group of the secret
 
@@ -168,7 +168,7 @@ APIGroup is the api group of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
 
 Kind is the kind of the secret
 
@@ -183,7 +183,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretName}
 
 
 
@@ -198,7 +198,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretNamespace}
+#### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretNamespace}
 
 
 
@@ -213,7 +213,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-key}
+#### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-key}
 
 
 
@@ -231,7 +231,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRoles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles}
+### `clusterRoles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles}
 
 ClusterRoles define the cluster roles that the users should have assigned in the cluster.
 
@@ -243,7 +243,7 @@ ClusterRoles define the cluster roles that the users should have assigned in the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles-name}
 
 Name is the cluster role to assign
 
@@ -261,7 +261,7 @@ Name is the cluster role to assign
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -273,7 +273,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -303,7 +303,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -318,7 +318,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -333,7 +333,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -354,7 +354,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 

--- a/platform/api/_partials/resources/teams/reference.mdx
+++ b/platform/api/_partials/resources/teams/reference.mdx
@@ -153,7 +153,7 @@ secrets the team has access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroup` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
+#### `apiGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
 
 APIGroup is the api group of the secret
 
@@ -168,7 +168,7 @@ APIGroup is the api group of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
 
 Kind is the kind of the secret
 

--- a/platform/api/_partials/resources/users/reference.mdx
+++ b/platform/api/_partials/resources/users/reference.mdx
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `username` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
+### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
 
 The username that is used to login
 
@@ -140,7 +140,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `subject` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
+### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
 
 The user subject as presented by the token
 
@@ -319,7 +319,7 @@ secrets the user has access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroup` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
+#### `apiGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
 
 APIGroup is the api group of the secret
 
@@ -334,7 +334,7 @@ APIGroup is the api group of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
 
 Kind is the kind of the secret
 

--- a/platform/api/_partials/resources/users/reference.mdx
+++ b/platform/api/_partials/resources/users/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 The display name shown in the UI
 
@@ -35,7 +35,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a cluster access object
 
@@ -50,7 +50,7 @@ Description describes a cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
+### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
 
 The username that is used to login
 
@@ -110,7 +110,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-icon}
+### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-icon}
 
 The URL to an icon that should be shown for the user
 
@@ -125,7 +125,7 @@ The URL to an icon that should be shown for the user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-email}
+### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-email}
 
 The users email address
 
@@ -140,7 +140,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
+### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
 
 The user subject as presented by the token
 
@@ -155,7 +155,7 @@ The user subject as presented by the token
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
+### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
 
 The groups the user has access to
 
@@ -170,7 +170,7 @@ The groups the user has access to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ssoGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ssoGroups}
+### `ssoGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ssoGroups}
 
 SSOGroups is used to remember groups that were
 added from sso.
@@ -186,7 +186,7 @@ added from sso.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef}
+### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef}
 
 A reference to the user password
 
@@ -198,7 +198,7 @@ A reference to the user password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-secretName}
 
 
 
@@ -213,7 +213,7 @@ A reference to the user password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-secretNamespace}
+#### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-secretNamespace}
 
 
 
@@ -228,7 +228,7 @@ A reference to the user password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-key}
+#### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-key}
 
 
 
@@ -246,7 +246,7 @@ A reference to the user password
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `codesRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef}
+### `codesRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef}
 
 A reference to the users access keys
 
@@ -258,7 +258,7 @@ A reference to the users access keys
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-secretName}
 
 
 
@@ -273,7 +273,7 @@ A reference to the users access keys
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-secretNamespace}
+#### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-secretNamespace}
 
 
 
@@ -288,7 +288,7 @@ A reference to the users access keys
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-key}
+#### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-key}
 
 
 
@@ -306,7 +306,7 @@ A reference to the users access keys
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets}
 
 ImagePullSecrets holds secret references to image pull
 secrets the user has access to.
@@ -319,7 +319,7 @@ secrets the user has access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
+#### `apiGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
 
 APIGroup is the api group of the secret
 
@@ -334,7 +334,7 @@ APIGroup is the api group of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
 
 Kind is the kind of the secret
 
@@ -349,7 +349,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretName}
 
 
 
@@ -364,7 +364,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretNamespace}
+#### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretNamespace}
 
 
 
@@ -379,7 +379,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-key}
+#### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-key}
 
 
 
@@ -397,7 +397,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `tokenGeneration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-tokenGeneration}
+### `tokenGeneration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-tokenGeneration}
 
 TokenGeneration can be used to invalidate all user tokens
 
@@ -412,7 +412,7 @@ TokenGeneration can be used to invalidate all user tokens
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-disabled}
+### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-disabled}
 
 If disabled is true, a user will not be able to login anymore. All other user resources
 are unaffected and other users can still interact with this user
@@ -428,7 +428,7 @@ are unaffected and other users can still interact with this user
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRoles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles}
+### `clusterRoles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles}
 
 ClusterRoles define the cluster roles that the users should have assigned in the cluster.
 
@@ -440,7 +440,7 @@ ClusterRoles define the cluster roles that the users should have assigned in the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles-name}
 
 Name is the cluster role to assign
 
@@ -458,7 +458,7 @@ Name is the cluster role to assign
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -470,7 +470,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -500,7 +500,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -515,7 +515,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -530,7 +530,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -548,7 +548,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraClaims}
+### `extraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraClaims}
 
 ExtraClaims are additional claims that have been added to the user by an admin.
 
@@ -566,7 +566,7 @@ ExtraClaims are additional claims that have been added to the user by an admin.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -578,7 +578,7 @@ ExtraClaims are additional claims that have been added to the user by an admin.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-teams}
+### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-teams}
 
 Teams the user is currently part of
 

--- a/platform/api/_partials/resources/virtualclusterinstances/kubeconfig/reference.mdx
+++ b/platform/api/_partials/resources/virtualclusterinstances/kubeconfig/reference.mdx
@@ -81,7 +81,7 @@ ClientCert, if set to true, will return kube config with generated client certs 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubeConfig}
 
 KubeConfig holds the final kubeconfig output
 

--- a/platform/api/_partials/resources/virtualclusterinstances/kubeconfig/reference.mdx
+++ b/platform/api/_partials/resources/virtualclusterinstances/kubeconfig/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -16,7 +16,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certificateTTL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-certificateTTL}
+### `certificateTTL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-certificateTTL}
 
 CertificateTTL holds the ttl (in seconds) to set for the certificate associated with the
 returned kubeconfig.
@@ -36,7 +36,7 @@ which is typically one year.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-server}
+### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-server}
 
 Server allows user to override server in the kubeconfig.
 
@@ -51,7 +51,7 @@ Server allows user to override server in the kubeconfig.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clientCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clientCert}
+### `clientCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clientCert}
 
 ClientCert, if set to true, will return kube config with generated client certs instead of platform token
 
@@ -69,7 +69,7 @@ ClientCert, if set to true, will return kube config with generated client certs 
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -81,7 +81,7 @@ ClientCert, if set to true, will return kube config with generated client certs 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubeConfig}
 
 KubeConfig holds the final kubeconfig output
 

--- a/platform/api/_partials/resources/virtualclusterinstances/reference.mdx
+++ b/platform/api/_partials/resources/virtualclusterinstances/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a tenant cluster instance
 
@@ -50,7 +50,7 @@ Description describes a tenant cluster instance
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `templateRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef}
+### `templateRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef}
 
 TemplateRef holds the tenant cluster template reference
 
@@ -107,7 +107,7 @@ TemplateRef holds the tenant cluster template reference
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-name}
 
 Name holds the name of the template to reference.
 
@@ -122,7 +122,7 @@ Name holds the name of the template to reference.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-version}
 
 Version holds the template version to use. Version is expected to
 be in semantic versioning format. Alternatively, you can also exchange
@@ -140,7 +140,7 @@ the latest major, minor or patch version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncOnce` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-syncOnce}
+#### `syncOnce` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-syncOnce}
 
 SyncOnce tells the controller to sync the instance once with the template.
 This is useful if you want to sync an instance after a template was changed.
@@ -161,7 +161,7 @@ instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
+### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
 
 Template is the inline template to use for tenant cluster creation. This is mutually
 exclusive with templateRef.
@@ -174,7 +174,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -186,7 +186,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -201,7 +201,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -219,7 +219,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -231,7 +231,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -243,7 +243,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -258,7 +258,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -279,7 +279,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -291,7 +291,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
 
 Name of the target app
 
@@ -306,7 +306,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -322,7 +322,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -337,7 +337,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
 
 Version of the app
 
@@ -352,7 +352,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -367,7 +367,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -385,7 +385,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -397,7 +397,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -412,7 +412,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -427,7 +427,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -442,7 +442,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -457,7 +457,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -469,7 +469,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -481,7 +481,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -496,7 +496,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -511,7 +511,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -532,7 +532,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -547,7 +547,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -559,7 +559,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -571,7 +571,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -586,7 +586,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -601,7 +601,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -622,7 +622,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -637,7 +637,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -652,7 +652,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -667,7 +667,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -682,7 +682,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -697,7 +697,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -715,7 +715,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -730,7 +730,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -742,7 +742,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -758,7 +758,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -772,7 +772,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -787,7 +787,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -802,7 +802,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -823,7 +823,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro}
+#### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -835,7 +835,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -853,7 +853,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease}
+#### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -865,7 +865,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -877,7 +877,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -892,7 +892,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -907,7 +907,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -922,7 +922,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -937,7 +937,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -952,7 +952,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -970,7 +970,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-values}
 
 the values for the given chart
 
@@ -988,7 +988,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint}
+#### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -1001,7 +1001,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -1013,7 +1013,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -1036,7 +1036,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-forwardToken}
+#### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -1052,7 +1052,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate}
+#### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -1064,7 +1064,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
 
 
 
@@ -1076,7 +1076,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1091,7 +1091,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1109,7 +1109,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -1124,7 +1124,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1136,7 +1136,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -1151,7 +1151,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -1166,7 +1166,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -1181,7 +1181,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -1196,7 +1196,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1208,7 +1208,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1220,7 +1220,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1235,7 +1235,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1250,7 +1250,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1271,7 +1271,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -1286,7 +1286,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1298,7 +1298,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1310,7 +1310,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1325,7 +1325,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1340,7 +1340,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1361,7 +1361,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1376,7 +1376,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1391,7 +1391,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1406,7 +1406,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1421,7 +1421,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1436,7 +1436,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1454,7 +1454,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -1466,7 +1466,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -1481,7 +1481,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1497,7 +1497,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1512,7 +1512,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -1527,7 +1527,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1542,7 +1542,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -1566,7 +1566,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef}
+### `clusterRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef}
 
 ClusterRef is the reference to the connected cluster holding
 this tenant cluster
@@ -1579,7 +1579,7 @@ this tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-cluster}
+#### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-cluster}
 
 Cluster is the connected cluster the space will be created in
 
@@ -1594,7 +1594,7 @@ Cluster is the connected cluster the space will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding the space
 
@@ -1609,7 +1609,7 @@ Namespace is the namespace inside the connected cluster holding the space
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-virtualCluster}
+#### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-virtualCluster}
 
 VirtualCluster is the name of the tenant cluster inside the namespace
 
@@ -1627,7 +1627,7 @@ VirtualCluster is the name of the tenant cluster inside the namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
 
 Parameters are values to pass to the template.
 The values should be encoded as YAML string where each parameter is represented as a top-level field key.
@@ -1643,7 +1643,7 @@ The values should be encoded as YAML string where each parameter is represented 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `extraAccessRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules}
+### `extraAccessRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules}
 
 ExtraAccessRules defines extra rules which users and teams should have which access to the tenant
 cluster.
@@ -1656,7 +1656,7 @@ cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-users}
 
 Users this rule matches. * means all users.
 
@@ -1671,7 +1671,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-teams}
 
 Teams that this rule matches.
 
@@ -1686,7 +1686,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -1704,7 +1704,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access to the tenant cluster object itself
 
@@ -1716,7 +1716,7 @@ Access to the tenant cluster object itself
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -1746,7 +1746,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -1761,7 +1761,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -1776,7 +1776,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -1794,7 +1794,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `networkPeer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-networkPeer}
+### `networkPeer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-networkPeer}
 
 NetworkPeer specifies if the cluster is connected via tailscale.
 
@@ -1809,7 +1809,7 @@ NetworkPeer specifies if the cluster is connected via tailscale.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-external}
+### `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-external}
 
 External specifies if the tenant cluster is managed by the platform agent or externally.
 
@@ -1824,7 +1824,7 @@ External specifies if the tenant cluster is managed by the platform agent or ext
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `standalone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-standalone}
+### `standalone` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-standalone}
 
 Standalone specifies if the tenant cluster is standalone and not hosted in another Kubernetes cluster.
 
@@ -1842,7 +1842,7 @@ Standalone specifies if the tenant cluster is standalone and not hosted in anoth
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -1854,7 +1854,7 @@ Standalone specifies if the tenant cluster is standalone and not hosted in anoth
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `phase` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
+### `phase` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
 
 Phase describes the current phase the tenant cluster instance is in
 
@@ -1869,7 +1869,7 @@ Phase describes the current phase the tenant cluster instance is in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `reason` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
+### `reason` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
 
 Reason describes the reason in machine-readable form why the cluster is in the current
 phase
@@ -1885,7 +1885,7 @@ phase
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `message` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
+### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
 
 Message describes the reason in human-readable form why the cluster is in the current
 phase
@@ -1901,7 +1901,7 @@ phase
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serviceUID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-serviceUID}
+### `serviceUID` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-serviceUID}
 
 ServiceUID is the service uid of the tenant cluster to uniquely identify it.
 
@@ -1916,7 +1916,7 @@ ServiceUID is the service uid of the tenant cluster to uniquely identify it.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubernetesVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubernetesVersion}
+### `kubernetesVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubernetesVersion}
 
 KubernetesVersion is the Kubernetes version of the tenant cluster.
 
@@ -1931,7 +1931,7 @@ KubernetesVersion is the Kubernetes version of the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `deployHash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-deployHash}
+### `deployHash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-deployHash}
 
 DeployHash is the hash of the last deployed values.
 
@@ -1946,7 +1946,7 @@ DeployHash is the hash of the last deployed values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions holds several conditions the tenant cluster might be in
 
@@ -1961,7 +1961,7 @@ Conditions holds several conditions the tenant cluster might be in
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualClusterObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects}
+### `virtualClusterObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects}
 
 VirtualClusterObjects are the objects that were applied within the tenant cluster itself
 
@@ -1973,7 +1973,7 @@ VirtualClusterObjects are the objects that were applied within the tenant cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `lastAppliedObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-lastAppliedObjects}
+#### `lastAppliedObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-lastAppliedObjects}
 
 LastAppliedObjects holds the status for the objects that were applied
 
@@ -1988,7 +1988,7 @@ LastAppliedObjects holds the status for the objects that were applied
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts}
 
 Charts are the charts that were applied
 
@@ -2000,7 +2000,7 @@ Charts are the charts that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-name}
 
 Name of the chart that was applied
 
@@ -2015,7 +2015,7 @@ Name of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-namespace}
 
 Namespace of the chart that was applied
 
@@ -2030,7 +2030,7 @@ Namespace of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-lastAppliedChartConfigHash}
+##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-lastAppliedChartConfigHash}
 
 LastAppliedChartConfigHash is the last applied configuration
 
@@ -2048,7 +2048,7 @@ LastAppliedChartConfigHash is the last applied configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps}
 
 Apps are the apps that were applied
 
@@ -2060,7 +2060,7 @@ Apps are the apps that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-name}
 
 Name of the target app
 
@@ -2075,7 +2075,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -2091,7 +2091,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -2106,7 +2106,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-version}
 
 Version of the app
 
@@ -2121,7 +2121,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -2136,7 +2136,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-parameters}
 
 Parameters to use for the app
 
@@ -2157,7 +2157,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spaceObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects}
+### `spaceObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects}
 
 SpaceObjects are the objects that were applied within the tenant cluster space
 
@@ -2169,7 +2169,7 @@ SpaceObjects are the objects that were applied within the tenant cluster space
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `lastAppliedObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-lastAppliedObjects}
+#### `lastAppliedObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-lastAppliedObjects}
 
 LastAppliedObjects holds the status for the objects that were applied
 
@@ -2184,7 +2184,7 @@ LastAppliedObjects holds the status for the objects that were applied
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts}
 
 Charts are the charts that were applied
 
@@ -2196,7 +2196,7 @@ Charts are the charts that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-name}
 
 Name of the chart that was applied
 
@@ -2211,7 +2211,7 @@ Name of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-namespace}
 
 Namespace of the chart that was applied
 
@@ -2226,7 +2226,7 @@ Namespace of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-lastAppliedChartConfigHash}
+##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-lastAppliedChartConfigHash}
 
 LastAppliedChartConfigHash is the last applied configuration
 
@@ -2244,7 +2244,7 @@ LastAppliedChartConfigHash is the last applied configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps}
 
 Apps are the apps that were applied
 
@@ -2256,7 +2256,7 @@ Apps are the apps that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-name}
 
 Name of the target app
 
@@ -2271,7 +2271,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -2287,7 +2287,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -2302,7 +2302,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-version}
 
 Version of the app
 
@@ -2317,7 +2317,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -2332,7 +2332,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-parameters}
 
 Parameters to use for the app
 
@@ -2353,7 +2353,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster}
+### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster}
 
 VirtualCluster is the template rendered with all the parameters
 
@@ -2365,7 +2365,7 @@ VirtualCluster is the template rendered with all the parameters
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata}
 
 
 
@@ -2377,7 +2377,7 @@ VirtualCluster is the template rendered with all the parameters
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata-labels}
 
 Labels are labels on the object
 
@@ -2392,7 +2392,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -2410,7 +2410,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -2422,7 +2422,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata}
 
 
 
@@ -2434,7 +2434,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -2449,7 +2449,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -2470,7 +2470,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -2482,7 +2482,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-name}
 
 Name of the target app
 
@@ -2497,7 +2497,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -2513,7 +2513,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -2528,7 +2528,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-version}
 
 Version of the app
 
@@ -2543,7 +2543,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -2558,7 +2558,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-parameters}
 
 Parameters to use for the app
 
@@ -2576,7 +2576,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts}
 
 Charts are helm charts that should get deployed
 
@@ -2588,7 +2588,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-name}
 
 Name is the chart name in the repository
 
@@ -2603,7 +2603,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-version}
 
 Version is the chart version in the repository
 
@@ -2618,7 +2618,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -2633,7 +2633,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-username}
 
 The username that is required for this repository
 
@@ -2648,7 +2648,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -2660,7 +2660,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2672,7 +2672,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2687,7 +2687,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2702,7 +2702,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2723,7 +2723,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-password}
 
 The password that is required for this repository
 
@@ -2738,7 +2738,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -2750,7 +2750,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2762,7 +2762,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2777,7 +2777,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2792,7 +2792,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2813,7 +2813,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -2828,7 +2828,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -2843,7 +2843,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -2858,7 +2858,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -2873,7 +2873,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -2888,7 +2888,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -2906,7 +2906,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -2921,7 +2921,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -2933,7 +2933,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -2949,7 +2949,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -2963,7 +2963,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -2978,7 +2978,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -2993,7 +2993,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -3014,7 +3014,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-pro}
+#### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -3026,7 +3026,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -3044,7 +3044,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease}
+#### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -3056,7 +3056,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -3068,7 +3068,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -3083,7 +3083,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -3098,7 +3098,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -3113,7 +3113,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -3128,7 +3128,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -3143,7 +3143,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -3161,7 +3161,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-values}
 
 the values for the given chart
 
@@ -3179,7 +3179,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint}
+#### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -3192,7 +3192,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -3204,7 +3204,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -3227,7 +3227,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-forwardToken}
+#### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -3243,7 +3243,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate}
+#### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -3255,7 +3255,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata}
 
 
 
@@ -3267,7 +3267,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -3282,7 +3282,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -3300,7 +3300,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -3315,7 +3315,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -3327,7 +3327,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -3342,7 +3342,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -3357,7 +3357,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -3372,7 +3372,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -3387,7 +3387,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -3399,7 +3399,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -3411,7 +3411,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -3426,7 +3426,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -3441,7 +3441,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -3462,7 +3462,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -3477,7 +3477,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -3489,7 +3489,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -3501,7 +3501,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -3516,7 +3516,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -3531,7 +3531,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -3552,7 +3552,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -3567,7 +3567,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -3582,7 +3582,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -3597,7 +3597,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -3612,7 +3612,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -3627,7 +3627,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -3645,7 +3645,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -3657,7 +3657,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -3672,7 +3672,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -3688,7 +3688,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -3703,7 +3703,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -3718,7 +3718,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -3733,7 +3733,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -3757,7 +3757,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ignoreReconciliation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
+### `ignoreReconciliation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
 
 IgnoreReconciliation tells the controller to ignore reconciliation for this instance -- this
 is primarily used when migrating tenant cluster instances from project to project; this

--- a/platform/api/_partials/resources/virtualclusterinstances/reference.mdx
+++ b/platform/api/_partials/resources/virtualclusterinstances/reference.mdx
@@ -174,7 +174,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -231,7 +231,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -397,7 +397,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -1013,7 +1013,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -1064,7 +1064,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
 
 
 
@@ -1136,7 +1136,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -2365,7 +2365,7 @@ VirtualCluster is the template rendered with all the parameters
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata}
 
 
 
@@ -2422,7 +2422,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata}
 
 
 
@@ -2588,7 +2588,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-name}
 
 Name is the chart name in the repository
 
@@ -3204,7 +3204,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -3255,7 +3255,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata}
 
 
 
@@ -3327,7 +3327,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -3757,7 +3757,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ignoreReconciliation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
+### `ignoreReconciliation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
 
 IgnoreReconciliation tells the controller to ignore reconciliation for this instance -- this
 is primarily used when migrating tenant cluster instances from project to project; this

--- a/platform/api/_partials/resources/virtualclustertemplates/reference.mdx
+++ b/platform/api/_partials/resources/virtualclustertemplates/reference.mdx
@@ -107,7 +107,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -164,7 +164,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -330,7 +330,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -946,7 +946,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -997,7 +997,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
 
 
 
@@ -1069,7 +1069,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -1734,7 +1734,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
 
 
 
@@ -1791,7 +1791,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -1957,7 +1957,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -2573,7 +2573,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -2624,7 +2624,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata}
 
 
 
@@ -2696,7 +2696,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 

--- a/platform/api/_partials/resources/virtualclustertemplates/reference.mdx
+++ b/platform/api/_partials/resources/virtualclustertemplates/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that is shown in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that is shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes the tenant cluster template
 
@@ -50,7 +50,7 @@ Description describes the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
+### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
 
 Template holds the tenant cluster template
 
@@ -107,7 +107,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -119,7 +119,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -134,7 +134,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -152,7 +152,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -164,7 +164,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -176,7 +176,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -191,7 +191,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -212,7 +212,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -224,7 +224,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
 
 Name of the target app
 
@@ -239,7 +239,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -255,7 +255,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -270,7 +270,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
 
 Version of the app
 
@@ -285,7 +285,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -300,7 +300,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -318,7 +318,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -330,7 +330,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -345,7 +345,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -360,7 +360,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -375,7 +375,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -390,7 +390,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -402,7 +402,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -414,7 +414,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -429,7 +429,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -444,7 +444,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -465,7 +465,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -480,7 +480,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -492,7 +492,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -504,7 +504,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -519,7 +519,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -534,7 +534,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -555,7 +555,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -570,7 +570,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -585,7 +585,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -600,7 +600,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -615,7 +615,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -630,7 +630,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -648,7 +648,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -663,7 +663,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -675,7 +675,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -691,7 +691,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -705,7 +705,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -720,7 +720,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -735,7 +735,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -756,7 +756,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro}
+#### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -768,7 +768,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -786,7 +786,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease}
+#### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -798,7 +798,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -810,7 +810,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -825,7 +825,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -840,7 +840,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -855,7 +855,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -870,7 +870,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -885,7 +885,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -903,7 +903,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-values}
 
 the values for the given chart
 
@@ -921,7 +921,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint}
+#### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -934,7 +934,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -946,7 +946,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -969,7 +969,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-forwardToken}
+#### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -985,7 +985,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate}
+#### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -997,7 +997,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
 
 
 
@@ -1009,7 +1009,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1024,7 +1024,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1042,7 +1042,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -1057,7 +1057,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1069,7 +1069,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -1084,7 +1084,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -1099,7 +1099,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -1114,7 +1114,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -1129,7 +1129,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1141,7 +1141,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1153,7 +1153,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1168,7 +1168,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1183,7 +1183,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1204,7 +1204,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -1219,7 +1219,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1231,7 +1231,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1243,7 +1243,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1258,7 +1258,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1273,7 +1273,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1294,7 +1294,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1309,7 +1309,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1324,7 +1324,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1339,7 +1339,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1354,7 +1354,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1369,7 +1369,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1387,7 +1387,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -1399,7 +1399,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -1414,7 +1414,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1430,7 +1430,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1445,7 +1445,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -1460,7 +1460,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1475,7 +1475,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -1499,7 +1499,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -1511,7 +1511,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
+#### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -1526,7 +1526,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
+#### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -1541,7 +1541,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -1556,7 +1556,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
+#### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -1572,7 +1572,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
+#### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -1587,7 +1587,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
+#### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -1602,7 +1602,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
+#### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -1617,7 +1617,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
+#### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -1632,7 +1632,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
+#### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -1647,7 +1647,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
+#### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -1662,7 +1662,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
+#### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -1677,7 +1677,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
+#### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -1692,7 +1692,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
+#### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -1710,7 +1710,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `versions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
+### `versions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
 
 Versions are different versions of the template that can be referenced as well
 
@@ -1722,7 +1722,7 @@ Versions are different versions of the template that can be referenced as well
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template}
+#### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template}
 
 Template holds the space template
 
@@ -1734,7 +1734,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
 
 
 
@@ -1746,7 +1746,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -1761,7 +1761,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1779,7 +1779,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -1791,7 +1791,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -1803,7 +1803,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1818,7 +1818,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1839,7 +1839,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -1851,7 +1851,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-name}
 
 Name of the target app
 
@@ -1866,7 +1866,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1882,7 +1882,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1897,7 +1897,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-version}
 
 Version of the app
 
@@ -1912,7 +1912,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1927,7 +1927,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -1945,7 +1945,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1957,7 +1957,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -1972,7 +1972,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -1987,7 +1987,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -2002,7 +2002,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-username}
 
 The username that is required for this repository
 
@@ -2017,7 +2017,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -2029,7 +2029,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2041,7 +2041,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2056,7 +2056,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2071,7 +2071,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2092,7 +2092,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-password}
 
 The password that is required for this repository
 
@@ -2107,7 +2107,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -2119,7 +2119,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2131,7 +2131,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2146,7 +2146,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2161,7 +2161,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2182,7 +2182,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -2197,7 +2197,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -2212,7 +2212,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -2227,7 +2227,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -2242,7 +2242,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -2257,7 +2257,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -2275,7 +2275,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -2290,7 +2290,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -2302,7 +2302,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -2318,7 +2318,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -2332,7 +2332,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -2347,7 +2347,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -2362,7 +2362,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -2383,7 +2383,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-pro}
+##### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -2395,7 +2395,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -2413,7 +2413,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease}
+##### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -2425,7 +2425,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -2437,7 +2437,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -2452,7 +2452,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -2467,7 +2467,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -2482,7 +2482,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -2497,7 +2497,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -2512,7 +2512,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -2530,7 +2530,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-values}
 
 the values for the given chart
 
@@ -2548,7 +2548,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint}
+##### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -2561,7 +2561,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -2573,7 +2573,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -2596,7 +2596,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-forwardToken}
+##### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -2612,7 +2612,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate}
+##### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -2624,7 +2624,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata}
 
 
 
@@ -2636,7 +2636,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -2651,7 +2651,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -2669,7 +2669,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -2684,7 +2684,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -2696,7 +2696,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -2711,7 +2711,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -2726,7 +2726,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -2741,7 +2741,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -2756,7 +2756,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -2768,7 +2768,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2780,7 +2780,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2795,7 +2795,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2810,7 +2810,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2831,7 +2831,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -2846,7 +2846,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -2858,7 +2858,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2870,7 +2870,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2885,7 +2885,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2900,7 +2900,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2921,7 +2921,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -2936,7 +2936,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -2951,7 +2951,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -2966,7 +2966,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -2981,7 +2981,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -2996,7 +2996,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -3014,7 +3014,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -3026,7 +3026,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -3041,7 +3041,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -3057,7 +3057,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -3072,7 +3072,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -3087,7 +3087,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -3102,7 +3102,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -3126,7 +3126,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -3138,7 +3138,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -3153,7 +3153,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -3168,7 +3168,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -3183,7 +3183,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -3199,7 +3199,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -3214,7 +3214,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -3229,7 +3229,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -3244,7 +3244,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -3259,7 +3259,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -3274,7 +3274,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -3289,7 +3289,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -3304,7 +3304,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -3319,7 +3319,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -3337,7 +3337,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
 
 Version is the version. Needs to be in X.X.X format.
 
@@ -3355,7 +3355,7 @@ Version is the version. Needs to be in X.X.X format.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -3367,7 +3367,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -3397,7 +3397,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -3412,7 +3412,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -3427,7 +3427,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -3445,7 +3445,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spaceTemplateRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-spaceTemplateRef}
+### `spaceTemplateRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-spaceTemplateRef}
 
 DEPRECATED: SpaceTemplate to use to create the tenant cluster space if it does not exist
 
@@ -3457,7 +3457,7 @@ DEPRECATED: SpaceTemplate to use to create the tenant cluster space if it does n
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-spaceTemplateRef-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-spaceTemplateRef-name}
 
 Name of the space template
 
@@ -3478,7 +3478,7 @@ Name of the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/apps/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/apps/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes an app
 
@@ -50,7 +50,7 @@ Description describes an app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
+### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
 
 Clusters are the clusters this app can be installed in.
 
@@ -110,7 +110,7 @@ Clusters are the clusters this app can be installed in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `recommendedApp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-recommendedApp}
+### `recommendedApp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-recommendedApp}
 
 RecommendedApp specifies where this app should show up as recommended app
 
@@ -125,7 +125,7 @@ RecommendedApp specifies where this app should show up as recommended app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-defaultNamespace}
+### `defaultNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-defaultNamespace}
 
 DefaultNamespace is the default namespace this app should installed
 in.
@@ -141,7 +141,7 @@ in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `readme` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-readme}
+### `readme` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-readme}
 
 Readme is a longer markdown string that describes the app.
 
@@ -156,7 +156,7 @@ Readme is a longer markdown string that describes the app.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-icon}
+### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-icon}
 
 Icon holds an URL to the app icon
 
@@ -171,7 +171,7 @@ Icon holds an URL to the app icon
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config}
+### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config}
 
 Config is the helm config to use to deploy the helm release
 
@@ -183,7 +183,7 @@ Config is the helm config to use to deploy the helm release
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart}
+#### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart}
 
 Chart holds information about a chart that should get deployed
 
@@ -195,7 +195,7 @@ Chart holds information about a chart that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-name}
 
 Name is the chart name in the repository
 
@@ -210,7 +210,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-version}
 
 Version is the chart version in the repository
 
@@ -225,7 +225,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -240,7 +240,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-username}
 
 The username that is required for this repository
 
@@ -255,7 +255,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef}
 
 The username that is required for this repository
 
@@ -267,7 +267,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -279,7 +279,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -294,7 +294,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -309,7 +309,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -330,7 +330,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-password}
 
 The password that is required for this repository
 
@@ -345,7 +345,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef}
 
 The password that is required for this repository
 
@@ -357,7 +357,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -369,7 +369,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -384,7 +384,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -399,7 +399,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -420,7 +420,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -438,7 +438,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-manifests}
+#### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-manifests}
 
 Manifests holds kube manifests that will be deployed as a chart
 
@@ -453,7 +453,7 @@ Manifests holds kube manifests that will be deployed as a chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `bash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash}
+#### `bash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash}
 
 Bash holds the bash script to execute in a container in the target
 
@@ -465,7 +465,7 @@ Bash holds the bash script to execute in a container in the target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `script` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-script}
+##### `script` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-script}
 
 Script is the script to execute.
 
@@ -480,7 +480,7 @@ Script is the script to execute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-image}
 
 Image is the image to use for this app
 
@@ -495,7 +495,7 @@ Image is the image to use for this app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-clusterRole}
 
 ClusterRole is the cluster role to use for this job
 
@@ -510,7 +510,7 @@ ClusterRole is the cluster role to use for this job
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext}
 
 PodSecurityContext for the bash pod.
 
@@ -522,7 +522,7 @@ PodSecurityContext for the bash pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seLinuxOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions}
+##### `seLinuxOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions}
 
 The SELinux context to be applied to all containers.
 If unspecified, the container runtime will allocate a random SELinux context for each
@@ -539,7 +539,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-user}
 
 User is a SELinux user label that applies to the container.
 
@@ -554,7 +554,7 @@ User is a SELinux user label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-role}
 
 Role is a SELinux role label that applies to the container.
 
@@ -569,7 +569,7 @@ Role is a SELinux role label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-type}
 
 Type is a SELinux type label that applies to the container.
 
@@ -584,7 +584,7 @@ Type is a SELinux type label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-level}
+##### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxOptions-level}
 
 Level is SELinux level label that applies to the container.
 
@@ -602,7 +602,7 @@ Level is SELinux level label that applies to the container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `windowsOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions}
+##### `windowsOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions}
 
 The Windows specific settings applied to all containers.
 If unspecified, the options within a container's SecurityContext will be used.
@@ -617,7 +617,7 @@ Note that this field cannot be set when spec.os.name is linux.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpecName}
+##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpecName}
 
 GMSACredentialSpecName is the name of the GMSA credential spec to use.
 
@@ -632,7 +632,7 @@ GMSACredentialSpecName is the name of the GMSA credential spec to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpec}
+##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpec}
 
 GMSACredentialSpec is where the GMSA admission webhook
 (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
@@ -649,7 +649,7 @@ GMSA credential spec named by the GMSACredentialSpecName field.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUserName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-runAsUserName}
+##### `runAsUserName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-runAsUserName}
 
 The UserName in Windows to run the entrypoint of the container process.
 Defaults to the user specified in image metadata if unspecified.
@@ -667,7 +667,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostProcess` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-hostProcess}
+##### `hostProcess` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-windowsOptions-hostProcess}
 
 HostProcess determines if a container should be run as a 'Host Process' container.
 All of a Pod's containers must have the same effective HostProcess value
@@ -688,7 +688,7 @@ In addition, if HostProcess is true then HostNetwork must also be set to true.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUser` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsUser}
+##### `runAsUser` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsUser}
 
 The UID to run the entrypoint of the container process.
 Defaults to user specified in image metadata if unspecified.
@@ -708,7 +708,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsGroup}
+##### `runAsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsGroup}
 
 The GID to run the entrypoint of the container process.
 Uses runtime default if unset.
@@ -728,7 +728,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsNonRoot` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsNonRoot}
+##### `runAsNonRoot` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-runAsNonRoot}
 
 Indicates that the container must run as a non-root user.
 If true, the Kubelet will validate the image at runtime to ensure that it
@@ -748,7 +748,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `supplementalGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-supplementalGroups}
+##### `supplementalGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-supplementalGroups}
 
 A list of groups applied to the first process run in each container, in
 addition to the container's primary GID and fsGroup (if specified).  If
@@ -771,7 +771,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `supplementalGroupsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-supplementalGroupsPolicy}
+##### `supplementalGroupsPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-supplementalGroupsPolicy}
 
 Defines how supplemental groups of the first container processes are calculated.
 Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
@@ -791,7 +791,7 @@ TODO: update the default value to "Merge" when spec.os.name is not windows in v1
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-fsGroup}
+##### `fsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-fsGroup}
 
 A special supplemental group that applies to all containers in a pod.
 Some volume types allow the Kubelet to change the ownership of that volume
@@ -815,7 +815,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sysctls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-sysctls}
+##### `sysctls` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-sysctls}
 
 Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
 sysctls (by the container runtime) might fail to launch.
@@ -862,7 +862,7 @@ Value of a property to set
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fsGroupChangePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-fsGroupChangePolicy}
+##### `fsGroupChangePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-fsGroupChangePolicy}
 
 fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
 before being exposed inside Pod. This field will only apply to
@@ -883,7 +883,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seccompProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seccompProfile}
+##### `seccompProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seccompProfile}
 
 The seccomp options to use by the containers in this pod.
 Note that this field cannot be set when spec.os.name is windows.
@@ -916,7 +916,7 @@ Unconfined - no profile should be applied.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seccompProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seccompProfile-localhostProfile}
 
 localhostProfile indicates a profile defined in a file on the node should be used.
 The profile must be preconfigured on the node to work.
@@ -937,7 +937,7 @@ Must be set if type is "Localhost". Must NOT be set for any other type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `appArmorProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-appArmorProfile}
+##### `appArmorProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-appArmorProfile}
 
 appArmorProfile is the AppArmor options to use by the containers in this pod.
 Note that this field cannot be set when spec.os.name is windows.
@@ -969,7 +969,7 @@ Valid options are:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-appArmorProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-appArmorProfile-localhostProfile}
 
 localhostProfile indicates a profile loaded on the node that should be used.
 The profile must be preconfigured on the node to work.
@@ -990,7 +990,7 @@ Must be set if and only if type is "Localhost".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `seLinuxChangePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxChangePolicy}
+##### `seLinuxChangePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-podSecurityContext-seLinuxChangePolicy}
 
 seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
 It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
@@ -1030,7 +1030,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext}
 
 SecurityContext for the bash container.
 
@@ -1042,7 +1042,7 @@ SecurityContext for the bash container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities}
 
 The capabilities to add/drop when running containers.
 Defaults to the default set of capabilities granted by the container runtime.
@@ -1056,7 +1056,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `add` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities-add}
+##### `add` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities-add}
 
 Added capabilities
 
@@ -1071,7 +1071,7 @@ Added capabilities
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `drop` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities-drop}
+##### `drop` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-capabilities-drop}
 
 Removed capabilities
 
@@ -1089,7 +1089,7 @@ Removed capabilities
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `privileged` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-privileged}
+##### `privileged` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-privileged}
 
 Run container in privileged mode.
 Processes in privileged containers are essentially equivalent to root on the host.
@@ -1107,7 +1107,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seLinuxOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions}
+##### `seLinuxOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions}
 
 The SELinux context to be applied to the container.
 If unspecified, the container runtime will allocate a random SELinux context for each
@@ -1123,7 +1123,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-user}
 
 User is a SELinux user label that applies to the container.
 
@@ -1138,7 +1138,7 @@ User is a SELinux user label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-role}
 
 Role is a SELinux role label that applies to the container.
 
@@ -1153,7 +1153,7 @@ Role is a SELinux role label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-type}
 
 Type is a SELinux type label that applies to the container.
 
@@ -1168,7 +1168,7 @@ Type is a SELinux type label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-level}
+##### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seLinuxOptions-level}
 
 Level is SELinux level label that applies to the container.
 
@@ -1186,7 +1186,7 @@ Level is SELinux level label that applies to the container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `windowsOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions}
+##### `windowsOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions}
 
 The Windows specific settings applied to all containers.
 If unspecified, the options from the PodSecurityContext will be used.
@@ -1201,7 +1201,7 @@ Note that this field cannot be set when spec.os.name is linux.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-gmsaCredentialSpecName}
+##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-gmsaCredentialSpecName}
 
 GMSACredentialSpecName is the name of the GMSA credential spec to use.
 
@@ -1216,7 +1216,7 @@ GMSACredentialSpecName is the name of the GMSA credential spec to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-gmsaCredentialSpec}
+##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-gmsaCredentialSpec}
 
 GMSACredentialSpec is where the GMSA admission webhook
 (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
@@ -1233,7 +1233,7 @@ GMSA credential spec named by the GMSACredentialSpecName field.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUserName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-runAsUserName}
+##### `runAsUserName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-runAsUserName}
 
 The UserName in Windows to run the entrypoint of the container process.
 Defaults to the user specified in image metadata if unspecified.
@@ -1251,7 +1251,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostProcess` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-hostProcess}
+##### `hostProcess` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-windowsOptions-hostProcess}
 
 HostProcess determines if a container should be run as a 'Host Process' container.
 All of a Pod's containers must have the same effective HostProcess value
@@ -1272,7 +1272,7 @@ In addition, if HostProcess is true then HostNetwork must also be set to true.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUser` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsUser}
+##### `runAsUser` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsUser}
 
 The UID to run the entrypoint of the container process.
 Defaults to user specified in image metadata if unspecified.
@@ -1291,7 +1291,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsGroup}
+##### `runAsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsGroup}
 
 The GID to run the entrypoint of the container process.
 Uses runtime default if unset.
@@ -1310,7 +1310,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsNonRoot` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsNonRoot}
+##### `runAsNonRoot` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-runAsNonRoot}
 
 Indicates that the container must run as a non-root user.
 If true, the Kubelet will validate the image at runtime to ensure that it
@@ -1330,7 +1330,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnlyRootFilesystem` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-readOnlyRootFilesystem}
+##### `readOnlyRootFilesystem` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-readOnlyRootFilesystem}
 
 Whether this container has a read-only root filesystem.
 Default is false.
@@ -1347,7 +1347,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowPrivilegeEscalation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-allowPrivilegeEscalation}
+##### `allowPrivilegeEscalation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-allowPrivilegeEscalation}
 
 AllowPrivilegeEscalation controls whether a process can gain more
 privileges than its parent process. This bool directly controls if
@@ -1368,7 +1368,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `procMount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-procMount}
+##### `procMount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-procMount}
 
 procMount denotes the type of proc mount to use for the containers.
 The default value is Default which uses the container runtime defaults for
@@ -1386,7 +1386,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seccompProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seccompProfile}
+##### `seccompProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seccompProfile}
 
 The seccomp options to use by this container. If seccomp options are
 provided at both the pod & container level, the container options
@@ -1421,7 +1421,7 @@ Unconfined - no profile should be applied.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seccompProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-seccompProfile-localhostProfile}
 
 localhostProfile indicates a profile defined in a file on the node should be used.
 The profile must be preconfigured on the node to work.
@@ -1442,7 +1442,7 @@ Must be set if type is "Localhost". Must NOT be set for any other type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `appArmorProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-appArmorProfile}
+##### `appArmorProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-appArmorProfile}
 
 appArmorProfile is the AppArmor options to use by this container. If set, this profile
 overrides the pod's appArmorProfile.
@@ -1475,7 +1475,7 @@ Valid options are:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-appArmorProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-bash-securityContext-appArmorProfile-localhostProfile}
 
 localhostProfile indicates a profile loaded on the node that should be used.
 The profile must be preconfigured on the node to work.
@@ -1502,7 +1502,7 @@ Must be set if and only if type is "Localhost".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-values}
+#### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-values}
 
 Values is the set of extra Values added to the chart.
 These values merge with the default values inside of the chart.
@@ -1519,7 +1519,7 @@ You can use golang templating in here with values from parameters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-parameters}
 
 Parameters are additional helm chart values that will get merged
 with config and are then used to deploy the helm chart.
@@ -1535,7 +1535,7 @@ with config and are then used to deploy the helm chart.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-annotations}
 
 Annotations are extra annotations for this helm release
 
@@ -1553,7 +1553,7 @@ Annotations are extra annotations for this helm release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-wait}
+### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1568,7 +1568,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-timeout}
+### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1583,7 +1583,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -1595,7 +1595,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
+#### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -1610,7 +1610,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
+#### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -1625,7 +1625,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -1640,7 +1640,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
+#### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -1656,7 +1656,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
+#### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -1671,7 +1671,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
+#### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -1686,7 +1686,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
+#### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -1701,7 +1701,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
+#### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -1716,7 +1716,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
+#### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -1731,7 +1731,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
+#### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -1746,7 +1746,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
+#### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -1761,7 +1761,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
+#### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -1776,7 +1776,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
+#### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -1794,7 +1794,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `streamContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer}
+### `streamContainer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer}
 
 DEPRECATED: Use config.bash instead
 StreamContainer can be used to stream a containers logs instead of the helm output.
@@ -1807,7 +1807,7 @@ StreamContainer can be used to stream a containers logs instead of the helm outp
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector}
 
 Label selector for pods. The newest matching pod will be used to stream logs from
 
@@ -1819,7 +1819,7 @@ Label selector for pods. The newest matching pod will be used to stream logs fro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchLabels}
 
 matchLabels is a map of &#123;key,value&#125; pairs. A single &#123;key,value&#125; in the matchLabels
 map is equivalent to an element of matchExpressions, whose key field is "key", the
@@ -1836,7 +1836,7 @@ operator is "In", and the values array contains only "value". The requirements a
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchExpressions}
 
 matchExpressions is a list of label selector requirements. The requirements are ANDed.
 
@@ -1879,7 +1879,7 @@ Valid operators are In, NotIn, Exists and DoesNotExist.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchExpressions-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-selector-matchExpressions-values}
 
 values is an array of string values. If the operator is In or NotIn,
 the values array must be non-empty. If the operator is Exists or DoesNotExist,
@@ -1903,7 +1903,7 @@ merge patch.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `container` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-container}
+#### `container` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-streamContainer-container}
 
 Container is the container name to use
 
@@ -1921,7 +1921,7 @@ Container is the container name to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `versions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
+### `versions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
 
 Versions are different app versions that can be referenced
 
@@ -1933,7 +1933,7 @@ Versions are different app versions that can be referenced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-defaultNamespace}
+#### `defaultNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-defaultNamespace}
 
 DefaultNamespace is the default namespace this app should installed
 in.
@@ -1949,7 +1949,7 @@ in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `readme` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-readme}
+#### `readme` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-readme}
 
 Readme is a longer markdown string that describes the app.
 
@@ -1964,7 +1964,7 @@ Readme is a longer markdown string that describes the app.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-icon}
 
 Icon holds an URL to the app icon
 
@@ -1979,7 +1979,7 @@ Icon holds an URL to the app icon
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config}
+#### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config}
 
 Config is the helm config to use to deploy the helm release
 
@@ -1991,7 +1991,7 @@ Config is the helm config to use to deploy the helm release
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart}
 
 Chart holds information about a chart that should get deployed
 
@@ -2003,7 +2003,7 @@ Chart holds information about a chart that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-name}
 
 Name is the chart name in the repository
 
@@ -2018,7 +2018,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-version}
 
 Version is the chart version in the repository
 
@@ -2033,7 +2033,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -2048,7 +2048,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-username}
 
 The username that is required for this repository
 
@@ -2063,7 +2063,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef}
 
 The username that is required for this repository
 
@@ -2075,7 +2075,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2087,7 +2087,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2102,7 +2102,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2117,7 +2117,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2138,7 +2138,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-password}
 
 The password that is required for this repository
 
@@ -2153,7 +2153,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef}
 
 The password that is required for this repository
 
@@ -2165,7 +2165,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2177,7 +2177,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2192,7 +2192,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2207,7 +2207,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2228,7 +2228,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -2246,7 +2246,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-manifests}
+##### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-manifests}
 
 Manifests holds kube manifests that will be deployed as a chart
 
@@ -2261,7 +2261,7 @@ Manifests holds kube manifests that will be deployed as a chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `bash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash}
+##### `bash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash}
 
 Bash holds the bash script to execute in a container in the target
 
@@ -2273,7 +2273,7 @@ Bash holds the bash script to execute in a container in the target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `script` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-script}
+##### `script` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-script}
 
 Script is the script to execute.
 
@@ -2288,7 +2288,7 @@ Script is the script to execute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-image}
 
 Image is the image to use for this app
 
@@ -2303,7 +2303,7 @@ Image is the image to use for this app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-clusterRole}
 
 ClusterRole is the cluster role to use for this job
 
@@ -2318,7 +2318,7 @@ ClusterRole is the cluster role to use for this job
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext}
 
 PodSecurityContext for the bash pod.
 
@@ -2330,7 +2330,7 @@ PodSecurityContext for the bash pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seLinuxOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions}
+##### `seLinuxOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions}
 
 The SELinux context to be applied to all containers.
 If unspecified, the container runtime will allocate a random SELinux context for each
@@ -2347,7 +2347,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-user}
 
 User is a SELinux user label that applies to the container.
 
@@ -2362,7 +2362,7 @@ User is a SELinux user label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-role}
 
 Role is a SELinux role label that applies to the container.
 
@@ -2377,7 +2377,7 @@ Role is a SELinux role label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-type}
 
 Type is a SELinux type label that applies to the container.
 
@@ -2392,7 +2392,7 @@ Type is a SELinux type label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-level}
+##### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxOptions-level}
 
 Level is SELinux level label that applies to the container.
 
@@ -2410,7 +2410,7 @@ Level is SELinux level label that applies to the container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `windowsOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions}
+##### `windowsOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions}
 
 The Windows specific settings applied to all containers.
 If unspecified, the options within a container's SecurityContext will be used.
@@ -2425,7 +2425,7 @@ Note that this field cannot be set when spec.os.name is linux.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpecName}
+##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpecName}
 
 GMSACredentialSpecName is the name of the GMSA credential spec to use.
 
@@ -2440,7 +2440,7 @@ GMSACredentialSpecName is the name of the GMSA credential spec to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpec}
+##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-gmsaCredentialSpec}
 
 GMSACredentialSpec is where the GMSA admission webhook
 (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
@@ -2457,7 +2457,7 @@ GMSA credential spec named by the GMSACredentialSpecName field.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUserName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-runAsUserName}
+##### `runAsUserName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-runAsUserName}
 
 The UserName in Windows to run the entrypoint of the container process.
 Defaults to the user specified in image metadata if unspecified.
@@ -2475,7 +2475,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostProcess` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-hostProcess}
+##### `hostProcess` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-windowsOptions-hostProcess}
 
 HostProcess determines if a container should be run as a 'Host Process' container.
 All of a Pod's containers must have the same effective HostProcess value
@@ -2496,7 +2496,7 @@ In addition, if HostProcess is true then HostNetwork must also be set to true.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUser` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsUser}
+##### `runAsUser` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsUser}
 
 The UID to run the entrypoint of the container process.
 Defaults to user specified in image metadata if unspecified.
@@ -2516,7 +2516,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsGroup}
+##### `runAsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsGroup}
 
 The GID to run the entrypoint of the container process.
 Uses runtime default if unset.
@@ -2536,7 +2536,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsNonRoot` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsNonRoot}
+##### `runAsNonRoot` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-runAsNonRoot}
 
 Indicates that the container must run as a non-root user.
 If true, the Kubelet will validate the image at runtime to ensure that it
@@ -2556,7 +2556,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `supplementalGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-supplementalGroups}
+##### `supplementalGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-supplementalGroups}
 
 A list of groups applied to the first process run in each container, in
 addition to the container's primary GID and fsGroup (if specified).  If
@@ -2579,7 +2579,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `supplementalGroupsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-supplementalGroupsPolicy}
+##### `supplementalGroupsPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-supplementalGroupsPolicy}
 
 Defines how supplemental groups of the first container processes are calculated.
 Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
@@ -2599,7 +2599,7 @@ TODO: update the default value to "Merge" when spec.os.name is not windows in v1
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-fsGroup}
+##### `fsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-fsGroup}
 
 A special supplemental group that applies to all containers in a pod.
 Some volume types allow the Kubelet to change the ownership of that volume
@@ -2623,7 +2623,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sysctls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-sysctls}
+##### `sysctls` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-sysctls}
 
 Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
 sysctls (by the container runtime) might fail to launch.
@@ -2670,7 +2670,7 @@ Value of a property to set
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fsGroupChangePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-fsGroupChangePolicy}
+##### `fsGroupChangePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-fsGroupChangePolicy}
 
 fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
 before being exposed inside Pod. This field will only apply to
@@ -2691,7 +2691,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seccompProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seccompProfile}
+##### `seccompProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seccompProfile}
 
 The seccomp options to use by the containers in this pod.
 Note that this field cannot be set when spec.os.name is windows.
@@ -2724,7 +2724,7 @@ Unconfined - no profile should be applied.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seccompProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seccompProfile-localhostProfile}
 
 localhostProfile indicates a profile defined in a file on the node should be used.
 The profile must be preconfigured on the node to work.
@@ -2745,7 +2745,7 @@ Must be set if type is "Localhost". Must NOT be set for any other type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `appArmorProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-appArmorProfile}
+##### `appArmorProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-appArmorProfile}
 
 appArmorProfile is the AppArmor options to use by the containers in this pod.
 Note that this field cannot be set when spec.os.name is windows.
@@ -2777,7 +2777,7 @@ Valid options are:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-appArmorProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-appArmorProfile-localhostProfile}
 
 localhostProfile indicates a profile loaded on the node that should be used.
 The profile must be preconfigured on the node to work.
@@ -2798,7 +2798,7 @@ Must be set if and only if type is "Localhost".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `seLinuxChangePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxChangePolicy}
+##### `seLinuxChangePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-podSecurityContext-seLinuxChangePolicy}
 
 seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
 It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
@@ -2838,7 +2838,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext}
 
 SecurityContext for the bash container.
 
@@ -2850,7 +2850,7 @@ SecurityContext for the bash container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities}
 
 The capabilities to add/drop when running containers.
 Defaults to the default set of capabilities granted by the container runtime.
@@ -2864,7 +2864,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `add` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities-add}
+##### `add` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities-add}
 
 Added capabilities
 
@@ -2879,7 +2879,7 @@ Added capabilities
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `drop` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities-drop}
+##### `drop` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-capabilities-drop}
 
 Removed capabilities
 
@@ -2897,7 +2897,7 @@ Removed capabilities
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `privileged` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-privileged}
+##### `privileged` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-privileged}
 
 Run container in privileged mode.
 Processes in privileged containers are essentially equivalent to root on the host.
@@ -2915,7 +2915,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seLinuxOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions}
+##### `seLinuxOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions}
 
 The SELinux context to be applied to the container.
 If unspecified, the container runtime will allocate a random SELinux context for each
@@ -2931,7 +2931,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-user}
 
 User is a SELinux user label that applies to the container.
 
@@ -2946,7 +2946,7 @@ User is a SELinux user label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-role}
 
 Role is a SELinux role label that applies to the container.
 
@@ -2961,7 +2961,7 @@ Role is a SELinux role label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-type}
 
 Type is a SELinux type label that applies to the container.
 
@@ -2976,7 +2976,7 @@ Type is a SELinux type label that applies to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-level}
+##### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seLinuxOptions-level}
 
 Level is SELinux level label that applies to the container.
 
@@ -2994,7 +2994,7 @@ Level is SELinux level label that applies to the container.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `windowsOptions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions}
+##### `windowsOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions}
 
 The Windows specific settings applied to all containers.
 If unspecified, the options from the PodSecurityContext will be used.
@@ -3009,7 +3009,7 @@ Note that this field cannot be set when spec.os.name is linux.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-gmsaCredentialSpecName}
+##### `gmsaCredentialSpecName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-gmsaCredentialSpecName}
 
 GMSACredentialSpecName is the name of the GMSA credential spec to use.
 
@@ -3024,7 +3024,7 @@ GMSACredentialSpecName is the name of the GMSA credential spec to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-gmsaCredentialSpec}
+##### `gmsaCredentialSpec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-gmsaCredentialSpec}
 
 GMSACredentialSpec is where the GMSA admission webhook
 (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
@@ -3041,7 +3041,7 @@ GMSA credential spec named by the GMSACredentialSpecName field.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUserName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-runAsUserName}
+##### `runAsUserName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-runAsUserName}
 
 The UserName in Windows to run the entrypoint of the container process.
 Defaults to the user specified in image metadata if unspecified.
@@ -3059,7 +3059,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostProcess` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-hostProcess}
+##### `hostProcess` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-windowsOptions-hostProcess}
 
 HostProcess determines if a container should be run as a 'Host Process' container.
 All of a Pod's containers must have the same effective HostProcess value
@@ -3080,7 +3080,7 @@ In addition, if HostProcess is true then HostNetwork must also be set to true.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsUser` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsUser}
+##### `runAsUser` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsUser}
 
 The UID to run the entrypoint of the container process.
 Defaults to user specified in image metadata if unspecified.
@@ -3099,7 +3099,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsGroup}
+##### `runAsGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsGroup}
 
 The GID to run the entrypoint of the container process.
 Uses runtime default if unset.
@@ -3118,7 +3118,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runAsNonRoot` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsNonRoot}
+##### `runAsNonRoot` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-runAsNonRoot}
 
 Indicates that the container must run as a non-root user.
 If true, the Kubelet will validate the image at runtime to ensure that it
@@ -3138,7 +3138,7 @@ PodSecurityContext, the value specified in SecurityContext takes precedence.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnlyRootFilesystem` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-readOnlyRootFilesystem}
+##### `readOnlyRootFilesystem` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-readOnlyRootFilesystem}
 
 Whether this container has a read-only root filesystem.
 Default is false.
@@ -3155,7 +3155,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowPrivilegeEscalation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-allowPrivilegeEscalation}
+##### `allowPrivilegeEscalation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-allowPrivilegeEscalation}
 
 AllowPrivilegeEscalation controls whether a process can gain more
 privileges than its parent process. This bool directly controls if
@@ -3176,7 +3176,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `procMount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-procMount}
+##### `procMount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-procMount}
 
 procMount denotes the type of proc mount to use for the containers.
 The default value is Default which uses the container runtime defaults for
@@ -3194,7 +3194,7 @@ Note that this field cannot be set when spec.os.name is windows.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `seccompProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seccompProfile}
+##### `seccompProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seccompProfile}
 
 The seccomp options to use by this container. If seccomp options are
 provided at both the pod & container level, the container options
@@ -3229,7 +3229,7 @@ Unconfined - no profile should be applied.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seccompProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-seccompProfile-localhostProfile}
 
 localhostProfile indicates a profile defined in a file on the node should be used.
 The profile must be preconfigured on the node to work.
@@ -3250,7 +3250,7 @@ Must be set if type is "Localhost". Must NOT be set for any other type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `appArmorProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-appArmorProfile}
+##### `appArmorProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-appArmorProfile}
 
 appArmorProfile is the AppArmor options to use by this container. If set, this profile
 overrides the pod's appArmorProfile.
@@ -3283,7 +3283,7 @@ Valid options are:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `localhostProfile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-appArmorProfile-localhostProfile}
+##### `localhostProfile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-bash-securityContext-appArmorProfile-localhostProfile}
 
 localhostProfile indicates a profile loaded on the node that should be used.
 The profile must be preconfigured on the node to work.
@@ -3310,7 +3310,7 @@ Must be set if and only if type is "Localhost".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-values}
 
 Values is the set of extra Values added to the chart.
 These values merge with the default values inside of the chart.
@@ -3327,7 +3327,7 @@ You can use golang templating in here with values from parameters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-parameters}
 
 Parameters are additional helm chart values that will get merged
 with config and are then used to deploy the helm chart.
@@ -3343,7 +3343,7 @@ with config and are then used to deploy the helm chart.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-annotations}
 
 Annotations are extra annotations for this helm release
 
@@ -3361,7 +3361,7 @@ Annotations are extra annotations for this helm release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-wait}
+#### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -3376,7 +3376,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-timeout}
+#### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -3391,7 +3391,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -3403,7 +3403,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -3418,7 +3418,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -3433,7 +3433,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -3448,7 +3448,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -3464,7 +3464,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -3479,7 +3479,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -3494,7 +3494,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -3509,7 +3509,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -3524,7 +3524,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -3539,7 +3539,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -3554,7 +3554,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -3569,7 +3569,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -3584,7 +3584,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -3602,7 +3602,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `streamContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer}
+#### `streamContainer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer}
 
 DEPRECATED: Use config.bash instead
 StreamContainer can be used to stream a containers logs instead of the helm output.
@@ -3615,7 +3615,7 @@ StreamContainer can be used to stream a containers logs instead of the helm outp
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector}
 
 Label selector for pods. The newest matching pod will be used to stream logs from
 
@@ -3627,7 +3627,7 @@ Label selector for pods. The newest matching pod will be used to stream logs fro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchLabels}
 
 matchLabels is a map of &#123;key,value&#125; pairs. A single &#123;key,value&#125; in the matchLabels
 map is equivalent to an element of matchExpressions, whose key field is "key", the
@@ -3644,7 +3644,7 @@ operator is "In", and the values array contains only "value". The requirements a
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchExpressions}
 
 matchExpressions is a list of label selector requirements. The requirements are ANDed.
 
@@ -3687,7 +3687,7 @@ Valid operators are In, NotIn, Exists and DoesNotExist.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchExpressions-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-selector-matchExpressions-values}
 
 values is an array of string values. If the operator is In or NotIn,
 the values array must be non-empty. If the operator is Exists or DoesNotExist,
@@ -3711,7 +3711,7 @@ merge patch.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `container` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-container}
+##### `container` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-streamContainer-container}
 
 Container is the container name to use
 
@@ -3729,7 +3729,7 @@ Container is the container name to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
 
 Version is the version. Needs to be in X.X.X format.
 
@@ -3747,7 +3747,7 @@ Version is the version. Needs to be in X.X.X format.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -3759,7 +3759,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -3789,7 +3789,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -3804,7 +3804,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -3819,7 +3819,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -3837,7 +3837,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-manifests}
+### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-manifests}
 
 DEPRECATED: Use config instead
 manifest represents kubernetes resources that will be deployed into the target namespace
@@ -3853,7 +3853,7 @@ manifest represents kubernetes resources that will be deployed into the target n
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm}
+### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm}
 
 DEPRECATED: Use config instead
 helm defines the configuration for a helm deployment
@@ -3881,7 +3881,7 @@ Name of the chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-values}
+#### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-values}
 
 The additional helm values to use. Expected block string
 
@@ -3896,7 +3896,7 @@ The additional helm values to use. Expected block string
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-version}
 
 Version is the version of the chart to deploy
 
@@ -3911,7 +3911,7 @@ Version is the version of the chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repoUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-repoUrl}
+#### `repoUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-repoUrl}
 
 The repo url to use
 
@@ -3926,7 +3926,7 @@ The repo url to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-username}
 
 The username to use for the selected repository
 
@@ -3941,7 +3941,7 @@ The username to use for the selected repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-password}
+#### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-password}
 
 The password to use for the selected repository
 
@@ -3956,7 +3956,7 @@ The password to use for the selected repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-insecure}
+#### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-helm-insecure}
 
 Determines if the remote location uses an insecure
 TLS certificate.
@@ -3978,7 +3978,7 @@ TLS certificate.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/apps/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/apps/reference.mdx
@@ -195,7 +195,7 @@ Chart holds information about a chart that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-chart-name}
 
 Name is the chart name in the repository
 
@@ -2003,7 +2003,7 @@ Chart holds information about a chart that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-config-chart-name}
 
 Name is the chart name in the repository
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusteraccesses/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusteraccesses/reference.mdx
@@ -200,7 +200,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `localClusterAccessTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate}
+### `localClusterAccessTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate}
 
 LocalClusterAccessTemplate holds the cluster access template
 
@@ -640,7 +640,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -655,7 +655,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -671,7 +671,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -708,7 +708,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -739,7 +739,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusteraccesses/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusteraccesses/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a cluster access object
 
@@ -50,7 +50,7 @@ Description describes a cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
+### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
 
 Clusters are the clusters this template should be applied on.
 
@@ -110,7 +110,7 @@ Clusters are the clusters this template should be applied on.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -122,7 +122,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -152,7 +152,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -167,7 +167,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -182,7 +182,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -200,7 +200,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `localClusterAccessTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate}
+### `localClusterAccessTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate}
 
 LocalClusterAccessTemplate holds the cluster access template
 
@@ -212,7 +212,7 @@ LocalClusterAccessTemplate holds the cluster access template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata}
 
 Metadata is the metadata of the cluster access object
 
@@ -224,7 +224,7 @@ Metadata is the metadata of the cluster access object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -244,7 +244,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-generateName}
+##### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -270,7 +270,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -292,7 +292,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-selfLink}
+##### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -307,7 +307,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-uid}
+##### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -328,7 +328,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-resourceVersion}
+##### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -352,7 +352,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-generation}
+##### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -368,7 +368,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-creationTimestamp}
+##### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -390,7 +390,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-deletionTimestamp}
+##### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -422,7 +422,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-deletionGracePeriodSeconds}
+##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -440,7 +440,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -458,7 +458,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -476,7 +476,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences}
+##### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -554,7 +554,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -569,7 +569,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -594,7 +594,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-finalizers}
+##### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -621,7 +621,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields}
+##### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -640,7 +640,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -655,7 +655,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -671,7 +671,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -689,7 +689,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -708,7 +708,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -724,7 +724,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -739,7 +739,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -766,7 +766,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec}
 
 LocalClusterAccessSpec holds the spec of the cluster access in the cluster
 
@@ -778,7 +778,7 @@ LocalClusterAccessSpec holds the spec of the cluster access in the cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-displayName}
 
 DisplayName is the name that should be shown in the UI
 
@@ -793,7 +793,7 @@ DisplayName is the name that should be shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-description}
 
 Description is the description of this object in
 human-readable text.
@@ -809,7 +809,7 @@ human-readable text.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users}
 
 Users are the users affected by this cluster access object
 
@@ -821,7 +821,7 @@ Users are the users affected by this cluster access object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users-user}
 
 User specifies a Loft user.
 
@@ -836,7 +836,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users-team}
+##### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-users-team}
 
 Team specifies a Loft team.
 
@@ -854,7 +854,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-teams}
 
 Teams are the teams affected by this cluster access object
 
@@ -869,7 +869,7 @@ Teams are the teams affected by this cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-clusterRoles}
+##### `clusterRoles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-clusterRoles}
 
 ClusterRoles define the cluster roles that the users should have assigned in the cluster.
 
@@ -881,7 +881,7 @@ ClusterRoles define the cluster roles that the users should have assigned in the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-clusterRoles-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-clusterRoles-name}
 
 Name is the cluster role to assign
 
@@ -899,7 +899,7 @@ Name is the cluster role to assign
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priority` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-priority}
+##### `priority` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterAccessTemplate-spec-priority}
 
 Priority is a unique value that specifies the priority of this cluster access
 for the space constraints and quota. A higher priority means the cluster access object
@@ -925,7 +925,7 @@ will override the space constraints of lower priority cluster access objects
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusterroletemplates/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusterroletemplates/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a cluster role template object
 
@@ -50,7 +50,7 @@ Description describes a cluster role template object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
+### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusters}
 
 Clusters are the clusters this template should be applied on.
 
@@ -110,7 +110,7 @@ Clusters are the clusters this template should be applied on.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `management` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-management}
+### `management` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-management}
 
 Management defines if this cluster role should be created in the management instance.
 
@@ -125,7 +125,7 @@ Management defines if this cluster role should be created in the management inst
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -137,7 +137,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -167,7 +167,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -182,7 +182,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -197,7 +197,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -215,7 +215,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRoleTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate}
+### `clusterRoleTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate}
 
 ClusterRoleTemplate holds the cluster role template
 
@@ -227,7 +227,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata}
 
 
 
@@ -239,7 +239,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -259,7 +259,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-generateName}
+##### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -285,7 +285,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -307,7 +307,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-selfLink}
+##### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -322,7 +322,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-uid}
+##### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -343,7 +343,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-resourceVersion}
+##### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -367,7 +367,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-generation}
+##### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -383,7 +383,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-creationTimestamp}
+##### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -405,7 +405,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-deletionTimestamp}
+##### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -437,7 +437,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-deletionGracePeriodSeconds}
+##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -455,7 +455,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -473,7 +473,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -491,7 +491,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences}
+##### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -569,7 +569,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -584,7 +584,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -609,7 +609,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-finalizers}
+##### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -636,7 +636,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields}
+##### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -655,7 +655,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -670,7 +670,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -686,7 +686,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -704,7 +704,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -723,7 +723,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -739,7 +739,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -754,7 +754,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -781,7 +781,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules}
 
 Rules holds all the PolicyRules for this ClusterRole
 
@@ -808,7 +808,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-apiGroups}
 
 
 
@@ -823,7 +823,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resources}
 
 
 
@@ -838,7 +838,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resourceNames}
 
 
 
@@ -853,7 +853,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-nonResourceURLs}
 
 
 
@@ -871,7 +871,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `aggregationRule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule}
+#### `aggregationRule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule}
 
 AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
@@ -885,7 +885,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoleSelectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
+##### `clusterRoleSelectors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
 
 
 
@@ -897,7 +897,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchLabels}
 
 matchLabels is a map of &#123;key,value&#125; pairs. A single &#123;key,value&#125; in the matchLabels
 map is equivalent to an element of matchExpressions, whose key field is "key", the
@@ -914,7 +914,7 @@ operator is "In", and the values array contains only "value". The requirements a
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions}
 
 matchExpressions is a list of label selector requirements. The requirements are ANDed.
 
@@ -957,7 +957,7 @@ Valid operators are In, NotIn, Exists and DoesNotExist.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions-values}
 
 values is an array of string values. If the operator is In or NotIn,
 the values array must be non-empty. If the operator is Exists or DoesNotExist,
@@ -987,7 +987,7 @@ merge patch.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `localClusterRoleTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate}
+### `localClusterRoleTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate}
 
 DEPRECATED: Use ClusterRoleTemplate instead
 LocalClusterRoleTemplate holds the cluster role template
@@ -1000,7 +1000,7 @@ LocalClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata}
 
 Metadata is the metadata of the cluster role template object
 
@@ -1012,7 +1012,7 @@ Metadata is the metadata of the cluster role template object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -1032,7 +1032,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-generateName}
+##### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -1058,7 +1058,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -1080,7 +1080,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-selfLink}
+##### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -1095,7 +1095,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-uid}
+##### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -1116,7 +1116,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-resourceVersion}
+##### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -1140,7 +1140,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-generation}
+##### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -1156,7 +1156,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-creationTimestamp}
+##### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -1178,7 +1178,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-deletionTimestamp}
+##### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -1210,7 +1210,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-deletionGracePeriodSeconds}
+##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -1228,7 +1228,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -1246,7 +1246,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -1264,7 +1264,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences}
+##### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -1342,7 +1342,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -1357,7 +1357,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -1382,7 +1382,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-finalizers}
+##### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -1409,7 +1409,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields}
+##### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -1428,7 +1428,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -1443,7 +1443,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -1459,7 +1459,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -1477,7 +1477,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -1496,7 +1496,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -1512,7 +1512,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -1527,7 +1527,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -1554,7 +1554,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec}
 
 LocalClusterRoleTemplateSpec holds the spec of the cluster role template in the cluster
 
@@ -1566,7 +1566,7 @@ LocalClusterRoleTemplateSpec holds the spec of the cluster role template in the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-displayName}
 
 DisplayName is the name that should be shown in the UI
 
@@ -1581,7 +1581,7 @@ DisplayName is the name that should be shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-description}
 
 Description is the description of this object in
 human-readable text.
@@ -1597,7 +1597,7 @@ human-readable text.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoleTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate}
+##### `clusterRoleTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate}
 
 ClusterRoleTemplate holds the cluster role template
 
@@ -1609,7 +1609,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata}
 
 
 
@@ -1621,7 +1621,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -1641,7 +1641,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-generateName}
+##### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -1667,7 +1667,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -1689,7 +1689,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-selfLink}
+##### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -1704,7 +1704,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-uid}
+##### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -1725,7 +1725,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-resourceVersion}
+##### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -1749,7 +1749,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-generation}
+##### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -1765,7 +1765,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-creationTimestamp}
+##### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -1787,7 +1787,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-deletionTimestamp}
+##### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -1819,7 +1819,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-deletionGracePeriodSeconds}
+##### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -1837,7 +1837,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -1855,7 +1855,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -1873,7 +1873,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences}
+##### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -1951,7 +1951,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -1966,7 +1966,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -1991,7 +1991,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-finalizers}
+##### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -2018,7 +2018,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields}
+##### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -2037,7 +2037,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -2052,7 +2052,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -2068,7 +2068,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -2086,7 +2086,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -2105,7 +2105,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -2121,7 +2121,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -2136,7 +2136,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -2163,7 +2163,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules}
 
 Rules holds all the PolicyRules for this ClusterRole
 
@@ -2190,7 +2190,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-apiGroups}
 
 
 
@@ -2205,7 +2205,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resources}
 
 
 
@@ -2220,7 +2220,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resourceNames}
 
 
 
@@ -2235,7 +2235,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-nonResourceURLs}
 
 
 
@@ -2253,7 +2253,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `aggregationRule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule}
+##### `aggregationRule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule}
 
 AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
@@ -2267,7 +2267,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoleSelectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
+##### `clusterRoleSelectors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
 
 
 
@@ -2279,7 +2279,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchLabels}
 
 matchLabels is a map of &#123;key,value&#125; pairs. A single &#123;key,value&#125; in the matchLabels
 map is equivalent to an element of matchExpressions, whose key field is "key", the
@@ -2296,7 +2296,7 @@ operator is "In", and the values array contains only "value". The requirements a
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions}
 
 matchExpressions is a list of label selector requirements. The requirements are ANDed.
 
@@ -2339,7 +2339,7 @@ Valid operators are In, NotIn, Exists and DoesNotExist.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors-matchExpressions-values}
 
 values is an array of string values. If the operator is In or NotIn,
 the values array must be non-empty. If the operator is Exists or DoesNotExist,
@@ -2378,7 +2378,7 @@ merge patch.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -2390,7 +2390,7 @@ merge patch.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters}
+### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters}
 
 
 
@@ -2402,7 +2402,7 @@ merge patch.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-name}
 
 Name is the kubernetes name of the object
 
@@ -2417,7 +2417,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-displayName}
 
 The display name shown in the UI
 
@@ -2432,7 +2432,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-icon}
 
 Icon is the icon of the user / team
 
@@ -2447,7 +2447,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-username}
 
 The username that is used to login
 
@@ -2462,7 +2462,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-email}
 
 The users email address
 
@@ -2477,7 +2477,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-subject}
+#### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-subject}
 
 The user subject
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusterroletemplates/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusterroletemplates/reference.mdx
@@ -227,7 +227,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata}
 
 
 
@@ -655,7 +655,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -670,7 +670,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -686,7 +686,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -723,7 +723,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -754,7 +754,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -808,7 +808,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-apiGroups}
 
 
 
@@ -823,7 +823,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resources}
 
 
 
@@ -838,7 +838,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-resourceNames}
 
 
 
@@ -853,7 +853,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-rules-nonResourceURLs}
 
 
 
@@ -885,7 +885,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoleSelectors` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
+##### `clusterRoleSelectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
 
 
 
@@ -987,7 +987,7 @@ merge patch.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `localClusterRoleTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate}
+### `localClusterRoleTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate}
 
 DEPRECATED: Use ClusterRoleTemplate instead
 LocalClusterRoleTemplate holds the cluster role template
@@ -1428,7 +1428,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -1443,7 +1443,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -1459,7 +1459,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -1496,7 +1496,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -1527,7 +1527,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -1609,7 +1609,7 @@ ClusterRoleTemplate holds the cluster role template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata}
 
 
 
@@ -2037,7 +2037,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -2052,7 +2052,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -2068,7 +2068,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -2105,7 +2105,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -2136,7 +2136,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -2190,7 +2190,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-apiGroups}
 
 
 
@@ -2205,7 +2205,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resources}
 
 
 
@@ -2220,7 +2220,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-resourceNames}
 
 
 
@@ -2235,7 +2235,7 @@ Rules holds all the PolicyRules for this ClusterRole
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-rules-nonResourceURLs}
 
 
 
@@ -2267,7 +2267,7 @@ stomped by the controller.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterRoleSelectors` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
+##### `clusterRoleSelectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-localClusterRoleTemplate-spec-clusterRoleTemplate-aggregationRule-clusterRoleSelectors}
 
 
 
@@ -2402,7 +2402,7 @@ merge patch.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-clusters-name}
 
 Name is the kubernetes name of the object
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusters/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusters/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 If specified this name is displayed in the UI instead of the metadata name
 
@@ -35,7 +35,7 @@ If specified this name is displayed in the UI instead of the metadata name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a cluster access object
 
@@ -50,7 +50,7 @@ Description describes a cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config}
+### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config}
 
 Holds a reference to a secret that holds the kube config to access this cluster
 
@@ -107,7 +107,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-secretName}
 
 
 
@@ -122,7 +122,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-secretNamespace}
+#### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-secretNamespace}
 
 
 
@@ -137,7 +137,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-key}
+#### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-config-key}
 
 
 
@@ -155,7 +155,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `local` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-local}
+### `local` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-local}
 
 Local specifies if it is the local cluster that should be connected, when this is specified, config is optional
 
@@ -170,7 +170,7 @@ Local specifies if it is the local cluster that should be connected, when this i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `networkPeer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-networkPeer}
+### `networkPeer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-networkPeer}
 
 NetworkPeer specifies if the cluster is connected via tailscale, when this is specified, config is optional
 
@@ -185,7 +185,7 @@ NetworkPeer specifies if the cluster is connected via tailscale, when this is sp
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `managementNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-managementNamespace}
+### `managementNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-managementNamespace}
 
 The namespace where the cluster components will be installed in
 
@@ -200,7 +200,7 @@ The namespace where the cluster components will be installed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `unusable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-unusable}
+### `unusable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-unusable}
 
 If unusable is true, no spaces or tenant clusters can be scheduled on this cluster.
 
@@ -215,7 +215,7 @@ If unusable is true, no spaces or tenant clusters can be scheduled on this clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -227,7 +227,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -257,7 +257,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -272,7 +272,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -287,7 +287,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -305,7 +305,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics}
+### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics}
 
 Metrics holds the cluster's metrics backend configuration
 
@@ -317,7 +317,7 @@ Metrics holds the cluster's metrics backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-replicas}
+#### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -332,7 +332,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -344,7 +344,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -360,7 +360,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -378,7 +378,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -414,7 +414,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -438,7 +438,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-retention}
+#### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -453,7 +453,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage}
+#### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage}
 
 
 
@@ -465,7 +465,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -482,7 +482,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -503,7 +503,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost}
+### `opencost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost}
 
 OpenCost holds the cluster's OpenCost backend configuration
 
@@ -515,7 +515,7 @@ OpenCost holds the cluster's OpenCost backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-replicas}
+#### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -530,7 +530,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -542,7 +542,7 @@ Resources are compute resource required by the OpenCost backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -558,7 +558,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -576,7 +576,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -612,7 +612,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -639,7 +639,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `argoCD` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD}
+### `argoCD` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD}
 
 ArgoCD holds the cluster's argo cd configuration
 
@@ -651,7 +651,7 @@ ArgoCD holds the cluster's argo cd configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-enabled}
 
 Enabled defines if argo cd is enabled
 
@@ -666,7 +666,7 @@ Enabled defines if argo cd is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-connector}
+#### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-connector}
 
 Connector specifies the argo cd connector name
 
@@ -687,7 +687,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -699,22 +699,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `phase` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-### `reason` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
+### `phase` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
 
 
 
@@ -729,7 +714,22 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `message` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
+### `reason` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
 
 
 
@@ -744,7 +744,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions holds several conditions the cluster might be in
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusters/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/clusters/reference.mdx
@@ -305,7 +305,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics}
+### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics}
 
 Metrics holds the cluster's metrics backend configuration
 
@@ -317,7 +317,7 @@ Metrics holds the cluster's metrics backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -332,7 +332,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -438,7 +438,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-retention}
+#### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -453,7 +453,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage}
+#### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage}
 
 
 
@@ -465,7 +465,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -482,7 +482,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -503,7 +503,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `opencost` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost}
+### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost}
 
 OpenCost holds the cluster's OpenCost backend configuration
 
@@ -515,7 +515,7 @@ OpenCost holds the cluster's OpenCost backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -530,7 +530,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/reference.mdx
@@ -74,7 +74,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -97,7 +97,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -117,7 +117,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -132,7 +132,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -409,7 +409,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-clientId}
 
 ClientID holds the github client id
 
@@ -917,7 +917,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -934,7 +934,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -965,7 +965,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -980,7 +980,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -1161,7 +1161,7 @@ Password holds password authentication relevant information
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `disabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password-disabled}
+##### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password-disabled}
 
 If true login via password is disabled
 
@@ -1233,7 +1233,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -1256,7 +1256,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -1276,7 +1276,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -1291,7 +1291,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -1568,7 +1568,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-clientId}
 
 ClientID holds the github client id
 
@@ -2076,7 +2076,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -2093,7 +2093,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -2124,7 +2124,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -2139,7 +2139,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -2395,7 +2395,7 @@ CustomHttpHeaders are additional headers that should be set for the authenticati
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsFilters` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-groupsFilters}
+#### `groupsFilters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-groupsFilters}
 
 GroupsFilters is a regex expression to only save matching sso groups into the user resource
 
@@ -2425,7 +2425,7 @@ DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-enabled}
 
 If true indicates that loft will act as an OIDC server
 
@@ -2440,7 +2440,7 @@ If true indicates that loft will act as an OIDC server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `wildcardRedirect` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-wildcardRedirect}
+#### `wildcardRedirect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-wildcardRedirect}
 
 If true indicates that loft will allow wildcard '*' in client redirectURIs
 
@@ -2455,7 +2455,7 @@ If true indicates that loft will allow wildcard '*' in client redirectURIs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clients` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients}
+#### `clients` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients}
 
 The clients that are allowed to request loft tokens
 
@@ -2467,7 +2467,7 @@ The clients that are allowed to request loft tokens
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-name}
 
 The client name
 
@@ -2482,7 +2482,7 @@ The client name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientId}
 
 The client id of the client
 
@@ -2497,7 +2497,7 @@ The client id of the client
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientSecret}
 
 The client secret of the client
 
@@ -2851,7 +2851,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -3778,7 +3778,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableConfigEndpoint` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-disableConfigEndpoint}
+### `disableConfigEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-disableConfigEndpoint}
 
 DisableLoftConfigEndpoint will disable setting config via the UI and config.management.loft.sh endpoint
 
@@ -3793,7 +3793,7 @@ DisableLoftConfigEndpoint will disable setting config via the UI and config.mana
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `authenticateVersionEndpoint` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-authenticateVersionEndpoint}
+### `authenticateVersionEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-authenticateVersionEndpoint}
 
 AuthenticateVersionEndpoint will force authentication for the '/version' endpoint. Will only work with vCluster v0.27 & later
 
@@ -3808,7 +3808,7 @@ AuthenticateVersionEndpoint will force authentication for the '/version' endpoin
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cloud` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud}
+### `cloud` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud}
 
 Cloud holds the settings to be used exclusively in vCluster Cloud based
 environments and deployments.
@@ -3821,7 +3821,7 @@ environments and deployments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `releaseChannel` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-releaseChannel}
+#### `releaseChannel` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-releaseChannel}
 
 ReleaseChannel specifies the release channel for the cloud configuration.
 This can be used to determine which updates or versions are applied.
@@ -3837,7 +3837,7 @@ This can be used to determine which updates or versions are applied.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `maintenanceWindow` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow}
+#### `maintenanceWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow}
 
 MaintenanceWindow specifies the maintenance window for the cloud configuration.
 This is a structured representation of the time window during which maintenance can occur.
@@ -3850,7 +3850,7 @@ This is a structured representation of the time window during which maintenance 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dayOfWeek` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-dayOfWeek}
+##### `dayOfWeek` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-dayOfWeek}
 
 DayOfWeek specifies the day of the week for the maintenance window.
 It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
@@ -3866,7 +3866,7 @@ It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeWindow` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-timeWindow}
+##### `timeWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-timeWindow}
 
 TimeWindow specifies the time window for the maintenance.
 It should be a string representing the time range in 24-hour format, in UTC, e.g., "02:00-03:00".
@@ -3888,7 +3888,7 @@ It should be a string representing the time range in 24-hour format, in UTC, e.g
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `costControl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl}
+### `costControl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl}
 
 CostControl holds the settings related to the Cost Control ROI dashboard and its metrics gathering infrastructure
 
@@ -3900,7 +3900,7 @@ CostControl holds the settings related to the Cost Control ROI dashboard and its
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-enabled}
 
 Enabled specifies whether the ROI dashboard should be available in the UI, and if the metrics infrastructure
 that provides dashboard data is deployed
@@ -3916,7 +3916,7 @@ that provides dashboard data is deployed
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `global` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global}
+#### `global` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global}
 
 Global are settings for globally managed components
 
@@ -3928,7 +3928,7 @@ Global are settings for globally managed components
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics}
+##### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics}
 
 Metrics these settings apply to metric infrastructure used to aggregate metrics across all connected clusters
 
@@ -3940,7 +3940,7 @@ Metrics these settings apply to metric infrastructure used to aggregate metrics 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -3955,7 +3955,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4061,7 +4061,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4076,7 +4076,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage}
 
 
 
@@ -4088,7 +4088,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4105,7 +4105,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4129,7 +4129,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `cluster` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster}
+#### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster}
 
 Cluster are settings for each cluster's managed components. These settings apply to all connected clusters
 unless overridden by modifying the Cluster's spec
@@ -4142,7 +4142,7 @@ unless overridden by modifying the Cluster's spec
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics}
+##### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics}
 
 Metrics are settings applied to metric infrastructure in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4155,7 +4155,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4170,7 +4170,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4276,7 +4276,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4291,7 +4291,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage}
 
 
 
@@ -4303,7 +4303,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4320,7 +4320,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4341,7 +4341,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `opencost` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost}
+##### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost}
 
 OpenCost are settings applied to OpenCost deployments in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4354,7 +4354,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4369,7 +4369,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -4481,7 +4481,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `settings` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings}
+#### `settings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings}
 
 Settings specify price-related settings that are taken into account for the ROI dashboard calculations.
 
@@ -4493,7 +4493,7 @@ Settings specify price-related settings that are taken into account for the ROI 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priceCurrency` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-priceCurrency}
+##### `priceCurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-priceCurrency}
 
 PriceCurrency specifies the currency.
 
@@ -4508,7 +4508,7 @@ PriceCurrency specifies the currency.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageCPUPricePerNode` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode}
+##### `averageCPUPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode}
 
 AvgCPUPricePerNode specifies the average CPU price per node.
 
@@ -4520,7 +4520,7 @@ AvgCPUPricePerNode specifies the average CPU price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-price}
 
 Price specifies the price.
 
@@ -4535,7 +4535,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4553,7 +4553,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageRAMPricePerNode` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode}
+##### `averageRAMPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode}
 
 AvgRAMPricePerNode specifies the average RAM price per node.
 
@@ -4565,7 +4565,7 @@ AvgRAMPricePerNode specifies the average RAM price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-price}
 
 Price specifies the price.
 
@@ -4580,7 +4580,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4598,7 +4598,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `gpuSettings` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings}
+##### `gpuSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings}
 
 GPUSettings specifies GPU related settings.
 
@@ -4610,7 +4610,7 @@ GPUSettings specifies GPU related settings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-enabled}
 
 Enabled specifies whether GPU settings should be available in the UI.
 
@@ -4625,7 +4625,7 @@ Enabled specifies whether GPU settings should be available in the UI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageGPUPrice` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice}
+##### `averageGPUPrice` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice}
 
 AvgGPUPrice specifies the average GPU price.
 
@@ -4637,7 +4637,7 @@ AvgGPUPrice specifies the average GPU price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-price}
 
 Price specifies the price.
 
@@ -4652,7 +4652,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4673,7 +4673,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `controlPlanePricePerCluster` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster}
+##### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster}
 
 ControlPlanePricePerCluster specifies the price of one physical cluster.
 
@@ -4685,7 +4685,7 @@ ControlPlanePricePerCluster specifies the price of one physical cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-price}
 
 Price specifies the price.
 
@@ -4700,7 +4700,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4724,7 +4724,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `platformDB` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB}
+### `platformDB` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB}
 
 PlatformDB holds the settings related to the postgres database that platform uses to store data
 
@@ -4736,7 +4736,7 @@ PlatformDB holds the settings related to the postgres database that platform use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB-storageClass}
+#### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB-storageClass}
 
 StorageClass sets the storage class for the PersistentVolumeClaim used by the platform database statefulSet.
 
@@ -4754,7 +4754,7 @@ StorageClass sets the storage class for the PersistentVolumeClaim used by the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imageBuilder` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder}
+### `imageBuilder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder}
 
 ImageBuilder holds the settings related to the image builder
 
@@ -4766,7 +4766,7 @@ ImageBuilder holds the settings related to the image builder
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-enabled}
 
 Enabled specifies whether the remote image builder should be available.
 If it's not available building ad-hoc images from a devcontainer.json is not supported
@@ -4782,7 +4782,7 @@ If it's not available building ad-hoc images from a devcontainer.json is not sup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4797,7 +4797,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources}
 
 Resources are compute resource required by the buildkit containers
 
@@ -4906,7 +4906,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `database` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database}
+### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database}
 
 Database represents the database connection settings when deploying the platform with an embedded Kubernetes backed by kine
 
@@ -4918,7 +4918,7 @@ Database represents the database connection settings when deploying the platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-enabled}
 
 Enabled defines if the database should be used.
 
@@ -4933,7 +4933,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataSource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-dataSource}
+#### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -4951,7 +4951,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `identityProvider` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-identityProvider}
+#### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -4968,7 +4968,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `keyFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-keyFile}
+#### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -4983,7 +4983,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `certFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-certFile}
+#### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -4998,7 +4998,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-caFile}
+#### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -5013,7 +5013,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `raw` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-raw}
+### `raw` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-raw}
 
 Raw holds the raw config
 
@@ -38,7 +38,7 @@ Raw holds the raw config
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -50,7 +50,7 @@ Raw holds the raw config
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth}
+### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth}
 
 Authentication holds the information for authentication
 
@@ -62,7 +62,7 @@ Authentication holds the information for authentication
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc}
+#### `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc}
 
 OIDC holds oidc authentication configuration
 
@@ -74,7 +74,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -97,7 +97,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -117,7 +117,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -132,7 +132,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -147,7 +147,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-postLogoutRedirectURI}
+##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-postLogoutRedirectURI}
 
 Loft URI to be redirected to after successful logout by OIDC Provider
 
@@ -162,7 +162,7 @@ Loft URI to be redirected to after successful logout by OIDC Provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-caFile}
 
 Path to a PEM encoded root certificate of the provider. Optional
 
@@ -177,7 +177,7 @@ Path to a PEM encoded root certificate of the provider. Optional
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureCa` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-insecureCa}
+##### `insecureCa` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-insecureCa}
 
 Specify whether to communicate without validating SSL certificates
 
@@ -192,7 +192,7 @@ Specify whether to communicate without validating SSL certificates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `preferredUsername` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-preferredUsername}
+##### `preferredUsername` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-preferredUsername}
 
 Configurable key which contains the preferred username claims
 
@@ -207,7 +207,7 @@ Configurable key which contains the preferred username claims
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `loftUsernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-loftUsernameClaim}
+##### `loftUsernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-loftUsernameClaim}
 
 LoftUsernameClaim is the JWT field to use as the user's username.
 
@@ -222,7 +222,7 @@ LoftUsernameClaim is the JWT field to use as the user's username.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-usernameClaim}
+##### `usernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-usernameClaim}
 
 UsernameClaim is the JWT field to use as the user's id.
 
@@ -237,7 +237,7 @@ UsernameClaim is the JWT field to use as the user's id.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-emailClaim}
+##### `emailClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-emailClaim}
 
 EmailClaim is the JWT field to use as the user's email.
 
@@ -252,7 +252,7 @@ EmailClaim is the JWT field to use as the user's email.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedExtraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-allowedExtraClaims}
+##### `allowedExtraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-allowedExtraClaims}
 
 AllowedExtraClaims are claims of interest that are not part of User by default but may be provided by the OIDC provider.
 
@@ -267,7 +267,7 @@ AllowedExtraClaims are claims of interest that are not part of User by default b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernamePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-usernamePrefix}
+##### `usernamePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-usernamePrefix}
 
 UsernamePrefix, if specified, causes claims mapping to username to be prefix with
 the provided value. A value "oidc:" would result in usernames like "oidc:john".
@@ -283,7 +283,7 @@ the provided value. A value "oidc:" would result in usernames like "oidc:john".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groupsClaim}
+##### `groupsClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groupsClaim}
 
 GroupsClaim, if specified, causes the OIDCAuthenticator to try to populate the user's
 groups with an ID Token field. If the GroupsClaim field is present in an ID Token the value
@@ -300,7 +300,7 @@ must be a string or list of strings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groups}
 
 If required groups is non empty, access is denied if the user is not part of at least one
 of the specified groups.
@@ -316,7 +316,7 @@ of the specified groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-scopes}
 
 Scopes that should be sent to the server. If empty, defaults to "email" and "profile".
 
@@ -331,7 +331,7 @@ Scopes that should be sent to the server. If empty, defaults to "email" and "pro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `getUserInfo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-getUserInfo}
+##### `getUserInfo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-getUserInfo}
 
 GetUserInfo, if specified, tells the OIDCAuthenticator to try to populate the user's
 information from the UserInfo.
@@ -347,7 +347,7 @@ information from the UserInfo.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsPrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groupsPrefix}
+##### `groupsPrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-groupsPrefix}
 
 GroupsPrefix, if specified, causes claims mapping to group names to be prefixed with the
 value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:marketing".
@@ -363,7 +363,7 @@ value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-type}
 
 Type of the OIDC to show in the UI. Only for displaying purposes
 
@@ -378,7 +378,7 @@ Type of the OIDC to show in the UI. Only for displaying purposes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-resource}
+##### `resource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-oidc-resource}
 
 Resource, if specified, is the value that is set for the "resource" URL parameter when making a request to the /token endpoint of the
 OIDC provider.
@@ -397,7 +397,7 @@ OIDC provider.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `github` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github}
+#### `github` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github}
 
 Github holds github authentication configuration
 
@@ -409,7 +409,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-clientId}
 
 ClientID holds the github client id
 
@@ -454,7 +454,7 @@ RedirectURI holds the redirect URI. Should be https://loft.domain.tld/auth/githu
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `orgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs}
+##### `orgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs}
 
 Loft queries the following organizations for group information.
 Group claims are formatted as "(org):(team)".
@@ -472,7 +472,7 @@ authenticate with loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs-name}
 
 Organization name in github (not slug, full name). Only users in this github
 organization can authenticate.
@@ -488,7 +488,7 @@ organization can authenticate.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-orgs-teams}
 
 Names of teams in a github organization. A user will be able to
 authenticate if they are members of at least one of these teams. Users
@@ -509,7 +509,7 @@ config file.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-hostName}
+##### `hostName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-hostName}
 
 Required ONLY for GitHub Enterprise.
 This is the Hostname of the GitHub Enterprise account listed on the
@@ -526,7 +526,7 @@ management console. Ensure this domain is routable on your network.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rootCA` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-rootCA}
+##### `rootCA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-github-rootCA}
 
 ONLY for GitHub Enterprise. Optional field.
 Used to support self-signed or untrusted CA root certificates.
@@ -545,7 +545,7 @@ Used to support self-signed or untrusted CA root certificates.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gitlab` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab}
+#### `gitlab` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab}
 
 Gitlab holds gitlab authentication configuration
 
@@ -602,7 +602,7 @@ Redirect URI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `baseURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab-baseURL}
+##### `baseURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab-baseURL}
 
 BaseURL is optional, default = https://gitlab.com
 
@@ -617,7 +617,7 @@ BaseURL is optional, default = https://gitlab.com
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-gitlab-groups}
 
 Optional groups whitelist, communicated through the "groups" scope.
 If `groups` is omitted, all of the user's GitLab groups are returned.
@@ -637,7 +637,7 @@ If `groups` is provided, this acts as a whitelist - only the user's GitLab group
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `google` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google}
+#### `google` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google}
 
 Google holds google authentication configuration
 
@@ -694,7 +694,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/google/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-scopes}
 
 defaults to "profile" and "email"
 
@@ -709,7 +709,7 @@ defaults to "profile" and "email"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostedDomains` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-hostedDomains}
+##### `hostedDomains` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-hostedDomains}
 
 Optional list of whitelisted domains
 If this field is nonempty, only users from a listed domain will be allowed to log in
@@ -725,7 +725,7 @@ If this field is nonempty, only users from a listed domain will be allowed to lo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-groups}
 
 Optional list of whitelisted groups
 If this field is nonempty, only users from a listed group will be allowed to log in
@@ -741,7 +741,7 @@ If this field is nonempty, only users from a listed group will be allowed to log
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `serviceAccountFilePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-serviceAccountFilePath}
+##### `serviceAccountFilePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-serviceAccountFilePath}
 
 Optional path to service account json
 If nonempty, and groups claim is made, will use authentication from file to
@@ -758,7 +758,7 @@ check groups with the admin directory api
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `adminEmail` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-adminEmail}
+##### `adminEmail` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-google-adminEmail}
 
 Required if ServiceAccountFilePath
 The email of a GSuite super user which the service account will impersonate
@@ -778,7 +778,7 @@ when listing groups
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `microsoft` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft}
+#### `microsoft` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft}
 
 Microsoft holds microsoft authentication configuration
 
@@ -835,7 +835,7 @@ loft redirect uri. Usually https://loft.my.domain/auth/microsoft/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tenant` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-tenant}
+##### `tenant` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-tenant}
 
 tenant configuration parameter controls what kinds of accounts may be authenticated in loft.
 By default, all types of Microsoft accounts (consumers and organizations) can authenticate in loft via Microsoft.
@@ -857,7 +857,7 @@ tenant uuid or tenant name - only accounts belonging to specific tenant identifi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-groups}
 
 It is possible to require a user to be a member of a particular group in order to be successfully authenticated in loft.
 
@@ -872,7 +872,7 @@ It is possible to require a user to be a member of a particular group in order t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `onlySecurityGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-onlySecurityGroups}
+##### `onlySecurityGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-onlySecurityGroups}
 
 configuration option restricts the list to include only security groups. By default all groups (security, Office 365, mailing lists) are included.
 
@@ -887,7 +887,7 @@ configuration option restricts the list to include only security groups. By defa
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-useGroupsAsWhitelist}
+##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-microsoft-useGroupsAsWhitelist}
 
 Restrict the groups claims to include only the user’s groups that are in the configured groups
 
@@ -905,7 +905,7 @@ Restrict the groups claims to include only the user’s groups that are in the c
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `saml` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml}
+#### `saml` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml}
 
 SAML holds saml authentication configuration
 
@@ -917,7 +917,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -934,7 +934,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -949,7 +949,7 @@ SSO URL used for POST value.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caData` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-caData}
+##### `caData` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-caData}
 
 CAData is a base64 encoded string that holds the ca certificate for validating the signature of the SAML response.
 Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
@@ -965,7 +965,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -980,7 +980,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -995,7 +995,7 @@ Name of attribute in the returned assertions to map to email
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-groupsAttr}
+##### `groupsAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-groupsAttr}
 
 Name of attribute in the returned assertions to map to groups
 
@@ -1010,7 +1010,7 @@ Name of attribute in the returned assertions to map to groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ca` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ca}
+##### `ca` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ca}
 
 CA to use when validating the signature of the SAML response.
 
@@ -1025,7 +1025,7 @@ CA to use when validating the signature of the SAML response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-insecureSkipSignatureValidation}
+##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-insecureSkipSignatureValidation}
 
 Ignore the ca cert
 
@@ -1040,7 +1040,7 @@ Ignore the ca cert
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `entityIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-entityIssuer}
+##### `entityIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-entityIssuer}
 
 When provided Loft will include this as the Issuer value during AuthnRequest.
 It will also override the redirectURI as the required audience when evaluating
@@ -1057,7 +1057,7 @@ AudienceRestriction elements in the response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoIssuer}
+##### `ssoIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-ssoIssuer}
 
 Issuer value expected in the SAML response. Optional.
 
@@ -1072,7 +1072,7 @@ Issuer value expected in the SAML response. Optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsDelim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-groupsDelim}
+##### `groupsDelim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-groupsDelim}
 
 If GroupsDelim is supplied the connector assumes groups are returned as a
 single string instead of multiple attribute values. This delimiter will be
@@ -1089,7 +1089,7 @@ used split the groups string.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-allowedGroups}
+##### `allowedGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-allowedGroups}
 
 List of groups to filter access based on membership
 
@@ -1104,7 +1104,7 @@ List of groups to filter access based on membership
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `filterGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-filterGroups}
+##### `filterGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-filterGroups}
 
 If used with allowed groups, only forwards the allowed groups and not all
 groups specified.
@@ -1120,7 +1120,7 @@ groups specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-nameIDPolicyFormat}
+##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-saml-nameIDPolicyFormat}
 
 Requested format of the NameID. The NameID value is is mapped to the ID Token
 'sub' claim.
@@ -1149,7 +1149,7 @@ If no value is specified, this value defaults to:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password}
+#### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password}
 
 Password holds password authentication relevant information
 
@@ -1161,7 +1161,7 @@ Password holds password authentication relevant information
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password-disabled}
+##### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-password-disabled}
 
 If true login via password is disabled
 
@@ -1179,7 +1179,7 @@ If true login via password is disabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `connectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors}
+#### `connectors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors}
 
 Connectors are optional additional connectors for Loft.
 
@@ -1191,7 +1191,7 @@ Connectors are optional additional connectors for Loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `id` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-id}
+##### `id` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-id}
 
 ID is the id that should show up in the url
 
@@ -1206,7 +1206,7 @@ ID is the id that should show up in the url
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-displayName}
 
 DisplayName is the name that should show up in the ui
 
@@ -1221,7 +1221,7 @@ DisplayName is the name that should show up in the ui
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc}
+##### `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc}
 
 OIDC holds oidc authentication configuration
 
@@ -1233,7 +1233,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -1256,7 +1256,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -1276,7 +1276,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -1291,7 +1291,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -1306,7 +1306,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-postLogoutRedirectURI}
+##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-postLogoutRedirectURI}
 
 Loft URI to be redirected to after successful logout by OIDC Provider
 
@@ -1321,7 +1321,7 @@ Loft URI to be redirected to after successful logout by OIDC Provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-caFile}
 
 Path to a PEM encoded root certificate of the provider. Optional
 
@@ -1336,7 +1336,7 @@ Path to a PEM encoded root certificate of the provider. Optional
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureCa` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-insecureCa}
+##### `insecureCa` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-insecureCa}
 
 Specify whether to communicate without validating SSL certificates
 
@@ -1351,7 +1351,7 @@ Specify whether to communicate without validating SSL certificates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `preferredUsername` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-preferredUsername}
+##### `preferredUsername` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-preferredUsername}
 
 Configurable key which contains the preferred username claims
 
@@ -1366,7 +1366,7 @@ Configurable key which contains the preferred username claims
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `loftUsernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-loftUsernameClaim}
+##### `loftUsernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-loftUsernameClaim}
 
 LoftUsernameClaim is the JWT field to use as the user's username.
 
@@ -1381,7 +1381,7 @@ LoftUsernameClaim is the JWT field to use as the user's username.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-usernameClaim}
+##### `usernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-usernameClaim}
 
 UsernameClaim is the JWT field to use as the user's id.
 
@@ -1396,7 +1396,7 @@ UsernameClaim is the JWT field to use as the user's id.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-emailClaim}
+##### `emailClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-emailClaim}
 
 EmailClaim is the JWT field to use as the user's email.
 
@@ -1411,7 +1411,7 @@ EmailClaim is the JWT field to use as the user's email.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedExtraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-allowedExtraClaims}
+##### `allowedExtraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-allowedExtraClaims}
 
 AllowedExtraClaims are claims of interest that are not part of User by default but may be provided by the OIDC provider.
 
@@ -1426,7 +1426,7 @@ AllowedExtraClaims are claims of interest that are not part of User by default b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernamePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-usernamePrefix}
+##### `usernamePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-usernamePrefix}
 
 UsernamePrefix, if specified, causes claims mapping to username to be prefix with
 the provided value. A value "oidc:" would result in usernames like "oidc:john".
@@ -1442,7 +1442,7 @@ the provided value. A value "oidc:" would result in usernames like "oidc:john".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groupsClaim}
+##### `groupsClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groupsClaim}
 
 GroupsClaim, if specified, causes the OIDCAuthenticator to try to populate the user's
 groups with an ID Token field. If the GroupsClaim field is present in an ID Token the value
@@ -1459,7 +1459,7 @@ must be a string or list of strings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groups}
 
 If required groups is non empty, access is denied if the user is not part of at least one
 of the specified groups.
@@ -1475,7 +1475,7 @@ of the specified groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-scopes}
 
 Scopes that should be sent to the server. If empty, defaults to "email" and "profile".
 
@@ -1490,7 +1490,7 @@ Scopes that should be sent to the server. If empty, defaults to "email" and "pro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `getUserInfo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-getUserInfo}
+##### `getUserInfo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-getUserInfo}
 
 GetUserInfo, if specified, tells the OIDCAuthenticator to try to populate the user's
 information from the UserInfo.
@@ -1506,7 +1506,7 @@ information from the UserInfo.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsPrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groupsPrefix}
+##### `groupsPrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-groupsPrefix}
 
 GroupsPrefix, if specified, causes claims mapping to group names to be prefixed with the
 value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:marketing".
@@ -1522,7 +1522,7 @@ value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-type}
 
 Type of the OIDC to show in the UI. Only for displaying purposes
 
@@ -1537,7 +1537,7 @@ Type of the OIDC to show in the UI. Only for displaying purposes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-resource}
+##### `resource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-oidc-resource}
 
 Resource, if specified, is the value that is set for the "resource" URL parameter when making a request to the /token endpoint of the
 OIDC provider.
@@ -1556,7 +1556,7 @@ OIDC provider.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `github` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github}
+##### `github` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github}
 
 Github holds github authentication configuration
 
@@ -1568,7 +1568,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-clientId}
 
 ClientID holds the github client id
 
@@ -1613,7 +1613,7 @@ RedirectURI holds the redirect URI. Should be https://loft.domain.tld/auth/githu
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `orgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs}
+##### `orgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs}
 
 Loft queries the following organizations for group information.
 Group claims are formatted as "(org):(team)".
@@ -1631,7 +1631,7 @@ authenticate with loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs-name}
 
 Organization name in github (not slug, full name). Only users in this github
 organization can authenticate.
@@ -1647,7 +1647,7 @@ organization can authenticate.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-orgs-teams}
 
 Names of teams in a github organization. A user will be able to
 authenticate if they are members of at least one of these teams. Users
@@ -1668,7 +1668,7 @@ config file.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-hostName}
+##### `hostName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-hostName}
 
 Required ONLY for GitHub Enterprise.
 This is the Hostname of the GitHub Enterprise account listed on the
@@ -1685,7 +1685,7 @@ management console. Ensure this domain is routable on your network.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rootCA` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-rootCA}
+##### `rootCA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-github-rootCA}
 
 ONLY for GitHub Enterprise. Optional field.
 Used to support self-signed or untrusted CA root certificates.
@@ -1704,7 +1704,7 @@ Used to support self-signed or untrusted CA root certificates.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `gitlab` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab}
+##### `gitlab` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab}
 
 Gitlab holds gitlab authentication configuration
 
@@ -1761,7 +1761,7 @@ Redirect URI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `baseURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab-baseURL}
+##### `baseURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab-baseURL}
 
 BaseURL is optional, default = https://gitlab.com
 
@@ -1776,7 +1776,7 @@ BaseURL is optional, default = https://gitlab.com
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-gitlab-groups}
 
 Optional groups whitelist, communicated through the "groups" scope.
 If `groups` is omitted, all of the user's GitLab groups are returned.
@@ -1796,7 +1796,7 @@ If `groups` is provided, this acts as a whitelist - only the user's GitLab group
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `google` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google}
+##### `google` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google}
 
 Google holds google authentication configuration
 
@@ -1853,7 +1853,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/google/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-scopes}
 
 defaults to "profile" and "email"
 
@@ -1868,7 +1868,7 @@ defaults to "profile" and "email"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostedDomains` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-hostedDomains}
+##### `hostedDomains` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-hostedDomains}
 
 Optional list of whitelisted domains
 If this field is nonempty, only users from a listed domain will be allowed to log in
@@ -1884,7 +1884,7 @@ If this field is nonempty, only users from a listed domain will be allowed to lo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-groups}
 
 Optional list of whitelisted groups
 If this field is nonempty, only users from a listed group will be allowed to log in
@@ -1900,7 +1900,7 @@ If this field is nonempty, only users from a listed group will be allowed to log
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `serviceAccountFilePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-serviceAccountFilePath}
+##### `serviceAccountFilePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-serviceAccountFilePath}
 
 Optional path to service account json
 If nonempty, and groups claim is made, will use authentication from file to
@@ -1917,7 +1917,7 @@ check groups with the admin directory api
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `adminEmail` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-adminEmail}
+##### `adminEmail` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-google-adminEmail}
 
 Required if ServiceAccountFilePath
 The email of a GSuite super user which the service account will impersonate
@@ -1937,7 +1937,7 @@ when listing groups
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `microsoft` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft}
+##### `microsoft` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft}
 
 Microsoft holds microsoft authentication configuration
 
@@ -1994,7 +1994,7 @@ loft redirect uri. Usually https://loft.my.domain/auth/microsoft/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tenant` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-tenant}
+##### `tenant` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-tenant}
 
 tenant configuration parameter controls what kinds of accounts may be authenticated in loft.
 By default, all types of Microsoft accounts (consumers and organizations) can authenticate in loft via Microsoft.
@@ -2016,7 +2016,7 @@ tenant uuid or tenant name - only accounts belonging to specific tenant identifi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-groups}
 
 It is possible to require a user to be a member of a particular group in order to be successfully authenticated in loft.
 
@@ -2031,7 +2031,7 @@ It is possible to require a user to be a member of a particular group in order t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `onlySecurityGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-onlySecurityGroups}
+##### `onlySecurityGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-onlySecurityGroups}
 
 configuration option restricts the list to include only security groups. By default all groups (security, Office 365, mailing lists) are included.
 
@@ -2046,7 +2046,7 @@ configuration option restricts the list to include only security groups. By defa
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-useGroupsAsWhitelist}
+##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-microsoft-useGroupsAsWhitelist}
 
 Restrict the groups claims to include only the user’s groups that are in the configured groups
 
@@ -2064,7 +2064,7 @@ Restrict the groups claims to include only the user’s groups that are in the c
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `saml` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml}
+##### `saml` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml}
 
 SAML holds saml authentication configuration
 
@@ -2076,7 +2076,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -2093,7 +2093,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -2108,7 +2108,7 @@ SSO URL used for POST value.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caData` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-caData}
+##### `caData` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-caData}
 
 CAData is a base64 encoded string that holds the ca certificate for validating the signature of the SAML response.
 Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
@@ -2124,7 +2124,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -2139,7 +2139,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -2154,7 +2154,7 @@ Name of attribute in the returned assertions to map to email
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-groupsAttr}
+##### `groupsAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-groupsAttr}
 
 Name of attribute in the returned assertions to map to groups
 
@@ -2169,7 +2169,7 @@ Name of attribute in the returned assertions to map to groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ca` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ca}
+##### `ca` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ca}
 
 CA to use when validating the signature of the SAML response.
 
@@ -2184,7 +2184,7 @@ CA to use when validating the signature of the SAML response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-insecureSkipSignatureValidation}
+##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-insecureSkipSignatureValidation}
 
 Ignore the ca cert
 
@@ -2199,7 +2199,7 @@ Ignore the ca cert
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `entityIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-entityIssuer}
+##### `entityIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-entityIssuer}
 
 When provided Loft will include this as the Issuer value during AuthnRequest.
 It will also override the redirectURI as the required audience when evaluating
@@ -2216,7 +2216,7 @@ AudienceRestriction elements in the response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoIssuer}
+##### `ssoIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-ssoIssuer}
 
 Issuer value expected in the SAML response. Optional.
 
@@ -2231,7 +2231,7 @@ Issuer value expected in the SAML response. Optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsDelim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-groupsDelim}
+##### `groupsDelim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-groupsDelim}
 
 If GroupsDelim is supplied the connector assumes groups are returned as a
 single string instead of multiple attribute values. This delimiter will be
@@ -2248,7 +2248,7 @@ used split the groups string.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-allowedGroups}
+##### `allowedGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-allowedGroups}
 
 List of groups to filter access based on membership
 
@@ -2263,7 +2263,7 @@ List of groups to filter access based on membership
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `filterGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-filterGroups}
+##### `filterGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-filterGroups}
 
 If used with allowed groups, only forwards the allowed groups and not all
 groups specified.
@@ -2279,7 +2279,7 @@ groups specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-nameIDPolicyFormat}
+##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-connectors-saml-nameIDPolicyFormat}
 
 Requested format of the NameID. The NameID value is is mapped to the ID Token
 'sub' claim.
@@ -2311,7 +2311,7 @@ If no value is specified, this value defaults to:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disableTeamCreation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-disableTeamCreation}
+#### `disableTeamCreation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-disableTeamCreation}
 
 Prevents from team creation for the new groups associated with the user at the time of logging in through sso,
 Default behaviour is false, this means that teams will be created for new groups.
@@ -2327,7 +2327,7 @@ Default behaviour is false, this means that teams will be created for new groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disableUserCreation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-disableUserCreation}
+#### `disableUserCreation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-disableUserCreation}
 
 DisableUserCreation prevents the SSO connectors from creating a new user on a users initial signin through sso.
 Default behaviour is false, this means that a new user object will be created once a user without
@@ -2344,7 +2344,7 @@ a Kubernetes user object logs in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `accessKeyMaxTTLSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-accessKeyMaxTTLSeconds}
+#### `accessKeyMaxTTLSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-accessKeyMaxTTLSeconds}
 
 AccessKeyMaxTTLSeconds is the global maximum lifespan of an accesskey in seconds.
 Leaving it 0 or unspecified will disable it.
@@ -2361,7 +2361,7 @@ Specifying 2592000 will mean all keys have a Time-To-Live of 30 days.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `loginAccessKeyTTLSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-loginAccessKeyTTLSeconds}
+#### `loginAccessKeyTTLSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-loginAccessKeyTTLSeconds}
 
 LoginAccessKeyTTLSeconds is the time in seconds an access key is kept
 until it is deleted.
@@ -2380,7 +2380,7 @@ Specifying 2592000 will mean all keys have a  default Time-To-Live of 30 days.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `customHttpHeaders` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-customHttpHeaders}
+#### `customHttpHeaders` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-customHttpHeaders}
 
 CustomHttpHeaders are additional headers that should be set for the authentication endpoints
 
@@ -2395,7 +2395,7 @@ CustomHttpHeaders are additional headers that should be set for the authenticati
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsFilters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-groupsFilters}
+#### `groupsFilters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-auth-groupsFilters}
 
 GroupsFilters is a regex expression to only save matching sso groups into the user resource
 
@@ -2413,7 +2413,7 @@ GroupsFilters is a regex expression to only save matching sso groups into the us
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc}
+### `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc}
 
 DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secret. By default, vCluster Platform as an OIDC Provider is enabled but does not function without OIDC clients.
 
@@ -2425,7 +2425,7 @@ DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-enabled}
 
 If true indicates that loft will act as an OIDC server
 
@@ -2440,7 +2440,7 @@ If true indicates that loft will act as an OIDC server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `wildcardRedirect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-wildcardRedirect}
+#### `wildcardRedirect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-wildcardRedirect}
 
 If true indicates that loft will allow wildcard '*' in client redirectURIs
 
@@ -2455,7 +2455,7 @@ If true indicates that loft will allow wildcard '*' in client redirectURIs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clients` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients}
+#### `clients` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients}
 
 The clients that are allowed to request loft tokens
 
@@ -2467,7 +2467,7 @@ The clients that are allowed to request loft tokens
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-name}
 
 The client name
 
@@ -2482,7 +2482,7 @@ The client name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientId}
 
 The client id of the client
 
@@ -2497,7 +2497,7 @@ The client id of the client
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-oidc-clients-clientSecret}
 
 The client secret of the client
 
@@ -2534,7 +2534,7 @@ requested to redirect to MUST match one of these values, unless the client is "p
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps}
+### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps}
 
 Apps holds configuration around apps
 
@@ -2546,7 +2546,7 @@ Apps holds configuration around apps
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `noDefault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-noDefault}
+#### `noDefault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-noDefault}
 
 If this option is true, loft will not try to parse the default apps
 
@@ -2561,7 +2561,7 @@ If this option is true, loft will not try to parse the default apps
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `repositories` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories}
+#### `repositories` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories}
 
 These are additional repositories that are parsed by loft
 
@@ -2573,7 +2573,7 @@ These are additional repositories that are parsed by loft
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-name}
 
 Name is the name of the repository
 
@@ -2588,7 +2588,7 @@ Name is the name of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-url}
 
 URL is the repository url
 
@@ -2603,7 +2603,7 @@ URL is the repository url
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-username}
 
 Username of the repository
 
@@ -2618,7 +2618,7 @@ Username of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-password}
 
 Password of the repository
 
@@ -2633,7 +2633,7 @@ Password of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-insecure}
+##### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-repositories-insecure}
 
 Insecure specifies if the chart should be retrieved without TLS
 verification
@@ -2652,7 +2652,7 @@ verification
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `predefinedApps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps}
+#### `predefinedApps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps}
 
 Predefined apps that can be selected in the Spaces ) Space menu
 
@@ -2664,7 +2664,7 @@ Predefined apps that can be selected in the Spaces ) Space menu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-chart}
 
 Chart holds the repo/chart name of the predefined app
 
@@ -2679,7 +2679,7 @@ Chart holds the repo/chart name of the predefined app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initialVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-initialVersion}
+##### `initialVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-initialVersion}
 
 InitialVersion holds the initial version of this app.
 This version will be selected automatically.
@@ -2695,7 +2695,7 @@ This version will be selected automatically.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initialValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-initialValues}
+##### `initialValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-initialValues}
 
 InitialValues holds the initial values for this app.
 The values will be prefilled automatically. There are certain
@@ -2713,7 +2713,7 @@ by the loft UI automatically.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-clusters}
+##### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-clusters}
 
 Holds the cluster names where to display this app
 
@@ -2728,7 +2728,7 @@ Holds the cluster names where to display this app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `title` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-title}
+##### `title` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-title}
 
 Title is the name that should be displayed for the predefined app.
 If empty the chart name is used.
@@ -2744,7 +2744,7 @@ If empty the chart name is used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `iconUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-iconUrl}
+##### `iconUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-iconUrl}
 
 IconURL specifies an url to the icon that should be displayed for this app.
 If none is specified the icon from the chart metadata is used.
@@ -2760,7 +2760,7 @@ If none is specified the icon from the chart metadata is used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readmeUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-readmeUrl}
+##### `readmeUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-apps-predefinedApps-readmeUrl}
 
 ReadmeURL specifies an url to the readme page of this predefined app. If empty
 an url will be constructed to artifact hub.
@@ -2782,7 +2782,7 @@ an url will be constructed to artifact hub.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `audit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit}
+### `audit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit}
 
 Audit holds audit configuration
 
@@ -2794,7 +2794,7 @@ Audit holds audit configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-enabled}
 
 If audit is enabled and incoming api requests will be logged based on the supplied policy.
 
@@ -2809,7 +2809,7 @@ If audit is enabled and incoming api requests will be logged based on the suppli
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disableAgentSyncBack` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-disableAgentSyncBack}
+#### `disableAgentSyncBack` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-disableAgentSyncBack}
 
 If true, the agent will not send back any audit logs to Loft itself.
 
@@ -2824,7 +2824,7 @@ If true, the agent will not send back any audit logs to Loft itself.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-level}
+#### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-level}
 
 Level is an optional log level for audit logs. Cannot be used together with policy
 
@@ -2839,7 +2839,7 @@ Level is an optional log level for audit logs. Cannot be used together with poli
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `policy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy}
+#### `policy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy}
 
 The audit policy to use and log requests. By default loft will not log anything
 
@@ -2851,7 +2851,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -2881,7 +2881,7 @@ The Level that requests matching this rule are recorded at.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-users}
 
 The users (by authenticated user name) this rule applies to.
 An empty list implies every user.
@@ -2897,7 +2897,7 @@ An empty list implies every user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `userGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-userGroups}
+##### `userGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-userGroups}
 
 The user groups this rule applies to. A user is considered matching
 if it is a member of any of the UserGroups.
@@ -2914,7 +2914,7 @@ An empty list implies every user group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -2930,7 +2930,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -2942,7 +2942,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -2958,7 +2958,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -2985,7 +2985,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -3005,7 +3005,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-namespaces}
+##### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -3022,7 +3022,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be audited.
 *s are allowed, but only as the full, final step in the path.
@@ -3041,7 +3041,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-omitStages}
+##### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified policy wide in which case the union of both are omitted.
@@ -3058,7 +3058,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-requestTargets}
+##### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-requestTargets}
 
 RequestTargets is a list of request targets for which events are created.
 An empty list implies every request.
@@ -3074,7 +3074,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-clusters}
+##### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-rules-clusters}
 
 Clusters that this rule matches. Only applies to cluster requests.
 If this is set, no events for non cluster requests will be created.
@@ -3094,7 +3094,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-omitStages}
+##### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-policy-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified per rule in which case the union of both are omitted.
@@ -3113,7 +3113,7 @@ be specified per rule in which case the union of both are omitted.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataStoreEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-dataStoreEndpoint}
+#### `dataStoreEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-dataStoreEndpoint}
 
 DataStoreEndpoint is an endpoint to store events in.
 
@@ -3128,7 +3128,7 @@ DataStoreEndpoint is an endpoint to store events in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataStoreTTL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-dataStoreTTL}
+#### `dataStoreTTL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-dataStoreTTL}
 
 DataStoreMaxAge is the maximum number of hours to retain old log events in the datastore
 
@@ -3143,7 +3143,7 @@ DataStoreMaxAge is the maximum number of hours to retain old log events in the d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-path}
+#### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-path}
 
 The path where to save the audit log files. This is required if audit is enabled. Backup log files will
 be retained in the same directory.
@@ -3159,7 +3159,7 @@ be retained in the same directory.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `maxAge` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxAge}
+#### `maxAge` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxAge}
 
 MaxAge is the maximum number of days to retain old log files based on the
 timestamp encoded in their filename.  Note that a day is defined as 24
@@ -3178,7 +3178,7 @@ based on age.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `maxBackups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxBackups}
+#### `maxBackups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxBackups}
 
 MaxBackups is the maximum number of old log files to retain.  The default
 is to retain all old log files (though MaxAge may still cause them to get
@@ -3195,7 +3195,7 @@ deleted.)
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `maxSize` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxSize}
+#### `maxSize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-maxSize}
 
 MaxSize is the maximum size in megabytes of the log file before it gets
 rotated. It defaults to 100 megabytes.
@@ -3211,7 +3211,7 @@ rotated. It defaults to 100 megabytes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `compress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-compress}
+#### `compress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-audit-compress}
 
 Compress determines if the rotated log files should be compressed
 using gzip. The default is not to perform compression.
@@ -3230,7 +3230,7 @@ using gzip. The default is not to perform compression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `loftHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-loftHost}
+### `loftHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-loftHost}
 
 LoftHost holds the domain where the loft instance is hosted. This should not include https or http. E.g. loft.my-domain.com
 
@@ -3245,7 +3245,7 @@ LoftHost holds the domain where the loft instance is hosted. This should not inc
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `projectNamespacePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-projectNamespacePrefix}
+### `projectNamespacePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-projectNamespacePrefix}
 
 ProjectNamespacePrefix holds the prefix for loft project namespaces. Omitted defaults to "p-"
 
@@ -3260,7 +3260,7 @@ ProjectNamespacePrefix holds the prefix for loft project namespaces. Omitted def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `devPodSubDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-devPodSubDomain}
+### `devPodSubDomain` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-devPodSubDomain}
 
 DEPRECATED: DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.com
 DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.com
@@ -3276,7 +3276,7 @@ DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.co
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `uiSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings}
+### `uiSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings}
 
 UISettings holds the settings for modifying the Loft user interface
 
@@ -3288,7 +3288,7 @@ UISettings holds the settings for modifying the Loft user interface
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `loftVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-loftVersion}
+#### `loftVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-loftVersion}
 
 LoftVersion holds the current loft version
 
@@ -3303,7 +3303,7 @@ LoftVersion holds the current loft version
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `logoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-logoURL}
+#### `logoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-logoURL}
 
 LogoURL is url pointing to the logo to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3319,7 +3319,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `faviconURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-faviconURL}
+#### `faviconURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-faviconURL}
 
 FaviconURL is url pointing to the favicon to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3335,7 +3335,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `smallLogoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-smallLogoURL}
+#### `smallLogoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-smallLogoURL}
 
 SmallLogoURL is url pointing to the small logo to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3351,7 +3351,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `logoBackgroundColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-logoBackgroundColor}
+#### `logoBackgroundColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-logoBackgroundColor}
 
 LogoBackgroundColor is the color value (ex: "#12345") to use as the background color for the logo
 
@@ -3366,7 +3366,7 @@ LogoBackgroundColor is the color value (ex: "#12345") to use as the background c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `legalTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-legalTemplate}
+#### `legalTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-legalTemplate}
 
 LegalTemplate is a text (html) string containing the legal template to prompt to users when authenticating to Loft
 
@@ -3381,7 +3381,7 @@ LegalTemplate is a text (html) string containing the legal template to prompt to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `primaryColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-primaryColor}
+#### `primaryColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-primaryColor}
 
 PrimaryColor is the color value (ex: "#12345") to use as the primary color
 
@@ -3396,7 +3396,7 @@ PrimaryColor is the color value (ex: "#12345") to use as the primary color
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `sidebarColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-sidebarColor}
+#### `sidebarColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-sidebarColor}
 
 SidebarColor is the color value (ex: "#12345") to use for the sidebar
 
@@ -3411,7 +3411,7 @@ SidebarColor is the color value (ex: "#12345") to use for the sidebar
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `accentColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-accentColor}
+#### `accentColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-accentColor}
 
 AccentColor is the color value (ex: "#12345") to use for the accent
 
@@ -3426,7 +3426,7 @@ AccentColor is the color value (ex: "#12345") to use for the accent
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `customCss` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-customCss}
+#### `customCss` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-customCss}
 
 CustomCSS holds URLs with custom css files that should be included when loading the UI
 
@@ -3441,7 +3441,7 @@ CustomCSS holds URLs with custom css files that should be included when loading 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `customJavaScript` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-customJavaScript}
+#### `customJavaScript` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-customJavaScript}
 
 CustomJavaScript holds URLs with custom js files that should be included when loading the UI
 
@@ -3456,7 +3456,7 @@ CustomJavaScript holds URLs with custom js files that should be included when lo
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `navBarButtons` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons}
+#### `navBarButtons` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons}
 
 NavBarButtons holds extra nav bar buttons
 
@@ -3468,7 +3468,7 @@ NavBarButtons holds extra nav bar buttons
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `position` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-position}
+##### `position` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-position}
 
 Position holds the position of the button, can be one of:
 TopStart, TopEnd, BottomStart, BottomEnd. Defaults to BottomEnd
@@ -3484,7 +3484,7 @@ TopStart, TopEnd, BottomStart, BottomEnd. Defaults to BottomEnd
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `text` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-text}
+##### `text` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-text}
 
 Text holds text for the button
 
@@ -3499,7 +3499,7 @@ Text holds text for the button
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `link` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-link}
+##### `link` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-link}
 
 Link holds the link of the navbar button
 
@@ -3514,7 +3514,7 @@ Link holds the link of the navbar button
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-icon}
+##### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-navBarButtons-icon}
 
 Icon holds the url of the icon to display
 
@@ -3532,7 +3532,7 @@ Icon holds the url of the icon to display
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `externalURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs}
+#### `externalURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs}
 
 External URLs that can be called from the UI
 
@@ -3544,7 +3544,7 @@ External URLs that can be called from the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `block` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs-block}
+##### `block` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs-block}
 
 Block determines if requests to external URLs from the UI should be blocked
 
@@ -3559,7 +3559,7 @@ Block determines if requests to external URLs from the UI should be blocked
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs-allow}
+##### `allow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uiSettings-externalURLs-allow}
 
 Allow specifies which external URLs can be called. In addition to the predefined modules,
 - "vcluster" (license page, feature descriptions, ...)
@@ -3585,7 +3585,7 @@ This is only active when Block is true.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault}
+### `vault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault}
 
 VaultIntegration holds the vault integration configuration
 
@@ -3597,7 +3597,7 @@ VaultIntegration holds the vault integration configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-enabled}
 
 Enabled indicates if the Vault Integration is enabled for the project -- this knob only
 enables the syncing of secrets to or from Vault, but does not setup Kubernetes authentication
@@ -3614,7 +3614,7 @@ methods or Kubernetes secrets engines for vclusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `address` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-address}
+#### `address` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-address}
 
 Address defines the address of the Vault instance to use for this project.
 Will default to the `VAULT_ADDR` environment variable if not provided.
@@ -3630,7 +3630,7 @@ Will default to the `VAULT_ADDR` environment variable if not provided.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `skipTLSVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-skipTLSVerify}
+#### `skipTLSVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-skipTLSVerify}
 
 SkipTLSVerify defines if TLS verification should be skipped when connecting to Vault.
 
@@ -3645,7 +3645,7 @@ SkipTLSVerify defines if TLS verification should be skipped when connecting to V
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-namespace}
 
 Namespace defines the namespace to use when storing secrets in Vault.
 
@@ -3660,7 +3660,7 @@ Namespace defines the namespace to use when storing secrets in Vault.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth}
+#### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth}
 
 Auth defines the authentication method to use for this project.
 
@@ -3672,7 +3672,7 @@ Auth defines the authentication method to use for this project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-token}
+##### `token` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-token}
 
 Token defines the token to use for authentication.
 
@@ -3687,7 +3687,7 @@ Token defines the token to use for authentication.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tokenSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef}
+##### `tokenSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef}
 
 TokenSecretRef defines the Kubernetes secret to use for token authentication.
 Will be used if `token` is not provided.
@@ -3702,7 +3702,7 @@ Secret data should contain the `token` key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef-name}
 
 Name of the referent.
 This field is effectively required, but due to backwards compatibility is
@@ -3737,7 +3737,7 @@ The key of the secret to select from.  Must be a valid secret key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef-optional}
+##### `optional` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-auth-tokenSecretRef-optional}
 
 Specify whether the Secret or its key must be defined
 
@@ -3758,7 +3758,7 @@ Specify whether the Secret or its key must be defined
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-syncInterval}
+#### `syncInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-vault-syncInterval}
 
 SyncInterval defines the interval at which to sync secrets from Vault.
 Defaults to `1m.`
@@ -3778,7 +3778,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableConfigEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-disableConfigEndpoint}
+### `disableConfigEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-disableConfigEndpoint}
 
 DisableLoftConfigEndpoint will disable setting config via the UI and config.management.loft.sh endpoint
 
@@ -3793,7 +3793,7 @@ DisableLoftConfigEndpoint will disable setting config via the UI and config.mana
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `authenticateVersionEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-authenticateVersionEndpoint}
+### `authenticateVersionEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-authenticateVersionEndpoint}
 
 AuthenticateVersionEndpoint will force authentication for the '/version' endpoint. Will only work with vCluster v0.27 & later
 
@@ -3808,7 +3808,7 @@ AuthenticateVersionEndpoint will force authentication for the '/version' endpoin
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cloud` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud}
+### `cloud` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud}
 
 Cloud holds the settings to be used exclusively in vCluster Cloud based
 environments and deployments.
@@ -3821,7 +3821,7 @@ environments and deployments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `releaseChannel` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-releaseChannel}
+#### `releaseChannel` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-releaseChannel}
 
 ReleaseChannel specifies the release channel for the cloud configuration.
 This can be used to determine which updates or versions are applied.
@@ -3837,7 +3837,7 @@ This can be used to determine which updates or versions are applied.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `maintenanceWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow}
+#### `maintenanceWindow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow}
 
 MaintenanceWindow specifies the maintenance window for the cloud configuration.
 This is a structured representation of the time window during which maintenance can occur.
@@ -3850,7 +3850,7 @@ This is a structured representation of the time window during which maintenance 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dayOfWeek` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-dayOfWeek}
+##### `dayOfWeek` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-dayOfWeek}
 
 DayOfWeek specifies the day of the week for the maintenance window.
 It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
@@ -3866,7 +3866,7 @@ It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-timeWindow}
+##### `timeWindow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-cloud-maintenanceWindow-timeWindow}
 
 TimeWindow specifies the time window for the maintenance.
 It should be a string representing the time range in 24-hour format, in UTC, e.g., "02:00-03:00".
@@ -3888,7 +3888,7 @@ It should be a string representing the time range in 24-hour format, in UTC, e.g
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `costControl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl}
+### `costControl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl}
 
 CostControl holds the settings related to the Cost Control ROI dashboard and its metrics gathering infrastructure
 
@@ -3900,7 +3900,7 @@ CostControl holds the settings related to the Cost Control ROI dashboard and its
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-enabled}
 
 Enabled specifies whether the ROI dashboard should be available in the UI, and if the metrics infrastructure
 that provides dashboard data is deployed
@@ -3916,7 +3916,7 @@ that provides dashboard data is deployed
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `global` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global}
+#### `global` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global}
 
 Global are settings for globally managed components
 
@@ -3928,7 +3928,7 @@ Global are settings for globally managed components
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics}
+##### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics}
 
 Metrics these settings apply to metric infrastructure used to aggregate metrics across all connected clusters
 
@@ -3940,7 +3940,7 @@ Metrics these settings apply to metric infrastructure used to aggregate metrics 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -3955,7 +3955,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -3967,7 +3967,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -3983,7 +3983,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4001,7 +4001,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4037,7 +4037,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4061,7 +4061,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4076,7 +4076,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage}
 
 
 
@@ -4088,7 +4088,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4105,7 +4105,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-global-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4129,7 +4129,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster}
+#### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster}
 
 Cluster are settings for each cluster's managed components. These settings apply to all connected clusters
 unless overridden by modifying the Cluster's spec
@@ -4142,7 +4142,7 @@ unless overridden by modifying the Cluster's spec
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics}
+##### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics}
 
 Metrics are settings applied to metric infrastructure in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4155,7 +4155,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4170,7 +4170,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4182,7 +4182,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4198,7 +4198,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4216,7 +4216,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4252,7 +4252,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4276,7 +4276,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4291,7 +4291,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage}
 
 
 
@@ -4303,7 +4303,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4320,7 +4320,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4341,7 +4341,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost}
+##### `opencost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost}
 
 OpenCost are settings applied to OpenCost deployments in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4354,7 +4354,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4369,7 +4369,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -4381,7 +4381,7 @@ Resources are compute resource required by the OpenCost backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4397,7 +4397,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4415,7 +4415,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4451,7 +4451,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-cluster-opencost-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4481,7 +4481,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `settings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings}
+#### `settings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings}
 
 Settings specify price-related settings that are taken into account for the ROI dashboard calculations.
 
@@ -4493,7 +4493,7 @@ Settings specify price-related settings that are taken into account for the ROI 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priceCurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-priceCurrency}
+##### `priceCurrency` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-priceCurrency}
 
 PriceCurrency specifies the currency.
 
@@ -4508,7 +4508,7 @@ PriceCurrency specifies the currency.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageCPUPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode}
+##### `averageCPUPricePerNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode}
 
 AvgCPUPricePerNode specifies the average CPU price per node.
 
@@ -4520,7 +4520,7 @@ AvgCPUPricePerNode specifies the average CPU price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-price}
 
 Price specifies the price.
 
@@ -4535,7 +4535,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageCPUPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4553,7 +4553,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageRAMPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode}
+##### `averageRAMPricePerNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode}
 
 AvgRAMPricePerNode specifies the average RAM price per node.
 
@@ -4565,7 +4565,7 @@ AvgRAMPricePerNode specifies the average RAM price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-price}
 
 Price specifies the price.
 
@@ -4580,7 +4580,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-averageRAMPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4598,7 +4598,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `gpuSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings}
+##### `gpuSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings}
 
 GPUSettings specifies GPU related settings.
 
@@ -4610,7 +4610,7 @@ GPUSettings specifies GPU related settings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-enabled}
 
 Enabled specifies whether GPU settings should be available in the UI.
 
@@ -4625,7 +4625,7 @@ Enabled specifies whether GPU settings should be available in the UI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageGPUPrice` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice}
+##### `averageGPUPrice` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice}
 
 AvgGPUPrice specifies the average GPU price.
 
@@ -4637,7 +4637,7 @@ AvgGPUPrice specifies the average GPU price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-price}
 
 Price specifies the price.
 
@@ -4652,7 +4652,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4673,7 +4673,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster}
+##### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster}
 
 ControlPlanePricePerCluster specifies the price of one physical cluster.
 
@@ -4685,7 +4685,7 @@ ControlPlanePricePerCluster specifies the price of one physical cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-price}
 
 Price specifies the price.
 
@@ -4700,7 +4700,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-costControl-settings-controlPlanePricePerCluster-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4724,7 +4724,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `platformDB` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB}
+### `platformDB` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB}
 
 PlatformDB holds the settings related to the postgres database that platform uses to store data
 
@@ -4736,7 +4736,7 @@ PlatformDB holds the settings related to the postgres database that platform use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB-storageClass}
+#### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-platformDB-storageClass}
 
 StorageClass sets the storage class for the PersistentVolumeClaim used by the platform database statefulSet.
 
@@ -4754,7 +4754,7 @@ StorageClass sets the storage class for the PersistentVolumeClaim used by the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imageBuilder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder}
+### `imageBuilder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder}
 
 ImageBuilder holds the settings related to the image builder
 
@@ -4766,7 +4766,7 @@ ImageBuilder holds the settings related to the image builder
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-enabled}
 
 Enabled specifies whether the remote image builder should be available.
 If it's not available building ad-hoc images from a devcontainer.json is not supported
@@ -4782,7 +4782,7 @@ If it's not available building ad-hoc images from a devcontainer.json is not sup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-replicas}
+#### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4797,7 +4797,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources}
 
 Resources are compute resource required by the buildkit containers
 
@@ -4809,7 +4809,7 @@ Resources are compute resource required by the buildkit containers
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4825,7 +4825,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4843,7 +4843,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4879,7 +4879,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-imageBuilder-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4906,7 +4906,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database}
+### `database` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database}
 
 Database represents the database connection settings when deploying the platform with an embedded Kubernetes backed by kine
 
@@ -4918,7 +4918,7 @@ Database represents the database connection settings when deploying the platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-enabled}
 
 Enabled defines if the database should be used.
 
@@ -4933,7 +4933,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-dataSource}
+#### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -4951,7 +4951,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-identityProvider}
+#### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -4968,7 +4968,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-keyFile}
+#### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -4983,7 +4983,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-certFile}
+#### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -4998,7 +4998,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-caFile}
+#### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -5013,7 +5013,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-database-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status/audit.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status/audit.mdx
@@ -61,7 +61,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rules` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules}
+### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status/audit.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status/audit.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#enabled}
+## `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#enabled}
 
 If audit is enabled and incoming api requests will be logged based on the supplied policy.
 
@@ -19,7 +19,7 @@ If audit is enabled and incoming api requests will be logged based on the suppli
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `disableAgentSyncBack` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableAgentSyncBack}
+## `disableAgentSyncBack` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableAgentSyncBack}
 
 If true, the agent will not send back any audit logs to Loft itself.
 
@@ -34,7 +34,7 @@ If true, the agent will not send back any audit logs to Loft itself.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#level}
+## `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#level}
 
 Level is an optional log level for audit logs. Cannot be used together with policy
 
@@ -49,7 +49,7 @@ Level is an optional log level for audit logs. Cannot be used together with poli
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `policy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy}
+## `policy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy}
 
 The audit policy to use and log requests. By default loft will not log anything
 
@@ -61,7 +61,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules}
+### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -91,7 +91,7 @@ The Level that requests matching this rule are recorded at.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-users}
 
 The users (by authenticated user name) this rule applies to.
 An empty list implies every user.
@@ -107,7 +107,7 @@ An empty list implies every user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `userGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-userGroups}
+#### `userGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-userGroups}
 
 The user groups this rule applies to. A user is considered matching
 if it is a member of any of the UserGroups.
@@ -124,7 +124,7 @@ An empty list implies every user group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-verbs}
+#### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -140,7 +140,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -152,7 +152,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -168,7 +168,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -195,7 +195,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -215,7 +215,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -232,7 +232,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-nonResourceURLs}
+#### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be audited.
 *s are allowed, but only as the full, final step in the path.
@@ -251,7 +251,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-omitStages}
+#### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified policy wide in which case the union of both are omitted.
@@ -268,7 +268,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-requestTargets}
+#### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-requestTargets}
 
 RequestTargets is a list of request targets for which events are created.
 An empty list implies every request.
@@ -284,7 +284,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-clusters}
+#### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-rules-clusters}
 
 Clusters that this rule matches. Only applies to cluster requests.
 If this is set, no events for non cluster requests will be created.
@@ -304,7 +304,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-omitStages}
+### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policy-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified per rule in which case the union of both are omitted.
@@ -323,7 +323,7 @@ be specified per rule in which case the union of both are omitted.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `dataStoreEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dataStoreEndpoint}
+## `dataStoreEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dataStoreEndpoint}
 
 DataStoreEndpoint is an endpoint to store events in.
 
@@ -338,7 +338,7 @@ DataStoreEndpoint is an endpoint to store events in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `dataStoreTTL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dataStoreTTL}
+## `dataStoreTTL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dataStoreTTL}
 
 DataStoreMaxAge is the maximum number of hours to retain old log events in the datastore
 
@@ -353,7 +353,7 @@ DataStoreMaxAge is the maximum number of hours to retain old log events in the d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#path}
+## `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#path}
 
 The path where to save the audit log files. This is required if audit is enabled. Backup log files will
 be retained in the same directory.
@@ -369,7 +369,7 @@ be retained in the same directory.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `maxAge` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxAge}
+## `maxAge` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxAge}
 
 MaxAge is the maximum number of days to retain old log files based on the
 timestamp encoded in their filename.  Note that a day is defined as 24
@@ -388,7 +388,7 @@ based on age.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `maxBackups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxBackups}
+## `maxBackups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxBackups}
 
 MaxBackups is the maximum number of old log files to retain.  The default
 is to retain all old log files (though MaxAge may still cause them to get
@@ -405,7 +405,7 @@ deleted.)
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `maxSize` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxSize}
+## `maxSize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#maxSize}
 
 MaxSize is the maximum size in megabytes of the log file before it gets
 rotated. It defaults to 100 megabytes.
@@ -421,7 +421,7 @@ rotated. It defaults to 100 megabytes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `compress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#compress}
+## `compress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#compress}
 
 Compress determines if the rotated log files should be compressed
 using gzip. The default is not to perform compression.

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status/audit/policy.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status/audit/policy.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules}
+## `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -34,7 +34,7 @@ The Level that requests matching this rule are recorded at.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-users}
+### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-users}
 
 The users (by authenticated user name) this rule applies to.
 An empty list implies every user.
@@ -50,7 +50,7 @@ An empty list implies every user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `userGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-userGroups}
+### `userGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-userGroups}
 
 The user groups this rule applies to. A user is considered matching
 if it is a member of any of the UserGroups.
@@ -67,7 +67,7 @@ An empty list implies every user group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-verbs}
+### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -83,7 +83,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources}
+### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -95,7 +95,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-group}
+#### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -111,7 +111,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -138,7 +138,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-resourceNames}
+#### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -158,7 +158,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -175,7 +175,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-nonResourceURLs}
+### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be audited.
 *s are allowed, but only as the full, final step in the path.
@@ -194,7 +194,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-omitStages}
+### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified policy wide in which case the union of both are omitted.
@@ -211,7 +211,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-requestTargets}
+### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-requestTargets}
 
 RequestTargets is a list of request targets for which events are created.
 An empty list implies every request.
@@ -227,7 +227,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-clusters}
+### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules-clusters}
 
 Clusters that this rule matches. Only applies to cluster requests.
 If this is set, no events for non cluster requests will be created.
@@ -247,7 +247,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#omitStages}
+## `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified per rule in which case the union of both are omitted.

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status/audit/policy.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status/audit/policy.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `rules` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules}
+## `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status_reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status_reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth}
+## `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth}
 
 Authentication holds the information for authentication
 
@@ -16,7 +16,7 @@ Authentication holds the information for authentication
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc}
+### `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc}
 
 OIDC holds oidc authentication configuration
 
@@ -28,7 +28,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-issuerUrl}
+#### `issuerUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -51,7 +51,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientId}
+#### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -71,7 +71,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientSecret}
+#### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -86,7 +86,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-redirectURI}
+#### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -101,7 +101,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `postLogoutRedirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-postLogoutRedirectURI}
+#### `postLogoutRedirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-postLogoutRedirectURI}
 
 Loft URI to be redirected to after successful logout by OIDC Provider
 
@@ -116,7 +116,7 @@ Loft URI to be redirected to after successful logout by OIDC Provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-caFile}
+#### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-caFile}
 
 Path to a PEM encoded root certificate of the provider. Optional
 
@@ -131,7 +131,7 @@ Path to a PEM encoded root certificate of the provider. Optional
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecureCa` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-insecureCa}
+#### `insecureCa` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-insecureCa}
 
 Specify whether to communicate without validating SSL certificates
 
@@ -146,7 +146,7 @@ Specify whether to communicate without validating SSL certificates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preferredUsername` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-preferredUsername}
+#### `preferredUsername` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-preferredUsername}
 
 Configurable key which contains the preferred username claims
 
@@ -161,7 +161,7 @@ Configurable key which contains the preferred username claims
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `loftUsernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-loftUsernameClaim}
+#### `loftUsernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-loftUsernameClaim}
 
 LoftUsernameClaim is the JWT field to use as the user's username.
 
@@ -176,7 +176,7 @@ LoftUsernameClaim is the JWT field to use as the user's username.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `usernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-usernameClaim}
+#### `usernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-usernameClaim}
 
 UsernameClaim is the JWT field to use as the user's id.
 
@@ -191,7 +191,7 @@ UsernameClaim is the JWT field to use as the user's id.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `emailClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-emailClaim}
+#### `emailClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-emailClaim}
 
 EmailClaim is the JWT field to use as the user's email.
 
@@ -206,7 +206,7 @@ EmailClaim is the JWT field to use as the user's email.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allowedExtraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-allowedExtraClaims}
+#### `allowedExtraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-allowedExtraClaims}
 
 AllowedExtraClaims are claims of interest that are not part of User by default but may be provided by the OIDC provider.
 
@@ -221,7 +221,7 @@ AllowedExtraClaims are claims of interest that are not part of User by default b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `usernamePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-usernamePrefix}
+#### `usernamePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-usernamePrefix}
 
 UsernamePrefix, if specified, causes claims mapping to username to be prefix with
 the provided value. A value "oidc:" would result in usernames like "oidc:john".
@@ -237,7 +237,7 @@ the provided value. A value "oidc:" would result in usernames like "oidc:john".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groupsClaim}
+#### `groupsClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groupsClaim}
 
 GroupsClaim, if specified, causes the OIDCAuthenticator to try to populate the user's
 groups with an ID Token field. If the GroupsClaim field is present in an ID Token the value
@@ -254,7 +254,7 @@ must be a string or list of strings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groups}
+#### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groups}
 
 If required groups is non empty, access is denied if the user is not part of at least one
 of the specified groups.
@@ -270,7 +270,7 @@ of the specified groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-scopes}
+#### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-scopes}
 
 Scopes that should be sent to the server. If empty, defaults to "email" and "profile".
 
@@ -285,7 +285,7 @@ Scopes that should be sent to the server. If empty, defaults to "email" and "pro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `getUserInfo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-getUserInfo}
+#### `getUserInfo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-getUserInfo}
 
 GetUserInfo, if specified, tells the OIDCAuthenticator to try to populate the user's
 information from the UserInfo.
@@ -301,7 +301,7 @@ information from the UserInfo.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsPrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groupsPrefix}
+#### `groupsPrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-groupsPrefix}
 
 GroupsPrefix, if specified, causes claims mapping to group names to be prefixed with the
 value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:marketing".
@@ -317,7 +317,7 @@ value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-type}
+#### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-type}
 
 Type of the OIDC to show in the UI. Only for displaying purposes
 
@@ -332,7 +332,7 @@ Type of the OIDC to show in the UI. Only for displaying purposes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-resource}
+#### `resource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-resource}
 
 Resource, if specified, is the value that is set for the "resource" URL parameter when making a request to the /token endpoint of the
 OIDC provider.
@@ -351,7 +351,7 @@ OIDC provider.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `github` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github}
+### `github` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github}
 
 Github holds github authentication configuration
 
@@ -363,7 +363,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-clientId}
+#### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-clientId}
 
 ClientID holds the github client id
 
@@ -408,7 +408,7 @@ RedirectURI holds the redirect URI. Should be https://loft.domain.tld/auth/githu
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `orgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs}
+#### `orgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs}
 
 Loft queries the following organizations for group information.
 Group claims are formatted as "(org):(team)".
@@ -426,7 +426,7 @@ authenticate with loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs-name}
 
 Organization name in github (not slug, full name). Only users in this github
 organization can authenticate.
@@ -442,7 +442,7 @@ organization can authenticate.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-orgs-teams}
 
 Names of teams in a github organization. A user will be able to
 authenticate if they are members of at least one of these teams. Users
@@ -463,7 +463,7 @@ config file.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-hostName}
+#### `hostName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-hostName}
 
 Required ONLY for GitHub Enterprise.
 This is the Hostname of the GitHub Enterprise account listed on the
@@ -480,7 +480,7 @@ management console. Ensure this domain is routable on your network.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `rootCA` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-rootCA}
+#### `rootCA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-rootCA}
 
 ONLY for GitHub Enterprise. Optional field.
 Used to support self-signed or untrusted CA root certificates.
@@ -499,7 +499,7 @@ Used to support self-signed or untrusted CA root certificates.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `gitlab` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab}
+### `gitlab` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab}
 
 Gitlab holds gitlab authentication configuration
 
@@ -556,7 +556,7 @@ Redirect URI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `baseURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab-baseURL}
+#### `baseURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab-baseURL}
 
 BaseURL is optional, default = https://gitlab.com
 
@@ -571,7 +571,7 @@ BaseURL is optional, default = https://gitlab.com
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab-groups}
+#### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-gitlab-groups}
 
 Optional groups whitelist, communicated through the "groups" scope.
 If `groups` is omitted, all of the user's GitLab groups are returned.
@@ -591,7 +591,7 @@ If `groups` is provided, this acts as a whitelist - only the user's GitLab group
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `google` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google}
+### `google` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google}
 
 Google holds google authentication configuration
 
@@ -648,7 +648,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/google/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-scopes}
+#### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-scopes}
 
 defaults to "profile" and "email"
 
@@ -663,7 +663,7 @@ defaults to "profile" and "email"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostedDomains` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-hostedDomains}
+#### `hostedDomains` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-hostedDomains}
 
 Optional list of whitelisted domains
 If this field is nonempty, only users from a listed domain will be allowed to log in
@@ -679,7 +679,7 @@ If this field is nonempty, only users from a listed domain will be allowed to lo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-groups}
+#### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-groups}
 
 Optional list of whitelisted groups
 If this field is nonempty, only users from a listed group will be allowed to log in
@@ -695,7 +695,7 @@ If this field is nonempty, only users from a listed group will be allowed to log
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serviceAccountFilePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-serviceAccountFilePath}
+#### `serviceAccountFilePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-serviceAccountFilePath}
 
 Optional path to service account json
 If nonempty, and groups claim is made, will use authentication from file to
@@ -712,7 +712,7 @@ check groups with the admin directory api
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `adminEmail` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-adminEmail}
+#### `adminEmail` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-google-adminEmail}
 
 Required if ServiceAccountFilePath
 The email of a GSuite super user which the service account will impersonate
@@ -732,7 +732,7 @@ when listing groups
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `microsoft` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft}
+### `microsoft` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft}
 
 Microsoft holds microsoft authentication configuration
 
@@ -789,7 +789,7 @@ loft redirect uri. Usually https://loft.my.domain/auth/microsoft/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tenant` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-tenant}
+#### `tenant` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-tenant}
 
 tenant configuration parameter controls what kinds of accounts may be authenticated in loft.
 By default, all types of Microsoft accounts (consumers and organizations) can authenticate in loft via Microsoft.
@@ -811,7 +811,7 @@ tenant uuid or tenant name - only accounts belonging to specific tenant identifi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-groups}
+#### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-groups}
 
 It is possible to require a user to be a member of a particular group in order to be successfully authenticated in loft.
 
@@ -826,7 +826,7 @@ It is possible to require a user to be a member of a particular group in order t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `onlySecurityGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-onlySecurityGroups}
+#### `onlySecurityGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-onlySecurityGroups}
 
 configuration option restricts the list to include only security groups. By default all groups (security, Office 365, mailing lists) are included.
 
@@ -841,7 +841,7 @@ configuration option restricts the list to include only security groups. By defa
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-useGroupsAsWhitelist}
+#### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-microsoft-useGroupsAsWhitelist}
 
 Restrict the groups claims to include only the user’s groups that are in the configured groups
 
@@ -859,7 +859,7 @@ Restrict the groups claims to include only the user’s groups that are in the c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `saml` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml}
+### `saml` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml}
 
 SAML holds saml authentication configuration
 
@@ -871,7 +871,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-redirectURI}
+#### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -888,7 +888,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoURL}
+#### `ssoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -903,7 +903,7 @@ SSO URL used for POST value.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caData` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-caData}
+#### `caData` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-caData}
 
 CAData is a base64 encoded string that holds the ca certificate for validating the signature of the SAML response.
 Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
@@ -919,7 +919,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-usernameAttr}
+#### `usernameAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -934,7 +934,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-emailAttr}
+#### `emailAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -949,7 +949,7 @@ Name of attribute in the returned assertions to map to email
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-groupsAttr}
+#### `groupsAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-groupsAttr}
 
 Name of attribute in the returned assertions to map to groups
 
@@ -964,7 +964,7 @@ Name of attribute in the returned assertions to map to groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ca` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ca}
+#### `ca` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ca}
 
 CA to use when validating the signature of the SAML response.
 
@@ -979,7 +979,7 @@ CA to use when validating the signature of the SAML response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-insecureSkipSignatureValidation}
+#### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-insecureSkipSignatureValidation}
 
 Ignore the ca cert
 
@@ -994,7 +994,7 @@ Ignore the ca cert
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `entityIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-entityIssuer}
+#### `entityIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-entityIssuer}
 
 When provided Loft will include this as the Issuer value during AuthnRequest.
 It will also override the redirectURI as the required audience when evaluating
@@ -1011,7 +1011,7 @@ AudienceRestriction elements in the response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ssoIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoIssuer}
+#### `ssoIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoIssuer}
 
 Issuer value expected in the SAML response. Optional.
 
@@ -1026,7 +1026,7 @@ Issuer value expected in the SAML response. Optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groupsDelim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-groupsDelim}
+#### `groupsDelim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-groupsDelim}
 
 If GroupsDelim is supplied the connector assumes groups are returned as a
 single string instead of multiple attribute values. This delimiter will be
@@ -1043,7 +1043,7 @@ used split the groups string.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allowedGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-allowedGroups}
+#### `allowedGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-allowedGroups}
 
 List of groups to filter access based on membership
 
@@ -1058,7 +1058,7 @@ List of groups to filter access based on membership
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `filterGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-filterGroups}
+#### `filterGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-filterGroups}
 
 If used with allowed groups, only forwards the allowed groups and not all
 groups specified.
@@ -1074,7 +1074,7 @@ groups specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nameIDPolicyFormat` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-nameIDPolicyFormat}
+#### `nameIDPolicyFormat` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-nameIDPolicyFormat}
 
 Requested format of the NameID. The NameID value is is mapped to the ID Token
 'sub' claim.
@@ -1103,7 +1103,7 @@ If no value is specified, this value defaults to:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password}
+### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password}
 
 Password holds password authentication relevant information
 
@@ -1115,7 +1115,7 @@ Password holds password authentication relevant information
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password-disabled}
+#### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password-disabled}
 
 If true login via password is disabled
 
@@ -1133,7 +1133,7 @@ If true login via password is disabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `connectors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors}
+### `connectors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors}
 
 Connectors are optional additional connectors for Loft.
 
@@ -1145,7 +1145,7 @@ Connectors are optional additional connectors for Loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `id` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-id}
+#### `id` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-id}
 
 ID is the id that should show up in the url
 
@@ -1160,7 +1160,7 @@ ID is the id that should show up in the url
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-displayName}
 
 DisplayName is the name that should show up in the ui
 
@@ -1175,7 +1175,7 @@ DisplayName is the name that should show up in the ui
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc}
+#### `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc}
 
 OIDC holds oidc authentication configuration
 
@@ -1187,7 +1187,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -1210,7 +1210,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -1230,7 +1230,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -1245,7 +1245,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -1260,7 +1260,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-postLogoutRedirectURI}
+##### `postLogoutRedirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-postLogoutRedirectURI}
 
 Loft URI to be redirected to after successful logout by OIDC Provider
 
@@ -1275,7 +1275,7 @@ Loft URI to be redirected to after successful logout by OIDC Provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-caFile}
 
 Path to a PEM encoded root certificate of the provider. Optional
 
@@ -1290,7 +1290,7 @@ Path to a PEM encoded root certificate of the provider. Optional
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureCa` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-insecureCa}
+##### `insecureCa` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-insecureCa}
 
 Specify whether to communicate without validating SSL certificates
 
@@ -1305,7 +1305,7 @@ Specify whether to communicate without validating SSL certificates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `preferredUsername` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-preferredUsername}
+##### `preferredUsername` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-preferredUsername}
 
 Configurable key which contains the preferred username claims
 
@@ -1320,7 +1320,7 @@ Configurable key which contains the preferred username claims
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `loftUsernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-loftUsernameClaim}
+##### `loftUsernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-loftUsernameClaim}
 
 LoftUsernameClaim is the JWT field to use as the user's username.
 
@@ -1335,7 +1335,7 @@ LoftUsernameClaim is the JWT field to use as the user's username.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-usernameClaim}
+##### `usernameClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-usernameClaim}
 
 UsernameClaim is the JWT field to use as the user's id.
 
@@ -1350,7 +1350,7 @@ UsernameClaim is the JWT field to use as the user's id.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-emailClaim}
+##### `emailClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-emailClaim}
 
 EmailClaim is the JWT field to use as the user's email.
 
@@ -1365,7 +1365,7 @@ EmailClaim is the JWT field to use as the user's email.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedExtraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-allowedExtraClaims}
+##### `allowedExtraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-allowedExtraClaims}
 
 AllowedExtraClaims are claims of interest that are not part of User by default but may be provided by the OIDC provider.
 
@@ -1380,7 +1380,7 @@ AllowedExtraClaims are claims of interest that are not part of User by default b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernamePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-usernamePrefix}
+##### `usernamePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-usernamePrefix}
 
 UsernamePrefix, if specified, causes claims mapping to username to be prefix with
 the provided value. A value "oidc:" would result in usernames like "oidc:john".
@@ -1396,7 +1396,7 @@ the provided value. A value "oidc:" would result in usernames like "oidc:john".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groupsClaim}
+##### `groupsClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groupsClaim}
 
 GroupsClaim, if specified, causes the OIDCAuthenticator to try to populate the user's
 groups with an ID Token field. If the GroupsClaim field is present in an ID Token the value
@@ -1413,7 +1413,7 @@ must be a string or list of strings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groups}
 
 If required groups is non empty, access is denied if the user is not part of at least one
 of the specified groups.
@@ -1429,7 +1429,7 @@ of the specified groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-scopes}
 
 Scopes that should be sent to the server. If empty, defaults to "email" and "profile".
 
@@ -1444,7 +1444,7 @@ Scopes that should be sent to the server. If empty, defaults to "email" and "pro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `getUserInfo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-getUserInfo}
+##### `getUserInfo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-getUserInfo}
 
 GetUserInfo, if specified, tells the OIDCAuthenticator to try to populate the user's
 information from the UserInfo.
@@ -1460,7 +1460,7 @@ information from the UserInfo.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsPrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groupsPrefix}
+##### `groupsPrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-groupsPrefix}
 
 GroupsPrefix, if specified, causes claims mapping to group names to be prefixed with the
 value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:marketing".
@@ -1476,7 +1476,7 @@ value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-type}
 
 Type of the OIDC to show in the UI. Only for displaying purposes
 
@@ -1491,7 +1491,7 @@ Type of the OIDC to show in the UI. Only for displaying purposes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-resource}
+##### `resource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-resource}
 
 Resource, if specified, is the value that is set for the "resource" URL parameter when making a request to the /token endpoint of the
 OIDC provider.
@@ -1510,7 +1510,7 @@ OIDC provider.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `github` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github}
+#### `github` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github}
 
 Github holds github authentication configuration
 
@@ -1522,7 +1522,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-clientId}
 
 ClientID holds the github client id
 
@@ -1567,7 +1567,7 @@ RedirectURI holds the redirect URI. Should be https://loft.domain.tld/auth/githu
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `orgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs}
+##### `orgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs}
 
 Loft queries the following organizations for group information.
 Group claims are formatted as "(org):(team)".
@@ -1585,7 +1585,7 @@ authenticate with loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs-name}
 
 Organization name in github (not slug, full name). Only users in this github
 organization can authenticate.
@@ -1601,7 +1601,7 @@ organization can authenticate.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-orgs-teams}
 
 Names of teams in a github organization. A user will be able to
 authenticate if they are members of at least one of these teams. Users
@@ -1622,7 +1622,7 @@ config file.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-hostName}
+##### `hostName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-hostName}
 
 Required ONLY for GitHub Enterprise.
 This is the Hostname of the GitHub Enterprise account listed on the
@@ -1639,7 +1639,7 @@ management console. Ensure this domain is routable on your network.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rootCA` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-rootCA}
+##### `rootCA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-rootCA}
 
 ONLY for GitHub Enterprise. Optional field.
 Used to support self-signed or untrusted CA root certificates.
@@ -1658,7 +1658,7 @@ Used to support self-signed or untrusted CA root certificates.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gitlab` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab}
+#### `gitlab` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab}
 
 Gitlab holds gitlab authentication configuration
 
@@ -1715,7 +1715,7 @@ Redirect URI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `baseURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab-baseURL}
+##### `baseURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab-baseURL}
 
 BaseURL is optional, default = https://gitlab.com
 
@@ -1730,7 +1730,7 @@ BaseURL is optional, default = https://gitlab.com
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-gitlab-groups}
 
 Optional groups whitelist, communicated through the "groups" scope.
 If `groups` is omitted, all of the user's GitLab groups are returned.
@@ -1750,7 +1750,7 @@ If `groups` is provided, this acts as a whitelist - only the user's GitLab group
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `google` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google}
+#### `google` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google}
 
 Google holds google authentication configuration
 
@@ -1807,7 +1807,7 @@ loft redirect uri. E.g. https://loft.my.domain/auth/google/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-scopes}
+##### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-scopes}
 
 defaults to "profile" and "email"
 
@@ -1822,7 +1822,7 @@ defaults to "profile" and "email"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostedDomains` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-hostedDomains}
+##### `hostedDomains` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-hostedDomains}
 
 Optional list of whitelisted domains
 If this field is nonempty, only users from a listed domain will be allowed to log in
@@ -1838,7 +1838,7 @@ If this field is nonempty, only users from a listed domain will be allowed to lo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-groups}
 
 Optional list of whitelisted groups
 If this field is nonempty, only users from a listed group will be allowed to log in
@@ -1854,7 +1854,7 @@ If this field is nonempty, only users from a listed group will be allowed to log
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `serviceAccountFilePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-serviceAccountFilePath}
+##### `serviceAccountFilePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-serviceAccountFilePath}
 
 Optional path to service account json
 If nonempty, and groups claim is made, will use authentication from file to
@@ -1871,7 +1871,7 @@ check groups with the admin directory api
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `adminEmail` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-adminEmail}
+##### `adminEmail` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-google-adminEmail}
 
 Required if ServiceAccountFilePath
 The email of a GSuite super user which the service account will impersonate
@@ -1891,7 +1891,7 @@ when listing groups
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `microsoft` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft}
+#### `microsoft` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft}
 
 Microsoft holds microsoft authentication configuration
 
@@ -1948,7 +1948,7 @@ loft redirect uri. Usually https://loft.my.domain/auth/microsoft/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tenant` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-tenant}
+##### `tenant` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-tenant}
 
 tenant configuration parameter controls what kinds of accounts may be authenticated in loft.
 By default, all types of Microsoft accounts (consumers and organizations) can authenticate in loft via Microsoft.
@@ -1970,7 +1970,7 @@ tenant uuid or tenant name - only accounts belonging to specific tenant identifi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-groups}
 
 It is possible to require a user to be a member of a particular group in order to be successfully authenticated in loft.
 
@@ -1985,7 +1985,7 @@ It is possible to require a user to be a member of a particular group in order t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `onlySecurityGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-onlySecurityGroups}
+##### `onlySecurityGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-onlySecurityGroups}
 
 configuration option restricts the list to include only security groups. By default all groups (security, Office 365, mailing lists) are included.
 
@@ -2000,7 +2000,7 @@ configuration option restricts the list to include only security groups. By defa
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-useGroupsAsWhitelist}
+##### `useGroupsAsWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-microsoft-useGroupsAsWhitelist}
 
 Restrict the groups claims to include only the user’s groups that are in the configured groups
 
@@ -2018,7 +2018,7 @@ Restrict the groups claims to include only the user’s groups that are in the c
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `saml` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml}
+#### `saml` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml}
 
 SAML holds saml authentication configuration
 
@@ -2030,7 +2030,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -2047,7 +2047,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -2062,7 +2062,7 @@ SSO URL used for POST value.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caData` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-caData}
+##### `caData` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-caData}
 
 CAData is a base64 encoded string that holds the ca certificate for validating the signature of the SAML response.
 Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
@@ -2078,7 +2078,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -2093,7 +2093,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -2108,7 +2108,7 @@ Name of attribute in the returned assertions to map to email
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-groupsAttr}
+##### `groupsAttr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-groupsAttr}
 
 Name of attribute in the returned assertions to map to groups
 
@@ -2123,7 +2123,7 @@ Name of attribute in the returned assertions to map to groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ca` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ca}
+##### `ca` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ca}
 
 CA to use when validating the signature of the SAML response.
 
@@ -2138,7 +2138,7 @@ CA to use when validating the signature of the SAML response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-insecureSkipSignatureValidation}
+##### `insecureSkipSignatureValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-insecureSkipSignatureValidation}
 
 Ignore the ca cert
 
@@ -2153,7 +2153,7 @@ Ignore the ca cert
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `entityIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-entityIssuer}
+##### `entityIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-entityIssuer}
 
 When provided Loft will include this as the Issuer value during AuthnRequest.
 It will also override the redirectURI as the required audience when evaluating
@@ -2170,7 +2170,7 @@ AudienceRestriction elements in the response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoIssuer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoIssuer}
+##### `ssoIssuer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoIssuer}
 
 Issuer value expected in the SAML response. Optional.
 
@@ -2185,7 +2185,7 @@ Issuer value expected in the SAML response. Optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groupsDelim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-groupsDelim}
+##### `groupsDelim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-groupsDelim}
 
 If GroupsDelim is supplied the connector assumes groups are returned as a
 single string instead of multiple attribute values. This delimiter will be
@@ -2202,7 +2202,7 @@ used split the groups string.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `allowedGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-allowedGroups}
+##### `allowedGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-allowedGroups}
 
 List of groups to filter access based on membership
 
@@ -2217,7 +2217,7 @@ List of groups to filter access based on membership
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `filterGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-filterGroups}
+##### `filterGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-filterGroups}
 
 If used with allowed groups, only forwards the allowed groups and not all
 groups specified.
@@ -2233,7 +2233,7 @@ groups specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-nameIDPolicyFormat}
+##### `nameIDPolicyFormat` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-nameIDPolicyFormat}
 
 Requested format of the NameID. The NameID value is is mapped to the ID Token
 'sub' claim.
@@ -2265,7 +2265,7 @@ If no value is specified, this value defaults to:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableTeamCreation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-disableTeamCreation}
+### `disableTeamCreation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-disableTeamCreation}
 
 Prevents from team creation for the new groups associated with the user at the time of logging in through sso,
 Default behaviour is false, this means that teams will be created for new groups.
@@ -2281,7 +2281,7 @@ Default behaviour is false, this means that teams will be created for new groups
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableUserCreation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-disableUserCreation}
+### `disableUserCreation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-disableUserCreation}
 
 DisableUserCreation prevents the SSO connectors from creating a new user on a users initial signin through sso.
 Default behaviour is false, this means that a new user object will be created once a user without
@@ -2298,7 +2298,7 @@ a Kubernetes user object logs in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `accessKeyMaxTTLSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-accessKeyMaxTTLSeconds}
+### `accessKeyMaxTTLSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-accessKeyMaxTTLSeconds}
 
 AccessKeyMaxTTLSeconds is the global maximum lifespan of an accesskey in seconds.
 Leaving it 0 or unspecified will disable it.
@@ -2315,7 +2315,7 @@ Specifying 2592000 will mean all keys have a Time-To-Live of 30 days.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `loginAccessKeyTTLSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-loginAccessKeyTTLSeconds}
+### `loginAccessKeyTTLSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-loginAccessKeyTTLSeconds}
 
 LoginAccessKeyTTLSeconds is the time in seconds an access key is kept
 until it is deleted.
@@ -2334,7 +2334,7 @@ Specifying 2592000 will mean all keys have a  default Time-To-Live of 30 days.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `customHttpHeaders` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-customHttpHeaders}
+### `customHttpHeaders` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-customHttpHeaders}
 
 CustomHttpHeaders are additional headers that should be set for the authentication endpoints
 
@@ -2349,7 +2349,7 @@ CustomHttpHeaders are additional headers that should be set for the authenticati
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groupsFilters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-groupsFilters}
+### `groupsFilters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-groupsFilters}
 
 GroupsFilters is a regex expression to only save matching sso groups into the user resource
 
@@ -2367,7 +2367,7 @@ GroupsFilters is a regex expression to only save matching sso groups into the us
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `oidc` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc}
+## `oidc` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc}
 
 DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secret. By default, vCluster Platform as an OIDC Provider is enabled but does not function without OIDC clients.
 
@@ -2379,7 +2379,7 @@ DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-enabled}
 
 If true indicates that loft will act as an OIDC server
 
@@ -2394,7 +2394,7 @@ If true indicates that loft will act as an OIDC server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `wildcardRedirect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-wildcardRedirect}
+### `wildcardRedirect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-wildcardRedirect}
 
 If true indicates that loft will allow wildcard '*' in client redirectURIs
 
@@ -2409,7 +2409,7 @@ If true indicates that loft will allow wildcard '*' in client redirectURIs
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clients` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients}
+### `clients` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients}
 
 The clients that are allowed to request loft tokens
 
@@ -2421,7 +2421,7 @@ The clients that are allowed to request loft tokens
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-name}
 
 The client name
 
@@ -2436,7 +2436,7 @@ The client name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientId}
+#### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientId}
 
 The client id of the client
 
@@ -2451,7 +2451,7 @@ The client id of the client
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientSecret}
+#### `clientSecret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientSecret}
 
 The client secret of the client
 
@@ -2488,7 +2488,7 @@ requested to redirect to MUST match one of these values, unless the client is "p
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps}
+## `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps}
 
 Apps holds configuration around apps
 
@@ -2500,7 +2500,7 @@ Apps holds configuration around apps
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `noDefault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-noDefault}
+### `noDefault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-noDefault}
 
 If this option is true, loft will not try to parse the default apps
 
@@ -2515,7 +2515,7 @@ If this option is true, loft will not try to parse the default apps
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `repositories` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories}
+### `repositories` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories}
 
 These are additional repositories that are parsed by loft
 
@@ -2527,7 +2527,7 @@ These are additional repositories that are parsed by loft
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-name}
 
 Name is the name of the repository
 
@@ -2542,7 +2542,7 @@ Name is the name of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-url}
+#### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-url}
 
 URL is the repository url
 
@@ -2557,7 +2557,7 @@ URL is the repository url
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-username}
 
 Username of the repository
 
@@ -2572,7 +2572,7 @@ Username of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-password}
+#### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-password}
 
 Password of the repository
 
@@ -2587,7 +2587,7 @@ Password of the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-insecure}
+#### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-repositories-insecure}
 
 Insecure specifies if the chart should be retrieved without TLS
 verification
@@ -2606,7 +2606,7 @@ verification
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `predefinedApps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps}
+### `predefinedApps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps}
 
 Predefined apps that can be selected in the Spaces ) Space menu
 
@@ -2618,7 +2618,7 @@ Predefined apps that can be selected in the Spaces ) Space menu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-chart}
+#### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-chart}
 
 Chart holds the repo/chart name of the predefined app
 
@@ -2633,7 +2633,7 @@ Chart holds the repo/chart name of the predefined app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `initialVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-initialVersion}
+#### `initialVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-initialVersion}
 
 InitialVersion holds the initial version of this app.
 This version will be selected automatically.
@@ -2649,7 +2649,7 @@ This version will be selected automatically.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `initialValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-initialValues}
+#### `initialValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-initialValues}
 
 InitialValues holds the initial values for this app.
 The values will be prefilled automatically. There are certain
@@ -2667,7 +2667,7 @@ by the loft UI automatically.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-clusters}
+#### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-clusters}
 
 Holds the cluster names where to display this app
 
@@ -2682,7 +2682,7 @@ Holds the cluster names where to display this app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `title` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-title}
+#### `title` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-title}
 
 Title is the name that should be displayed for the predefined app.
 If empty the chart name is used.
@@ -2698,7 +2698,7 @@ If empty the chart name is used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `iconUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-iconUrl}
+#### `iconUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-iconUrl}
 
 IconURL specifies an url to the icon that should be displayed for this app.
 If none is specified the icon from the chart metadata is used.
@@ -2714,7 +2714,7 @@ If none is specified the icon from the chart metadata is used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `readmeUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-readmeUrl}
+#### `readmeUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apps-predefinedApps-readmeUrl}
 
 ReadmeURL specifies an url to the readme page of this predefined app. If empty
 an url will be constructed to artifact hub.
@@ -2736,7 +2736,7 @@ an url will be constructed to artifact hub.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `audit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit}
+## `audit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit}
 
 Audit holds audit configuration
 
@@ -2748,7 +2748,7 @@ Audit holds audit configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-enabled}
 
 If audit is enabled and incoming api requests will be logged based on the supplied policy.
 
@@ -2763,7 +2763,7 @@ If audit is enabled and incoming api requests will be logged based on the suppli
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableAgentSyncBack` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-disableAgentSyncBack}
+### `disableAgentSyncBack` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-disableAgentSyncBack}
 
 If true, the agent will not send back any audit logs to Loft itself.
 
@@ -2778,7 +2778,7 @@ If true, the agent will not send back any audit logs to Loft itself.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `level` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-level}
+### `level` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-level}
 
 Level is an optional log level for audit logs. Cannot be used together with policy
 
@@ -2793,7 +2793,7 @@ Level is an optional log level for audit logs. Cannot be used together with poli
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `policy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy}
+### `policy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy}
 
 The audit policy to use and log requests. By default loft will not log anything
 
@@ -2805,7 +2805,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -2835,7 +2835,7 @@ The Level that requests matching this rule are recorded at.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-users}
 
 The users (by authenticated user name) this rule applies to.
 An empty list implies every user.
@@ -2851,7 +2851,7 @@ An empty list implies every user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `userGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-userGroups}
+##### `userGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-userGroups}
 
 The user groups this rule applies to. A user is considered matching
 if it is a member of any of the UserGroups.
@@ -2868,7 +2868,7 @@ An empty list implies every user group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -2884,7 +2884,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -2896,7 +2896,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -2912,7 +2912,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -2939,7 +2939,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -2959,7 +2959,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-namespaces}
+##### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -2976,7 +2976,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be audited.
 *s are allowed, but only as the full, final step in the path.
@@ -2995,7 +2995,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-omitStages}
+##### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified policy wide in which case the union of both are omitted.
@@ -3012,7 +3012,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-requestTargets}
+##### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-requestTargets}
 
 RequestTargets is a list of request targets for which events are created.
 An empty list implies every request.
@@ -3028,7 +3028,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-clusters}
+##### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules-clusters}
 
 Clusters that this rule matches. Only applies to cluster requests.
 If this is set, no events for non cluster requests will be created.
@@ -3048,7 +3048,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `omitStages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-omitStages}
+#### `omitStages` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-omitStages}
 
 OmitStages is a list of stages for which no events are created. Note that this can also
 be specified per rule in which case the union of both are omitted.
@@ -3067,7 +3067,7 @@ be specified per rule in which case the union of both are omitted.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataStoreEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-dataStoreEndpoint}
+### `dataStoreEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-dataStoreEndpoint}
 
 DataStoreEndpoint is an endpoint to store events in.
 
@@ -3082,7 +3082,7 @@ DataStoreEndpoint is an endpoint to store events in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataStoreTTL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-dataStoreTTL}
+### `dataStoreTTL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-dataStoreTTL}
 
 DataStoreMaxAge is the maximum number of hours to retain old log events in the datastore
 
@@ -3097,7 +3097,7 @@ DataStoreMaxAge is the maximum number of hours to retain old log events in the d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-path}
+### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-path}
 
 The path where to save the audit log files. This is required if audit is enabled. Backup log files will
 be retained in the same directory.
@@ -3113,7 +3113,7 @@ be retained in the same directory.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `maxAge` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxAge}
+### `maxAge` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxAge}
 
 MaxAge is the maximum number of days to retain old log files based on the
 timestamp encoded in their filename.  Note that a day is defined as 24
@@ -3132,7 +3132,7 @@ based on age.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `maxBackups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxBackups}
+### `maxBackups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxBackups}
 
 MaxBackups is the maximum number of old log files to retain.  The default
 is to retain all old log files (though MaxAge may still cause them to get
@@ -3149,7 +3149,7 @@ deleted.)
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `maxSize` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxSize}
+### `maxSize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-maxSize}
 
 MaxSize is the maximum size in megabytes of the log file before it gets
 rotated. It defaults to 100 megabytes.
@@ -3165,7 +3165,7 @@ rotated. It defaults to 100 megabytes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `compress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-compress}
+### `compress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-compress}
 
 Compress determines if the rotated log files should be compressed
 using gzip. The default is not to perform compression.
@@ -3184,7 +3184,7 @@ using gzip. The default is not to perform compression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `loftHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#loftHost}
+## `loftHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#loftHost}
 
 LoftHost holds the domain where the loft instance is hosted. This should not include https or http. E.g. loft.my-domain.com
 
@@ -3199,7 +3199,7 @@ LoftHost holds the domain where the loft instance is hosted. This should not inc
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `projectNamespacePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#projectNamespacePrefix}
+## `projectNamespacePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#projectNamespacePrefix}
 
 ProjectNamespacePrefix holds the prefix for loft project namespaces. Omitted defaults to "p-"
 
@@ -3214,7 +3214,7 @@ ProjectNamespacePrefix holds the prefix for loft project namespaces. Omitted def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `devPodSubDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#devPodSubDomain}
+## `devPodSubDomain` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#devPodSubDomain}
 
 DEPRECATED: DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.com
 DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.com
@@ -3230,7 +3230,7 @@ DevPodSubDomain holds a subdomain in the following form *.workspace.my-domain.co
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `uiSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings}
+## `uiSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings}
 
 UISettings holds the settings for modifying the Loft user interface
 
@@ -3242,7 +3242,7 @@ UISettings holds the settings for modifying the Loft user interface
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `loftVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-loftVersion}
+### `loftVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-loftVersion}
 
 LoftVersion holds the current loft version
 
@@ -3257,7 +3257,7 @@ LoftVersion holds the current loft version
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `logoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-logoURL}
+### `logoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-logoURL}
 
 LogoURL is url pointing to the logo to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3273,7 +3273,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `faviconURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-faviconURL}
+### `faviconURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-faviconURL}
 
 FaviconURL is url pointing to the favicon to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3289,7 +3289,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `smallLogoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-smallLogoURL}
+### `smallLogoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-smallLogoURL}
 
 SmallLogoURL is url pointing to the small logo to use in the vCluster Platform UI. This path must be accessible for clients accessing
 the vCluster Platform UI!
@@ -3305,7 +3305,7 @@ the vCluster Platform UI!
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `logoBackgroundColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-logoBackgroundColor}
+### `logoBackgroundColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-logoBackgroundColor}
 
 LogoBackgroundColor is the color value (ex: "#12345") to use as the background color for the logo
 
@@ -3320,7 +3320,7 @@ LogoBackgroundColor is the color value (ex: "#12345") to use as the background c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `legalTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-legalTemplate}
+### `legalTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-legalTemplate}
 
 LegalTemplate is a text (html) string containing the legal template to prompt to users when authenticating to Loft
 
@@ -3335,7 +3335,7 @@ LegalTemplate is a text (html) string containing the legal template to prompt to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `primaryColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-primaryColor}
+### `primaryColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-primaryColor}
 
 PrimaryColor is the color value (ex: "#12345") to use as the primary color
 
@@ -3350,7 +3350,7 @@ PrimaryColor is the color value (ex: "#12345") to use as the primary color
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `sidebarColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-sidebarColor}
+### `sidebarColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-sidebarColor}
 
 SidebarColor is the color value (ex: "#12345") to use for the sidebar
 
@@ -3365,7 +3365,7 @@ SidebarColor is the color value (ex: "#12345") to use for the sidebar
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `accentColor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-accentColor}
+### `accentColor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-accentColor}
 
 AccentColor is the color value (ex: "#12345") to use for the accent
 
@@ -3380,7 +3380,7 @@ AccentColor is the color value (ex: "#12345") to use for the accent
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `customCss` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-customCss}
+### `customCss` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-customCss}
 
 CustomCSS holds URLs with custom css files that should be included when loading the UI
 
@@ -3395,7 +3395,7 @@ CustomCSS holds URLs with custom css files that should be included when loading 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `customJavaScript` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-customJavaScript}
+### `customJavaScript` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-customJavaScript}
 
 CustomJavaScript holds URLs with custom js files that should be included when loading the UI
 
@@ -3410,7 +3410,7 @@ CustomJavaScript holds URLs with custom js files that should be included when lo
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `navBarButtons` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons}
+### `navBarButtons` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons}
 
 NavBarButtons holds extra nav bar buttons
 
@@ -3422,7 +3422,7 @@ NavBarButtons holds extra nav bar buttons
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `position` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-position}
+#### `position` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-position}
 
 Position holds the position of the button, can be one of:
 TopStart, TopEnd, BottomStart, BottomEnd. Defaults to BottomEnd
@@ -3438,7 +3438,7 @@ TopStart, TopEnd, BottomStart, BottomEnd. Defaults to BottomEnd
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `text` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-text}
+#### `text` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-text}
 
 Text holds text for the button
 
@@ -3453,7 +3453,7 @@ Text holds text for the button
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `link` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-link}
+#### `link` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-link}
 
 Link holds the link of the navbar button
 
@@ -3468,7 +3468,7 @@ Link holds the link of the navbar button
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-navBarButtons-icon}
 
 Icon holds the url of the icon to display
 
@@ -3486,7 +3486,7 @@ Icon holds the url of the icon to display
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `externalURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs}
+### `externalURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs}
 
 External URLs that can be called from the UI
 
@@ -3498,7 +3498,7 @@ External URLs that can be called from the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `block` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs-block}
+#### `block` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs-block}
 
 Block determines if requests to external URLs from the UI should be blocked
 
@@ -3513,7 +3513,7 @@ Block determines if requests to external URLs from the UI should be blocked
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs-allow}
+#### `allow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#uiSettings-externalURLs-allow}
 
 Allow specifies which external URLs can be called. In addition to the predefined modules,
 - "vcluster" (license page, feature descriptions, ...)
@@ -3539,7 +3539,7 @@ This is only active when Block is true.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `vault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault}
+## `vault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault}
 
 VaultIntegration holds the vault integration configuration
 
@@ -3551,7 +3551,7 @@ VaultIntegration holds the vault integration configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-enabled}
 
 Enabled indicates if the Vault Integration is enabled for the project -- this knob only
 enables the syncing of secrets to or from Vault, but does not setup Kubernetes authentication
@@ -3568,7 +3568,7 @@ methods or Kubernetes secrets engines for vclusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `address` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-address}
+### `address` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-address}
 
 Address defines the address of the Vault instance to use for this project.
 Will default to the `VAULT_ADDR` environment variable if not provided.
@@ -3584,7 +3584,7 @@ Will default to the `VAULT_ADDR` environment variable if not provided.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `skipTLSVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-skipTLSVerify}
+### `skipTLSVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-skipTLSVerify}
 
 SkipTLSVerify defines if TLS verification should be skipped when connecting to Vault.
 
@@ -3599,7 +3599,7 @@ SkipTLSVerify defines if TLS verification should be skipped when connecting to V
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-namespace}
+### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-namespace}
 
 Namespace defines the namespace to use when storing secrets in Vault.
 
@@ -3614,7 +3614,7 @@ Namespace defines the namespace to use when storing secrets in Vault.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth}
+### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth}
 
 Auth defines the authentication method to use for this project.
 
@@ -3626,7 +3626,7 @@ Auth defines the authentication method to use for this project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-token}
+#### `token` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-token}
 
 Token defines the token to use for authentication.
 
@@ -3641,7 +3641,7 @@ Token defines the token to use for authentication.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `tokenSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef}
+#### `tokenSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef}
 
 TokenSecretRef defines the Kubernetes secret to use for token authentication.
 Will be used if `token` is not provided.
@@ -3656,7 +3656,7 @@ Secret data should contain the `token` key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef-name}
 
 Name of the referent.
 This field is effectively required, but due to backwards compatibility is
@@ -3691,7 +3691,7 @@ The key of the secret to select from.  Must be a valid secret key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef-optional}
+##### `optional` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-auth-tokenSecretRef-optional}
 
 Specify whether the Secret or its key must be defined
 
@@ -3712,7 +3712,7 @@ Specify whether the Secret or its key must be defined
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `syncInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-syncInterval}
+### `syncInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vault-syncInterval}
 
 SyncInterval defines the interval at which to sync secrets from Vault.
 Defaults to `1m.`
@@ -3732,7 +3732,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `disableConfigEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableConfigEndpoint}
+## `disableConfigEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableConfigEndpoint}
 
 DisableLoftConfigEndpoint will disable setting config via the UI and config.management.loft.sh endpoint
 
@@ -3747,7 +3747,7 @@ DisableLoftConfigEndpoint will disable setting config via the UI and config.mana
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `authenticateVersionEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#authenticateVersionEndpoint}
+## `authenticateVersionEndpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#authenticateVersionEndpoint}
 
 AuthenticateVersionEndpoint will force authentication for the '/version' endpoint. Will only work with vCluster v0.27 & later
 
@@ -3762,7 +3762,7 @@ AuthenticateVersionEndpoint will force authentication for the '/version' endpoin
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `cloud` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud}
+## `cloud` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud}
 
 Cloud holds the settings to be used exclusively in vCluster Cloud based
 environments and deployments.
@@ -3775,7 +3775,7 @@ environments and deployments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `releaseChannel` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-releaseChannel}
+### `releaseChannel` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-releaseChannel}
 
 ReleaseChannel specifies the release channel for the cloud configuration.
 This can be used to determine which updates or versions are applied.
@@ -3791,7 +3791,7 @@ This can be used to determine which updates or versions are applied.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `maintenanceWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow}
+### `maintenanceWindow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow}
 
 MaintenanceWindow specifies the maintenance window for the cloud configuration.
 This is a structured representation of the time window during which maintenance can occur.
@@ -3804,7 +3804,7 @@ This is a structured representation of the time window during which maintenance 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dayOfWeek` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-dayOfWeek}
+#### `dayOfWeek` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-dayOfWeek}
 
 DayOfWeek specifies the day of the week for the maintenance window.
 It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
@@ -3820,7 +3820,7 @@ It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timeWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-timeWindow}
+#### `timeWindow` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-timeWindow}
 
 TimeWindow specifies the time window for the maintenance.
 It should be a string representing the time range in 24-hour format, in UTC, e.g., "02:00-03:00".
@@ -3842,7 +3842,7 @@ It should be a string representing the time range in 24-hour format, in UTC, e.g
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `costControl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl}
+## `costControl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl}
 
 CostControl holds the settings related to the Cost Control ROI dashboard and its metrics gathering infrastructure
 
@@ -3854,7 +3854,7 @@ CostControl holds the settings related to the Cost Control ROI dashboard and its
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-enabled}
 
 Enabled specifies whether the ROI dashboard should be available in the UI, and if the metrics infrastructure
 that provides dashboard data is deployed
@@ -3870,7 +3870,7 @@ that provides dashboard data is deployed
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `global` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global}
+### `global` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global}
 
 Global are settings for globally managed components
 
@@ -3882,7 +3882,7 @@ Global are settings for globally managed components
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics}
+#### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics}
 
 Metrics these settings apply to metric infrastructure used to aggregate metrics across all connected clusters
 
@@ -3894,7 +3894,7 @@ Metrics these settings apply to metric infrastructure used to aggregate metrics 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -3909,7 +3909,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -3921,7 +3921,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -3937,7 +3937,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -3955,7 +3955,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -3991,7 +3991,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4015,7 +4015,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4030,7 +4030,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage}
 
 
 
@@ -4042,7 +4042,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4059,7 +4059,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4083,7 +4083,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster}
+### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster}
 
 Cluster are settings for each cluster's managed components. These settings apply to all connected clusters
 unless overridden by modifying the Cluster's spec
@@ -4096,7 +4096,7 @@ unless overridden by modifying the Cluster's spec
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics}
+#### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics}
 
 Metrics are settings applied to metric infrastructure in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4109,7 +4109,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4124,7 +4124,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4136,7 +4136,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4152,7 +4152,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4170,7 +4170,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4206,7 +4206,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4230,7 +4230,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4245,7 +4245,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage}
 
 
 
@@ -4257,7 +4257,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4274,7 +4274,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4295,7 +4295,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost}
+#### `opencost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost}
 
 OpenCost are settings applied to OpenCost deployments in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4308,7 +4308,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4323,7 +4323,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -4335,7 +4335,7 @@ Resources are compute resource required by the OpenCost backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4351,7 +4351,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4369,7 +4369,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4405,7 +4405,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4435,7 +4435,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `settings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings}
+### `settings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings}
 
 Settings specify price-related settings that are taken into account for the ROI dashboard calculations.
 
@@ -4447,7 +4447,7 @@ Settings specify price-related settings that are taken into account for the ROI 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priceCurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-priceCurrency}
+#### `priceCurrency` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-priceCurrency}
 
 PriceCurrency specifies the currency.
 
@@ -4462,7 +4462,7 @@ PriceCurrency specifies the currency.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `averageCPUPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode}
+#### `averageCPUPricePerNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode}
 
 AvgCPUPricePerNode specifies the average CPU price per node.
 
@@ -4474,7 +4474,7 @@ AvgCPUPricePerNode specifies the average CPU price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-price}
 
 Price specifies the price.
 
@@ -4489,7 +4489,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4507,7 +4507,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `averageRAMPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode}
+#### `averageRAMPricePerNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode}
 
 AvgRAMPricePerNode specifies the average RAM price per node.
 
@@ -4519,7 +4519,7 @@ AvgRAMPricePerNode specifies the average RAM price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-price}
 
 Price specifies the price.
 
@@ -4534,7 +4534,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4552,7 +4552,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gpuSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings}
+#### `gpuSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings}
 
 GPUSettings specifies GPU related settings.
 
@@ -4564,7 +4564,7 @@ GPUSettings specifies GPU related settings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-enabled}
 
 Enabled specifies whether GPU settings should be available in the UI.
 
@@ -4579,7 +4579,7 @@ Enabled specifies whether GPU settings should be available in the UI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageGPUPrice` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice}
+##### `averageGPUPrice` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice}
 
 AvgGPUPrice specifies the average GPU price.
 
@@ -4591,7 +4591,7 @@ AvgGPUPrice specifies the average GPU price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-price}
 
 Price specifies the price.
 
@@ -4606,7 +4606,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4627,7 +4627,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster}
+#### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster}
 
 ControlPlanePricePerCluster specifies the price of one physical cluster.
 
@@ -4639,7 +4639,7 @@ ControlPlanePricePerCluster specifies the price of one physical cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-price}
+##### `price` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-price}
 
 Price specifies the price.
 
@@ -4654,7 +4654,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4678,7 +4678,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `platformDB` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB}
+## `platformDB` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB}
 
 PlatformDB holds the settings related to the postgres database that platform uses to store data
 
@@ -4690,7 +4690,7 @@ PlatformDB holds the settings related to the postgres database that platform use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB-storageClass}
+### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB-storageClass}
 
 StorageClass sets the storage class for the PersistentVolumeClaim used by the platform database statefulSet.
 
@@ -4708,7 +4708,7 @@ StorageClass sets the storage class for the PersistentVolumeClaim used by the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `imageBuilder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder}
+## `imageBuilder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder}
 
 ImageBuilder holds the settings related to the image builder
 
@@ -4720,7 +4720,7 @@ ImageBuilder holds the settings related to the image builder
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-enabled}
 
 Enabled specifies whether the remote image builder should be available.
 If it's not available building ad-hoc images from a devcontainer.json is not supported
@@ -4736,7 +4736,7 @@ If it's not available building ad-hoc images from a devcontainer.json is not sup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-replicas}
+### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4751,7 +4751,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources}
+### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources}
 
 Resources are compute resource required by the buildkit containers
 
@@ -4763,7 +4763,7 @@ Resources are compute resource required by the buildkit containers
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-limits}
+#### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -4779,7 +4779,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-requests}
+#### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -4797,7 +4797,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-claims}
+#### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -4833,7 +4833,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -4860,7 +4860,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database}
+## `database` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database}
 
 Database represents the database connection settings when deploying the platform with an embedded Kubernetes backed by kine
 
@@ -4872,7 +4872,7 @@ Database represents the database connection settings when deploying the platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-enabled}
 
 Enabled defines if the database should be used.
 
@@ -4887,7 +4887,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -4905,7 +4905,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-identityProvider}
+### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -4922,7 +4922,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -4937,7 +4937,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-certFile}
+### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -4952,7 +4952,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-caFile}
+### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -4967,7 +4967,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status_reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/config/status_reference.mdx
@@ -28,7 +28,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `issuerUrl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-issuerUrl}
+#### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -51,7 +51,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientId}
+#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -71,7 +71,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientSecret}
+#### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -86,7 +86,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-redirectURI}
+#### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -363,7 +363,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-clientId}
+#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-github-clientId}
 
 ClientID holds the github client id
 
@@ -871,7 +871,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-redirectURI}
+#### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -888,7 +888,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ssoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoURL}
+#### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -919,7 +919,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `usernameAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-usernameAttr}
+#### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -934,7 +934,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `emailAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-emailAttr}
+#### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -1115,7 +1115,7 @@ Password holds password authentication relevant information
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password-disabled}
+#### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-password-disabled}
 
 If true login via password is disabled
 
@@ -1187,7 +1187,7 @@ OIDC holds oidc authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `issuerUrl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-issuerUrl}
+##### `issuerUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-issuerUrl}
 
 IssuerURL is the URL the provider signs ID Tokens as. This will be the "iss"
 field of all tokens produced by the provider and is used for configuration
@@ -1210,7 +1210,7 @@ See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientId}
 
 ClientID the JWT must be issued for, the "sub" field. This plugin only trusts a single
 client to ensure the plugin can be used with public providers.
@@ -1230,7 +1230,7 @@ See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientSecret}
+##### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-clientSecret}
 
 ClientSecret to issue tokens from the OIDC provider
 
@@ -1245,7 +1245,7 @@ ClientSecret to issue tokens from the OIDC provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-oidc-redirectURI}
 
 loft redirect uri. E.g. https://loft.my.domain/auth/oidc/callback
 
@@ -1522,7 +1522,7 @@ Github holds github authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-clientId}
+##### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-github-clientId}
 
 ClientID holds the github client id
 
@@ -2030,7 +2030,7 @@ SAML holds saml authentication configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `redirectURI` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-redirectURI}
+##### `redirectURI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-redirectURI}
 
 If the response assertion status value contains a Destination element, it
 must match this value exactly.
@@ -2047,7 +2047,7 @@ Usually looks like https://your-loft-domain/auth/saml/callback
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ssoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoURL}
+##### `ssoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-ssoURL}
 
 SSO URL used for POST value.
 
@@ -2078,7 +2078,7 @@ Either CAData, CA or InsecureSkipSignatureValidation needs to be defined.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `usernameAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-usernameAttr}
+##### `usernameAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-usernameAttr}
 
 Name of attribute in the returned assertions to map to username
 
@@ -2093,7 +2093,7 @@ Name of attribute in the returned assertions to map to username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `emailAttr` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-emailAttr}
+##### `emailAttr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-connectors-saml-emailAttr}
 
 Name of attribute in the returned assertions to map to email
 
@@ -2349,7 +2349,7 @@ CustomHttpHeaders are additional headers that should be set for the authenticati
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groupsFilters` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-groupsFilters}
+### `groupsFilters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-groupsFilters}
 
 GroupsFilters is a regex expression to only save matching sso groups into the user resource
 
@@ -2379,7 +2379,7 @@ DEPRECATED: Configure the OIDC clients using either the OIDC Client UI or a secr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-enabled}
 
 If true indicates that loft will act as an OIDC server
 
@@ -2394,7 +2394,7 @@ If true indicates that loft will act as an OIDC server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `wildcardRedirect` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-wildcardRedirect}
+### `wildcardRedirect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-wildcardRedirect}
 
 If true indicates that loft will allow wildcard '*' in client redirectURIs
 
@@ -2409,7 +2409,7 @@ If true indicates that loft will allow wildcard '*' in client redirectURIs
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clients` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients}
+### `clients` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients}
 
 The clients that are allowed to request loft tokens
 
@@ -2421,7 +2421,7 @@ The clients that are allowed to request loft tokens
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-name}
 
 The client name
 
@@ -2436,7 +2436,7 @@ The client name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientId}
+#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientId}
 
 The client id of the client
 
@@ -2451,7 +2451,7 @@ The client id of the client
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientSecret` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientSecret}
+#### `clientSecret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#oidc-clients-clientSecret}
 
 The client secret of the client
 
@@ -2805,7 +2805,7 @@ The audit policy to use and log requests. By default loft will not log anything
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules}
+#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#audit-policy-rules}
 
 Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -3732,7 +3732,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `disableConfigEndpoint` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableConfigEndpoint}
+## `disableConfigEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#disableConfigEndpoint}
 
 DisableLoftConfigEndpoint will disable setting config via the UI and config.management.loft.sh endpoint
 
@@ -3747,7 +3747,7 @@ DisableLoftConfigEndpoint will disable setting config via the UI and config.mana
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `authenticateVersionEndpoint` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#authenticateVersionEndpoint}
+## `authenticateVersionEndpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#authenticateVersionEndpoint}
 
 AuthenticateVersionEndpoint will force authentication for the '/version' endpoint. Will only work with vCluster v0.27 & later
 
@@ -3762,7 +3762,7 @@ AuthenticateVersionEndpoint will force authentication for the '/version' endpoin
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `cloud` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud}
+## `cloud` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud}
 
 Cloud holds the settings to be used exclusively in vCluster Cloud based
 environments and deployments.
@@ -3775,7 +3775,7 @@ environments and deployments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `releaseChannel` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-releaseChannel}
+### `releaseChannel` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-releaseChannel}
 
 ReleaseChannel specifies the release channel for the cloud configuration.
 This can be used to determine which updates or versions are applied.
@@ -3791,7 +3791,7 @@ This can be used to determine which updates or versions are applied.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `maintenanceWindow` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow}
+### `maintenanceWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow}
 
 MaintenanceWindow specifies the maintenance window for the cloud configuration.
 This is a structured representation of the time window during which maintenance can occur.
@@ -3804,7 +3804,7 @@ This is a structured representation of the time window during which maintenance 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dayOfWeek` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-dayOfWeek}
+#### `dayOfWeek` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-dayOfWeek}
 
 DayOfWeek specifies the day of the week for the maintenance window.
 It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
@@ -3820,7 +3820,7 @@ It should be a string representing the day, e.g., "Monday", "Tuesday", etc.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timeWindow` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-timeWindow}
+#### `timeWindow` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#cloud-maintenanceWindow-timeWindow}
 
 TimeWindow specifies the time window for the maintenance.
 It should be a string representing the time range in 24-hour format, in UTC, e.g., "02:00-03:00".
@@ -3842,7 +3842,7 @@ It should be a string representing the time range in 24-hour format, in UTC, e.g
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `costControl` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl}
+## `costControl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl}
 
 CostControl holds the settings related to the Cost Control ROI dashboard and its metrics gathering infrastructure
 
@@ -3854,7 +3854,7 @@ CostControl holds the settings related to the Cost Control ROI dashboard and its
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-enabled}
 
 Enabled specifies whether the ROI dashboard should be available in the UI, and if the metrics infrastructure
 that provides dashboard data is deployed
@@ -3870,7 +3870,7 @@ that provides dashboard data is deployed
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `global` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global}
+### `global` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global}
 
 Global are settings for globally managed components
 
@@ -3882,7 +3882,7 @@ Global are settings for globally managed components
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics}
+#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics}
 
 Metrics these settings apply to metric infrastructure used to aggregate metrics across all connected clusters
 
@@ -3894,7 +3894,7 @@ Metrics these settings apply to metric infrastructure used to aggregate metrics 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -3909,7 +3909,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4015,7 +4015,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4030,7 +4030,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage}
 
 
 
@@ -4042,7 +4042,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4059,7 +4059,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-global-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4083,7 +4083,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cluster` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster}
+### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster}
 
 Cluster are settings for each cluster's managed components. These settings apply to all connected clusters
 unless overridden by modifying the Cluster's spec
@@ -4096,7 +4096,7 @@ unless overridden by modifying the Cluster's spec
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics}
+#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics}
 
 Metrics are settings applied to metric infrastructure in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4109,7 +4109,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4124,7 +4124,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -4230,7 +4230,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -4245,7 +4245,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage}
 
 
 
@@ -4257,7 +4257,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -4274,7 +4274,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -4295,7 +4295,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `opencost` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost}
+#### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost}
 
 OpenCost are settings applied to OpenCost deployments in each connected cluster. These can be overridden in
 individual clusters by modifying the Cluster's spec
@@ -4308,7 +4308,7 @@ individual clusters by modifying the Cluster's spec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4323,7 +4323,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-cluster-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -4435,7 +4435,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `settings` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings}
+### `settings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings}
 
 Settings specify price-related settings that are taken into account for the ROI dashboard calculations.
 
@@ -4447,7 +4447,7 @@ Settings specify price-related settings that are taken into account for the ROI 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priceCurrency` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-priceCurrency}
+#### `priceCurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-priceCurrency}
 
 PriceCurrency specifies the currency.
 
@@ -4462,7 +4462,7 @@ PriceCurrency specifies the currency.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `averageCPUPricePerNode` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode}
+#### `averageCPUPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode}
 
 AvgCPUPricePerNode specifies the average CPU price per node.
 
@@ -4474,7 +4474,7 @@ AvgCPUPricePerNode specifies the average CPU price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-price}
 
 Price specifies the price.
 
@@ -4489,7 +4489,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageCPUPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4507,7 +4507,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `averageRAMPricePerNode` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode}
+#### `averageRAMPricePerNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode}
 
 AvgRAMPricePerNode specifies the average RAM price per node.
 
@@ -4519,7 +4519,7 @@ AvgRAMPricePerNode specifies the average RAM price per node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-price}
 
 Price specifies the price.
 
@@ -4534,7 +4534,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-averageRAMPricePerNode-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4552,7 +4552,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gpuSettings` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings}
+#### `gpuSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings}
 
 GPUSettings specifies GPU related settings.
 
@@ -4564,7 +4564,7 @@ GPUSettings specifies GPU related settings.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-enabled}
 
 Enabled specifies whether GPU settings should be available in the UI.
 
@@ -4579,7 +4579,7 @@ Enabled specifies whether GPU settings should be available in the UI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `averageGPUPrice` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice}
+##### `averageGPUPrice` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice}
 
 AvgGPUPrice specifies the average GPU price.
 
@@ -4591,7 +4591,7 @@ AvgGPUPrice specifies the average GPU price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-price}
 
 Price specifies the price.
 
@@ -4606,7 +4606,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-gpuSettings-averageGPUPrice-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4627,7 +4627,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controlPlanePricePerCluster` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster}
+#### `controlPlanePricePerCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster}
 
 ControlPlanePricePerCluster specifies the price of one physical cluster.
 
@@ -4639,7 +4639,7 @@ ControlPlanePricePerCluster specifies the price of one physical cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `price` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-price}
+##### `price` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">number</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-price}
 
 Price specifies the price.
 
@@ -4654,7 +4654,7 @@ Price specifies the price.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timePeriod` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-timePeriod}
+##### `timePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#costControl-settings-controlPlanePricePerCluster-timePeriod}
 
 TimePeriod specifies the time period for the price.
 
@@ -4678,7 +4678,7 @@ TimePeriod specifies the time period for the price.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `platformDB` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB}
+## `platformDB` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB}
 
 PlatformDB holds the settings related to the postgres database that platform uses to store data
 
@@ -4690,7 +4690,7 @@ PlatformDB holds the settings related to the postgres database that platform use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB-storageClass}
+### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platformDB-storageClass}
 
 StorageClass sets the storage class for the PersistentVolumeClaim used by the platform database statefulSet.
 
@@ -4708,7 +4708,7 @@ StorageClass sets the storage class for the PersistentVolumeClaim used by the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `imageBuilder` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder}
+## `imageBuilder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder}
 
 ImageBuilder holds the settings related to the image builder
 
@@ -4720,7 +4720,7 @@ ImageBuilder holds the settings related to the image builder
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-enabled}
 
 Enabled specifies whether the remote image builder should be available.
 If it's not available building ad-hoc images from a devcontainer.json is not supported
@@ -4736,7 +4736,7 @@ If it's not available building ad-hoc images from a devcontainer.json is not sup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-replicas}
+### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -4751,7 +4751,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#imageBuilder-resources}
 
 Resources are compute resource required by the buildkit containers
 
@@ -4860,7 +4860,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `database` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database}
+## `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database}
 
 Database represents the database connection settings when deploying the platform with an embedded Kubernetes backed by kine
 
@@ -4872,7 +4872,7 @@ Database represents the database connection settings when deploying the platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-enabled}
 
 Enabled defines if the database should be used.
 
@@ -4887,7 +4887,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -4905,7 +4905,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `identityProvider` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-identityProvider}
+### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -4922,7 +4922,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -4937,7 +4937,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-certFile}
+### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -4952,7 +4952,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-caFile}
+### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -4967,7 +4967,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#database-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/directclusterendpointtokens/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/directclusterendpointtokens/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ttl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttl}
+### `ttl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttl}
 
 The time to live for this access token in seconds
 
@@ -35,7 +35,7 @@ The time to live for this access token in seconds
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope}
+### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope}
 
 Scope is the optional scope of the direct cluster endpoint
 
@@ -47,7 +47,7 @@ Scope is the optional scope of the direct cluster endpoint
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `roles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles}
+#### `roles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles}
 
 Roles is a set of managed permissions to apply to the access key.
 
@@ -59,7 +59,7 @@ Roles is a set of managed permissions to apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-role}
 
 Role is the name of the role to apply to the access key scope.
 
@@ -74,7 +74,7 @@ Role is the name of the role to apply to the access key scope.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-projects}
+##### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -89,7 +89,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -107,7 +107,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects}
+#### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -119,7 +119,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects-project}
 
 Project is the name of the project. You can specify * to select all projects.
 
@@ -137,7 +137,7 @@ Project is the name of the project. You can specify * to select all projects.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces}
+#### `spaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces}
 
 Spaces specifies the spaces the access key is allowed to access.
 
@@ -149,7 +149,7 @@ Spaces specifies the spaces the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-project}
 
 Project is the name of the project.
 
@@ -164,7 +164,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `space` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-space}
+##### `space` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-space}
 
 Space is the name of the space. You can specify * to select all spaces.
 
@@ -182,7 +182,7 @@ Space is the name of the space. You can specify * to select all spaces.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters}
+#### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -194,7 +194,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-project}
 
 Project is the name of the project.
 
@@ -209,7 +209,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-virtualCluster}
+##### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-virtualCluster}
 
 VirtualCluster is the name of the tenant cluster to access. You can specify * to select all tenant clusters.
 
@@ -227,7 +227,7 @@ VirtualCluster is the name of the tenant cluster to access. You can specify * to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters}
+#### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters}
 
 Clusters specifies the project cluster the access key is allowed to access.
 
@@ -239,7 +239,7 @@ Clusters specifies the project cluster the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters-cluster}
 
 Cluster is the name of the cluster to access. You can specify * to select all clusters.
 
@@ -257,7 +257,7 @@ Cluster is the name of the cluster to access. You can specify * to select all cl
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules}
 
 DEPRECATED: Use Projects, Spaces and VirtualClusters instead
 Rules specifies the rules that should apply to the access key.
@@ -270,7 +270,7 @@ Rules specifies the rules that should apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -286,7 +286,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -298,7 +298,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -314,7 +314,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -341,7 +341,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -361,7 +361,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-namespaces}
+##### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -378,7 +378,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be checked.
 *s are allowed, but only as the full, final step in the path.
@@ -397,7 +397,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-requestTargets}
+##### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-requestTargets}
 
 RequestTargets is a list of request targets that are allowed.
 An empty list implies every request.
@@ -413,7 +413,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-cluster}
 
 Cluster that this rule matches. Only applies to cluster requests.
 If this is set, no requests for non cluster requests are allowed.
@@ -430,7 +430,7 @@ An empty cluster means no restrictions will apply.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters}
 
 VirtualClusters that this rule matches. Only applies to tenant cluster requests.
 An empty list means no restrictions will apply.
@@ -443,7 +443,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-name}
 
 Name of the tenant cluster. Empty means all tenant clusters.
 
@@ -458,7 +458,7 @@ Name of the tenant cluster. Empty means all tenant clusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-namespace}
 
 Namespace of the tenant cluster. Empty means all namespaces.
 
@@ -479,7 +479,7 @@ Namespace of the tenant cluster. Empty means all namespaces.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allowLoftCli` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-allowLoftCli}
+#### `allowLoftCli` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-allowLoftCli}
 
 AllowLoftCLI allows certain read-only management requests to
 make sure loft cli works correctly with this specific access key.
@@ -508,7 +508,7 @@ Deprecated: Use the `roles` field instead
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -520,7 +520,7 @@ Deprecated: Use the `roles` field instead
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-token}
+### `token` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-token}
 
 
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/metadata/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/metadata/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kind}
+## `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -23,7 +23,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiVersion}
+## `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -41,7 +41,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata}
+## `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata}
 
 
 
@@ -53,7 +53,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -73,7 +73,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-generateName}
+### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -99,7 +99,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-namespace}
+### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -121,7 +121,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-selfLink}
+### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -136,7 +136,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-uid}
+### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -157,7 +157,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-resourceVersion}
+### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -181,7 +181,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-generation}
+### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -197,7 +197,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-creationTimestamp}
+### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -219,7 +219,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-deletionTimestamp}
+### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -251,7 +251,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-deletionGracePeriodSeconds}
+### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -269,7 +269,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -287,7 +287,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -305,7 +305,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences}
+### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -383,7 +383,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences-controller}
+#### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -398,7 +398,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences-blockOwnerDeletion}
+#### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -423,7 +423,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-finalizers}
+### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -450,7 +450,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields}
+### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -469,7 +469,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-manager}
+#### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -484,7 +484,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-operation}
+#### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -500,7 +500,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -518,7 +518,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-time}
+#### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -537,7 +537,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsType}
+#### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -553,7 +553,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsV1}
+#### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -568,7 +568,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-subresource}
+#### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/metadata/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/metadata/reference.mdx
@@ -469,7 +469,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-manager}
+#### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -484,7 +484,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-operation}
+#### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -500,7 +500,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -537,7 +537,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsType}
+#### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -568,7 +568,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-subresource}
+#### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/nodeproviders/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/nodeproviders/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-properties}
+### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-properties}
 
 Properties are global properties that are applied to all node claims and environments managed by this provider.
 
@@ -35,7 +35,7 @@ Properties are global properties that are applied to all node claims and environ
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `bcm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm}
+### `bcm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm}
 
 BCM configures a node provider for BCM Bare Metal Cloud environments.
 
@@ -107,7 +107,7 @@ Endpoint is an address for head node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -119,7 +119,7 @@ NodeTypes define NodeTypes that should be automatically created for this provide
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `providerRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-providerRef}
+##### `providerRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-providerRef}
 
 ProviderRef is the node provider to use for this node type.
 
@@ -134,7 +134,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -149,7 +149,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -164,7 +164,7 @@ Resources lists the full resources for a single node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `overhead` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-overhead}
+##### `overhead` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-overhead}
 
 Overhead defines the resource overhead for this node type.
 
@@ -176,7 +176,7 @@ Overhead defines the resource overhead for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeReserved` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-overhead-kubeReserved}
+##### `kubeReserved` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-overhead-kubeReserved}
 
 KubeReserved is the resource overhead for kubelet and other Kubernetes system daemons.
 
@@ -194,7 +194,7 @@ KubeReserved is the resource overhead for kubelet and other Kubernetes system da
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-cost}
+##### `cost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-cost}
 
 Cost is the instance cost. The higher the cost, the less likely it is to be selected. If empty, cost is automatically calculated
 from the resources specified.
@@ -210,7 +210,7 @@ from the resources specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -240,7 +240,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -252,7 +252,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -267,7 +267,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -285,7 +285,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodes}
+##### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodes}
 
 Nodes specifies nodes.
 
@@ -300,7 +300,7 @@ Nodes specifies nodes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodeGroups}
+##### `nodeGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodeGroups}
 
 NodeGroups is the name of the node groups to use for this provider.
 
@@ -321,7 +321,7 @@ NodeGroups is the name of the node groups to use for this provider.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt}
+### `kubeVirt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt}
 
 Kubevirt configures a node provider using KubeVirt, enabling virtual machines
 to be provisioned as nodes within a vCluster.
@@ -334,7 +334,7 @@ to be provisioned as nodes within a vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -361,7 +361,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -379,7 +379,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy}
+#### `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy}
 
 Deploy configures components deployed into the connected control plane cluster.
 
@@ -391,7 +391,7 @@ Deploy configures components deployed into the connected control plane cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubevirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt}
+##### `kubevirt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt}
 
 KubeVirt configures the KubeVirt operator deployment.
 
@@ -418,7 +418,7 @@ Enabled controls whether the KubeVirt operator is deployed into the cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chartRepo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-chartRepo}
+##### `chartRepo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-chartRepo}
 
 ChartRepo overrides the Helm chart repository used to install the KubeVirt operator.
 
@@ -433,7 +433,7 @@ ChartRepo overrides the Helm chart repository used to install the KubeVirt opera
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-chart}
 
 Chart overrides the Helm chart name used to install the KubeVirt operator.
 
@@ -448,7 +448,7 @@ Chart overrides the Helm chart name used to install the KubeVirt operator.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-version}
 
 Version overrides the Helm chart version used to install the KubeVirt operator.
 
@@ -463,7 +463,7 @@ Version overrides the Helm chart version used to install the KubeVirt operator.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `helmValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-helmValues}
+##### `helmValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-deploy-kubevirt-helmValues}
 
 HelmValues is raw YAML that will be passed as values to the KubeVirt Helm chart.
 
@@ -484,7 +484,7 @@ HelmValues is raw YAML that will be passed as values to the KubeVirt Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-virtualMachineTemplate}
+#### `virtualMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-virtualMachineTemplate}
 
 VirtualMachineTemplate is a KubeVirt VirtualMachine template to use by NodeTypes managed by this NodeProvider
 
@@ -511,7 +511,7 @@ NodeTypes define NodeTypes that should be automatically created for this provide
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `providerRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-providerRef}
+##### `providerRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-providerRef}
 
 ProviderRef is the node provider to use for this node type.
 
@@ -526,7 +526,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -541,7 +541,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -556,7 +556,7 @@ Resources lists the full resources for a single node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `overhead` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-overhead}
+##### `overhead` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-overhead}
 
 Overhead defines the resource overhead for this node type.
 
@@ -568,7 +568,7 @@ Overhead defines the resource overhead for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeReserved` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-overhead-kubeReserved}
+##### `kubeReserved` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-overhead-kubeReserved}
 
 KubeReserved is the resource overhead for kubelet and other Kubernetes system daemons.
 
@@ -586,7 +586,7 @@ KubeReserved is the resource overhead for kubelet and other Kubernetes system da
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-cost}
+##### `cost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-cost}
 
 Cost is the instance cost. The higher the cost, the less likely it is to be selected. If empty, cost is automatically calculated
 from the resources specified.
@@ -602,7 +602,7 @@ from the resources specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -632,7 +632,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -644,7 +644,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -659,7 +659,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -677,7 +677,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-virtualMachineTemplate}
+##### `virtualMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-virtualMachineTemplate}
 
 VirtualMachineTemplate is a full KubeVirt VirtualMachine template to use for this NodeType.
 This is mutually exclusive with MergeVirtualMachineTemplate
@@ -693,7 +693,7 @@ This is mutually exclusive with MergeVirtualMachineTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeVirtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-mergeVirtualMachineTemplate}
+##### `mergeVirtualMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-mergeVirtualMachineTemplate}
 
 MergeVirtualMachineTemplate will be merged into base VirtualMachine template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -710,7 +710,7 @@ This is mutually exclusive with VirtualMachineTemplate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -731,7 +731,7 @@ MaxCapacity is the maximum number of nodes that can be created for this NodeType
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `terraform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform}
+### `terraform` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform}
 
 Terraform configures a node provider using Terraform, enabling nodes to be provisioned using Terraform.
 
@@ -743,7 +743,7 @@ Terraform configures a node provider using Terraform, enabling nodes to be provi
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate}
+#### `nodeTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate}
 
 NodeTemplate is the template to use for this node provider.
 
@@ -755,7 +755,7 @@ NodeTemplate is the template to use for this node provider.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -770,7 +770,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git}
+##### `git` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -782,7 +782,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -797,7 +797,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -812,7 +812,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -827,7 +827,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -842,7 +842,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -857,7 +857,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -869,7 +869,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-secretName}
 
 
 
@@ -884,7 +884,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-secretNamespace}
 
 
 
@@ -899,7 +899,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials-key}
 
 
 
@@ -917,7 +917,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -932,7 +932,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -950,7 +950,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -968,7 +968,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeEnvironmentTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate}
+#### `nodeEnvironmentTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate}
 
 NodeEnvironmentTemplate is the template to use for this node environment.
 
@@ -980,7 +980,7 @@ NodeEnvironmentTemplate is the template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -995,7 +995,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git}
+##### `git` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -1007,7 +1007,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -1022,7 +1022,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -1037,7 +1037,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1052,7 +1052,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1067,7 +1067,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1082,7 +1082,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1094,7 +1094,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-secretName}
 
 
 
@@ -1109,7 +1109,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-secretNamespace}
 
 
 
@@ -1124,7 +1124,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials-key}
 
 
 
@@ -1142,7 +1142,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1157,7 +1157,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1175,7 +1175,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1190,7 +1190,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `infrastructure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure}
+##### `infrastructure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure}
 
 Infrastructure is the infrastructure template to use for this node environment.
 
@@ -1202,7 +1202,7 @@ Infrastructure is the infrastructure template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1217,7 +1217,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git}
+##### `git` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git}
 
 Git is the git repository to use for this node type.
 
@@ -1229,7 +1229,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-repository}
 
 Repository is the repository to clone
 
@@ -1244,7 +1244,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-branch}
+##### `branch` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-branch}
 
 Branch is the branch to use
 
@@ -1259,7 +1259,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-commit}
+##### `commit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1274,7 +1274,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1289,7 +1289,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1304,7 +1304,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1316,7 +1316,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-secretName}
 
 
 
@@ -1331,7 +1331,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-secretNamespace}
 
 
 
@@ -1346,7 +1346,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials-key}
 
 
 
@@ -1364,7 +1364,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1379,7 +1379,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1397,7 +1397,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1415,7 +1415,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubernetes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes}
+##### `kubernetes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes}
 
 Kubernetes is the kubernetes template to use for this node environment.
 
@@ -1427,7 +1427,7 @@ Kubernetes is the kubernetes template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1442,7 +1442,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git}
+##### `git` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git}
 
 Git is the git repository to use for this node type.
 
@@ -1454,7 +1454,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-repository}
 
 Repository is the repository to clone
 
@@ -1469,7 +1469,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-branch}
+##### `branch` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-branch}
 
 Branch is the branch to use
 
@@ -1484,7 +1484,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-commit}
+##### `commit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1499,7 +1499,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1514,7 +1514,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1529,7 +1529,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1541,7 +1541,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-secretName}
 
 
 
@@ -1556,7 +1556,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-secretNamespace}
 
 
 
@@ -1571,7 +1571,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials-key}
 
 
 
@@ -1589,7 +1589,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1604,7 +1604,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1622,7 +1622,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1643,7 +1643,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -1655,7 +1655,7 @@ NodeTypes define NodeTypes that should be automatically created for this provide
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `providerRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-providerRef}
+##### `providerRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-providerRef}
 
 ProviderRef is the node provider to use for this node type.
 
@@ -1670,7 +1670,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -1685,7 +1685,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -1700,7 +1700,7 @@ Resources lists the full resources for a single node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `overhead` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-overhead}
+##### `overhead` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-overhead}
 
 Overhead defines the resource overhead for this node type.
 
@@ -1712,7 +1712,7 @@ Overhead defines the resource overhead for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeReserved` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-overhead-kubeReserved}
+##### `kubeReserved` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-overhead-kubeReserved}
 
 KubeReserved is the resource overhead for kubelet and other Kubernetes system daemons.
 
@@ -1730,7 +1730,7 @@ KubeReserved is the resource overhead for kubelet and other Kubernetes system da
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-cost}
+##### `cost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-cost}
 
 Cost is the instance cost. The higher the cost, the less likely it is to be selected. If empty, cost is automatically calculated
 from the resources specified.
@@ -1746,7 +1746,7 @@ from the resources specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -1776,7 +1776,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -1788,7 +1788,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -1803,7 +1803,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -1821,7 +1821,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate}
+##### `nodeTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate}
 
 NodeTemplate is the template to use for this node type.
 
@@ -1833,7 +1833,7 @@ NodeTemplate is the template to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1848,7 +1848,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git}
+##### `git` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -1860,7 +1860,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -1875,7 +1875,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -1890,7 +1890,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1905,7 +1905,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1920,7 +1920,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1935,7 +1935,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1947,7 +1947,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-secretName}
 
 
 
@@ -1962,7 +1962,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-secretNamespace}
 
 
 
@@ -1977,7 +1977,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials-key}
 
 
 
@@ -1995,7 +1995,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -2010,7 +2010,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -2028,7 +2028,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -2046,7 +2046,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -2067,7 +2067,7 @@ MaxCapacity is the maximum number of nodes that can be created for this NodeType
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterAPI` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI}
+### `clusterAPI` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI}
 
 ClusterAPI configures a node provider using Cluster API, enabling nodes to be provisioned using Cluster API.
 This requires the vCluster to be deployed with Cluster API as well.
@@ -2080,7 +2080,7 @@ This requires the vCluster to be deployed with Cluster API as well.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-infrastructureMachineTemplate}
+#### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-infrastructureMachineTemplate}
 
 InfrastructureMachineTemplate is a template for the infrastructure machine, e.g. AWSMachine
 
@@ -2095,7 +2095,7 @@ InfrastructureMachineTemplate is a template for the infrastructure machine, e.g.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-bootstrapConfigTemplate}
+#### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-bootstrapConfigTemplate}
 
 BootstrapConfigTemplate is a template for the bootstrap config. Currently only KubeadmConfig is supported.
 
@@ -2110,7 +2110,7 @@ BootstrapConfigTemplate is a template for the bootstrap config. Currently only K
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -2137,7 +2137,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -2155,7 +2155,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -2167,7 +2167,7 @@ NodeTypes define NodeTypes that should be automatically created for this provide
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `providerRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-providerRef}
+##### `providerRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-providerRef}
 
 ProviderRef is the node provider to use for this node type.
 
@@ -2182,7 +2182,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -2197,7 +2197,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -2212,7 +2212,7 @@ Resources lists the full resources for a single node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `overhead` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-overhead}
+##### `overhead` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-overhead}
 
 Overhead defines the resource overhead for this node type.
 
@@ -2224,7 +2224,7 @@ Overhead defines the resource overhead for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeReserved` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-overhead-kubeReserved}
+##### `kubeReserved` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-overhead-kubeReserved}
 
 KubeReserved is the resource overhead for kubelet and other Kubernetes system daemons.
 
@@ -2242,7 +2242,7 @@ KubeReserved is the resource overhead for kubelet and other Kubernetes system da
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-cost}
+##### `cost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-cost}
 
 Cost is the instance cost. The higher the cost, the less likely it is to be selected. If empty, cost is automatically calculated
 from the resources specified.
@@ -2258,7 +2258,7 @@ from the resources specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -2288,7 +2288,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -2300,7 +2300,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -2315,7 +2315,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -2333,7 +2333,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-infrastructureMachineTemplate}
+##### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-infrastructureMachineTemplate}
 
 InfrastructureMachineTemplate is a template for the infrastructure machine, e.g. AWSMachine
 
@@ -2348,7 +2348,7 @@ InfrastructureMachineTemplate is a template for the infrastructure machine, e.g.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-bootstrapConfigTemplate}
+##### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-bootstrapConfigTemplate}
 
 BootstrapConfigTemplate is a template for the bootstrap config. Currently only KubeadmConfig is supported.
 
@@ -2363,7 +2363,7 @@ BootstrapConfigTemplate is a template for the bootstrap config. Currently only K
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeInfrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeInfrastructureMachineTemplate}
+##### `mergeInfrastructureMachineTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeInfrastructureMachineTemplate}
 
 MergeInfrastructureMachineTemplate will be merged into base InfrastructureMachine template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -2380,7 +2380,7 @@ This is mutually exclusive with InfrastructureMachineTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeBootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeBootstrapConfigTemplate}
+##### `mergeBootstrapConfigTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeBootstrapConfigTemplate}
 
 MergeBootstrapConfigTemplate will be merged into base BootstrapConfig template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -2397,7 +2397,7 @@ This is mutually exclusive with BootstrapConfigTemplate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -2418,7 +2418,7 @@ MaxCapacity is the maximum number of nodes that can be created for this NodeType
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metal3` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3}
+### `metal3` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3}
 
 Metal3 configures a node provider using metal3.io BareMetalHost resources.
 
@@ -2430,7 +2430,7 @@ Metal3 configures a node provider using metal3.io BareMetalHost resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -2457,7 +2457,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -2475,7 +2475,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy}
+#### `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy}
 
 
 
@@ -2487,7 +2487,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `multus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-multus}
+##### `multus` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-multus}
 
 Multus configures the Multus CNI deployment.
 
@@ -2514,7 +2514,7 @@ Enabled controls whether Multus CNI is deployed into the cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `helmValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-multus-helmValues}
+##### `helmValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-multus-helmValues}
 
 HelmValues is raw YAML that will be passed as values to the Multus Helm chart.
 
@@ -2532,7 +2532,7 @@ HelmValues is raw YAML that will be passed as values to the Multus Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `dhcp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp}
+##### `dhcp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp}
 
 DHCP configures the DHCP server deployment.
 
@@ -2559,7 +2559,7 @@ Enabled controls whether the DHCP server is deployed into the cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chartRepo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-chartRepo}
+##### `chartRepo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-chartRepo}
 
 ChartRepo overrides the Helm chart repository used to install the DHCP server.
 
@@ -2574,7 +2574,7 @@ ChartRepo overrides the Helm chart repository used to install the DHCP server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-chart}
 
 Chart overrides the Helm chart name used to install the DHCP server.
 
@@ -2589,7 +2589,7 @@ Chart overrides the Helm chart name used to install the DHCP server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-version}
 
 Version overrides the Helm chart version used to install the DHCP server.
 
@@ -2604,7 +2604,7 @@ Version overrides the Helm chart version used to install the DHCP server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `helmValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-helmValues}
+##### `helmValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-dhcp-helmValues}
 
 HelmValues is raw YAML that will be passed as values to the DHCP Helm chart.
 
@@ -2622,7 +2622,7 @@ HelmValues is raw YAML that will be passed as values to the DHCP Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metal3` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3}
+##### `metal3` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3}
 
 Metal3 configures the Metal3/Ironic deployment.
 
@@ -2649,7 +2649,7 @@ Enabled controls whether Metal3 and Ironic are deployed into the cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chartRepo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-chartRepo}
+##### `chartRepo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-chartRepo}
 
 ChartRepo overrides the Helm chart repository used to install Metal3.
 
@@ -2664,7 +2664,7 @@ ChartRepo overrides the Helm chart repository used to install Metal3.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-chart}
 
 Chart overrides the Helm chart name used to install Metal3.
 
@@ -2679,7 +2679,7 @@ Chart overrides the Helm chart name used to install Metal3.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-version}
 
 Version overrides the Helm chart version used to install Metal3.
 
@@ -2694,7 +2694,7 @@ Version overrides the Helm chart version used to install Metal3.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `helmValues` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-helmValues}
+##### `helmValues` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy-metal3-helmValues}
 
 HelmValues is raw YAML that will be passed as values to the Metal3 Helm chart.
 
@@ -2715,7 +2715,7 @@ HelmValues is raw YAML that will be passed as values to the Metal3 Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -2727,7 +2727,7 @@ NodeTypes define NodeTypes that should be automatically created for this provide
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `providerRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-providerRef}
+##### `providerRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-providerRef}
 
 ProviderRef is the node provider to use for this node type.
 
@@ -2742,7 +2742,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -2757,7 +2757,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -2772,7 +2772,7 @@ Resources lists the full resources for a single node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `overhead` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-overhead}
+##### `overhead` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-overhead}
 
 Overhead defines the resource overhead for this node type.
 
@@ -2784,7 +2784,7 @@ Overhead defines the resource overhead for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeReserved` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-overhead-kubeReserved}
+##### `kubeReserved` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-overhead-kubeReserved}
 
 KubeReserved is the resource overhead for kubelet and other Kubernetes system daemons.
 
@@ -2802,7 +2802,7 @@ KubeReserved is the resource overhead for kubelet and other Kubernetes system da
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-cost}
+##### `cost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-cost}
 
 Cost is the instance cost. The higher the cost, the less likely it is to be selected. If empty, cost is automatically calculated
 from the resources specified.
@@ -2818,7 +2818,7 @@ from the resources specified.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -2848,7 +2848,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -2860,7 +2860,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -2875,7 +2875,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -2893,7 +2893,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `bareMetalHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts}
+##### `bareMetalHosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts}
 
 BareMetalHosts is a list of BareMetalHosts to use for this NodeType.
 
@@ -2905,7 +2905,7 @@ BareMetalHosts is a list of BareMetalHosts to use for this NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector}
 
 Selector is a label selector to select the BareMetalHosts to use for this NodeType.
 
@@ -2917,7 +2917,7 @@ Selector is a label selector to select the BareMetalHosts to use for this NodeTy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchLabels}
 
 matchLabels is a map of &#123;key,value&#125; pairs. A single &#123;key,value&#125; in the matchLabels
 map is equivalent to an element of matchExpressions, whose key field is "key", the
@@ -2934,7 +2934,7 @@ operator is "In", and the values array contains only "value". The requirements a
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchExpressions}
 
 matchExpressions is a list of label selector requirements. The requirements are ANDed.
 
@@ -2977,7 +2977,7 @@ Valid operators are In, NotIn, Exists and DoesNotExist.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchExpressions-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-bareMetalHosts-selector-matchExpressions-values}
 
 values is an array of string values. If the operator is In or NotIn,
 the values array must be non-empty. If the operator is Exists or DoesNotExist,
@@ -3010,7 +3010,7 @@ merge patch.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -3028,7 +3028,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -3040,7 +3040,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions describe the current state of the platform NodeProvider.
 
@@ -3055,7 +3055,7 @@ Conditions describe the current state of the platform NodeProvider.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `reason` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
+### `reason` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
 
 Reason describes the reason in machine-readable form
 
@@ -3070,7 +3070,7 @@ Reason describes the reason in machine-readable form
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `phase` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
+### `phase` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
 
 Phase is the current lifecycle phase of the NodeProvider.
 
@@ -3085,7 +3085,7 @@ Phase is the current lifecycle phase of the NodeProvider.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `message` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
+### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
 
 Message is a human-readable message indicating details about why the NodeProvider is in its current state.
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/nodeproviders/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/nodeproviders/reference.mdx
@@ -107,7 +107,7 @@ Endpoint is an address for head node.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -134,7 +134,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -149,7 +149,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -240,7 +240,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -252,7 +252,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -267,7 +267,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -285,7 +285,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodes}
+##### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodes}
 
 Nodes specifies nodes.
 
@@ -300,7 +300,7 @@ Nodes specifies nodes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeGroups` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodeGroups}
+##### `nodeGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-bcm-nodeTypes-nodeGroups}
 
 NodeGroups is the name of the node groups to use for this provider.
 
@@ -334,7 +334,7 @@ to be provisioned as nodes within a vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -361,7 +361,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -484,7 +484,7 @@ HelmValues is raw YAML that will be passed as values to the KubeVirt Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-virtualMachineTemplate}
+#### `virtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-virtualMachineTemplate}
 
 VirtualMachineTemplate is a KubeVirt VirtualMachine template to use by NodeTypes managed by this NodeProvider
 
@@ -526,7 +526,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -541,7 +541,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -632,7 +632,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -644,7 +644,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -659,7 +659,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -677,7 +677,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-virtualMachineTemplate}
+##### `virtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-virtualMachineTemplate}
 
 VirtualMachineTemplate is a full KubeVirt VirtualMachine template to use for this NodeType.
 This is mutually exclusive with MergeVirtualMachineTemplate
@@ -693,7 +693,7 @@ This is mutually exclusive with MergeVirtualMachineTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeVirtualMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-mergeVirtualMachineTemplate}
+##### `mergeVirtualMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-mergeVirtualMachineTemplate}
 
 MergeVirtualMachineTemplate will be merged into base VirtualMachine template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -710,7 +710,7 @@ This is mutually exclusive with VirtualMachineTemplate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeVirt-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -743,7 +743,7 @@ Terraform configures a node provider using Terraform, enabling nodes to be provi
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate}
+#### `nodeTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate}
 
 NodeTemplate is the template to use for this node provider.
 
@@ -755,7 +755,7 @@ NodeTemplate is the template to use for this node provider.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -770,7 +770,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git}
+##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -782,7 +782,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -797,7 +797,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -812,7 +812,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -827,7 +827,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -842,7 +842,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -857,7 +857,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -917,7 +917,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -932,7 +932,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -950,7 +950,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -968,7 +968,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeEnvironmentTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate}
+#### `nodeEnvironmentTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate}
 
 NodeEnvironmentTemplate is the template to use for this node environment.
 
@@ -980,7 +980,7 @@ NodeEnvironmentTemplate is the template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -995,7 +995,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git}
+##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -1007,7 +1007,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -1022,7 +1022,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -1037,7 +1037,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1052,7 +1052,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1067,7 +1067,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1082,7 +1082,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1142,7 +1142,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1157,7 +1157,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1175,7 +1175,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1190,7 +1190,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `infrastructure` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure}
+##### `infrastructure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure}
 
 Infrastructure is the infrastructure template to use for this node environment.
 
@@ -1202,7 +1202,7 @@ Infrastructure is the infrastructure template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-inline}
+##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1217,7 +1217,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git}
+##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git}
 
 Git is the git repository to use for this node type.
 
@@ -1229,7 +1229,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-repository}
 
 Repository is the repository to clone
 
@@ -1244,7 +1244,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-branch}
+##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-branch}
 
 Branch is the branch to use
 
@@ -1259,7 +1259,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-commit}
+##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1274,7 +1274,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1289,7 +1289,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1304,7 +1304,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1364,7 +1364,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1379,7 +1379,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1397,7 +1397,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-infrastructure-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1415,7 +1415,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubernetes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes}
+##### `kubernetes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes}
 
 Kubernetes is the kubernetes template to use for this node environment.
 
@@ -1427,7 +1427,7 @@ Kubernetes is the kubernetes template to use for this node environment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-inline}
+##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1442,7 +1442,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git}
+##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git}
 
 Git is the git repository to use for this node type.
 
@@ -1454,7 +1454,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-repository}
 
 Repository is the repository to clone
 
@@ -1469,7 +1469,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-branch}
+##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-branch}
 
 Branch is the branch to use
 
@@ -1484,7 +1484,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-commit}
+##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1499,7 +1499,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1514,7 +1514,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1529,7 +1529,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1589,7 +1589,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -1604,7 +1604,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -1622,7 +1622,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeEnvironmentTemplate-kubernetes-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -1643,7 +1643,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -1670,7 +1670,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -1685,7 +1685,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -1776,7 +1776,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -1788,7 +1788,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -1803,7 +1803,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -1821,7 +1821,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate}
+##### `nodeTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate}
 
 NodeTemplate is the template to use for this node type.
 
@@ -1833,7 +1833,7 @@ NodeTemplate is the template to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-inline}
+##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-inline}
 
 Inline is the inline template to use for this node type.
 
@@ -1848,7 +1848,7 @@ Inline is the inline template to use for this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `git` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git}
+##### `git` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git}
 
 Git is the git repository to use for this node type.
 
@@ -1860,7 +1860,7 @@ Git is the git repository to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-repository}
 
 Repository is the repository to clone
 
@@ -1875,7 +1875,7 @@ Repository is the repository to clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `branch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-branch}
+##### `branch` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-branch}
 
 Branch is the branch to use
 
@@ -1890,7 +1890,7 @@ Branch is the branch to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `commit` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-commit}
+##### `commit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-commit}
 
 Commit is the commit SHA to checkout
 
@@ -1905,7 +1905,7 @@ Commit is the commit SHA to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-tag}
 
 Tag is the tag reference to checkout
 
@@ -1920,7 +1920,7 @@ Tag is the tag reference to checkout
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-subPath}
 
 SubPath is the subpath in the repo to use
 
@@ -1935,7 +1935,7 @@ SubPath is the subpath in the repo to use
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credentials` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials}
+##### `credentials` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-credentials}
 
 Credentials is the reference to a secret containing the username and password for the git repository.
 
@@ -1995,7 +1995,7 @@ Credentials is the reference to a secret containing the username and password fo
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fetchInterval` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-fetchInterval}
+##### `fetchInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-fetchInterval}
 
 FetchInterval is the interval to use for refetching the git repository. Defaults to 5m. Refetching only checks for remote changes but does not do a complete repull.
 
@@ -2010,7 +2010,7 @@ FetchInterval is the interval to use for refetching the git repository. Defaults
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-git-extraEnv}
 
 ExtraEnv is the extra environment variables to use for the clone
 
@@ -2028,7 +2028,7 @@ ExtraEnv is the extra environment variables to use for the clone
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-nodeTemplate-timeout}
 
 Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 
@@ -2046,7 +2046,7 @@ Timeout is the timeout to use for the terraform operations. Defaults to 60m.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-terraform-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -2080,7 +2080,7 @@ This requires the vCluster to be deployed with Cluster API as well.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `infrastructureMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-infrastructureMachineTemplate}
+#### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-infrastructureMachineTemplate}
 
 InfrastructureMachineTemplate is a template for the infrastructure machine, e.g. AWSMachine
 
@@ -2095,7 +2095,7 @@ InfrastructureMachineTemplate is a template for the infrastructure machine, e.g.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `bootstrapConfigTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-bootstrapConfigTemplate}
+#### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-bootstrapConfigTemplate}
 
 BootstrapConfigTemplate is a template for the bootstrap config. Currently only KubeadmConfig is supported.
 
@@ -2110,7 +2110,7 @@ BootstrapConfigTemplate is a template for the bootstrap config. Currently only K
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -2137,7 +2137,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -2155,7 +2155,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -2182,7 +2182,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -2197,7 +2197,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -2288,7 +2288,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -2300,7 +2300,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -2315,7 +2315,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 
@@ -2333,7 +2333,7 @@ Annotations holds annotations to add to this managed NodeType.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `infrastructureMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-infrastructureMachineTemplate}
+##### `infrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-infrastructureMachineTemplate}
 
 InfrastructureMachineTemplate is a template for the infrastructure machine, e.g. AWSMachine
 
@@ -2348,7 +2348,7 @@ InfrastructureMachineTemplate is a template for the infrastructure machine, e.g.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `bootstrapConfigTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-bootstrapConfigTemplate}
+##### `bootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-bootstrapConfigTemplate}
 
 BootstrapConfigTemplate is a template for the bootstrap config. Currently only KubeadmConfig is supported.
 
@@ -2363,7 +2363,7 @@ BootstrapConfigTemplate is a template for the bootstrap config. Currently only K
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeInfrastructureMachineTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeInfrastructureMachineTemplate}
+##### `mergeInfrastructureMachineTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeInfrastructureMachineTemplate}
 
 MergeInfrastructureMachineTemplate will be merged into base InfrastructureMachine template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -2380,7 +2380,7 @@ This is mutually exclusive with InfrastructureMachineTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mergeBootstrapConfigTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeBootstrapConfigTemplate}
+##### `mergeBootstrapConfigTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-mergeBootstrapConfigTemplate}
 
 MergeBootstrapConfigTemplate will be merged into base BootstrapConfig template for this NodeProvider.
 This allows overwriting of specific fields from top level template by individual NodeTypes
@@ -2397,7 +2397,7 @@ This is mutually exclusive with BootstrapConfigTemplate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxCapacity` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-maxCapacity}
+##### `maxCapacity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterAPI-nodeTypes-maxCapacity}
 
 MaxCapacity is the maximum number of nodes that can be created for this NodeType.
 
@@ -2430,7 +2430,7 @@ Metal3 configures a node provider using metal3.io BareMetalHost resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRef` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef}
+#### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef}
 
 ClusterRef is a reference to connected control plane cluster in which KubeVirt operator is running
 
@@ -2457,7 +2457,7 @@ Cluster is the connected cluster the VMs will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding VMs
 
@@ -2475,7 +2475,7 @@ Namespace is the namespace inside the connected cluster holding VMs
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy}
+#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-deploy}
 
 
 
@@ -2715,7 +2715,7 @@ HelmValues is raw YAML that will be passed as values to the Metal3 Helm chart.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes}
+#### `nodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes}
 
 NodeTypes define NodeTypes that should be automatically created for this provider.
 
@@ -2742,7 +2742,7 @@ ProviderRef is the node provider to use for this node type.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `properties` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-properties}
+##### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-properties}
 
 Properties returns a flexible set of properties that may be selected for scheduling.
 
@@ -2757,7 +2757,7 @@ Properties returns a flexible set of properties that may be selected for schedul
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-resources}
 
 Resources lists the full resources for a single node.
 
@@ -2848,7 +2848,7 @@ Name is the name of this node type.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata}
 
 Metadata holds metadata to add to this managed NodeType.
 
@@ -2860,7 +2860,7 @@ Metadata holds metadata to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-labels}
 
 Labels holds labels to add to this managed NodeType.
 
@@ -2875,7 +2875,7 @@ Labels holds labels to add to this managed NodeType.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-metal3-nodeTypes-metadata-annotations}
 
 Annotations holds annotations to add to this managed NodeType.
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/ownedaccesskeys/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/ownedaccesskeys/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 The display name shown in the UI
 
@@ -35,7 +35,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes an app
 
@@ -50,7 +50,7 @@ Description describes an app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-user}
+### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-user}
 
 The user this access key refers to
 
@@ -65,7 +65,7 @@ The user this access key refers to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-team}
+### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-team}
 
 The team this access key refers to
 
@@ -80,7 +80,7 @@ The team this access key refers to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
+### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
 
 Subject is a generic subject that can be used
 instead of user or team
@@ -96,7 +96,7 @@ instead of user or team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
+### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
 
 Groups specifies extra groups to apply when using
 this access key
@@ -112,7 +112,7 @@ this access key
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-key}
+### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-key}
 
 The actual access key that will be used as a bearer token
 
@@ -127,7 +127,7 @@ The actual access key that will be used as a bearer token
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-disabled}
+### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-disabled}
 
 If this field is true, the access key is still allowed to exist,
 however will not work to access the api
@@ -143,7 +143,7 @@ however will not work to access the api
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ttl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttl}
+### `ttl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttl}
 
 The time to live for this access key
 
@@ -158,7 +158,7 @@ The time to live for this access key
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ttlAfterLastActivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttlAfterLastActivity}
+### `ttlAfterLastActivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ttlAfterLastActivity}
 
 If this is specified, the time to live for this access key will
 start after the lastActivity instead of creation timestamp
@@ -174,7 +174,7 @@ start after the lastActivity instead of creation timestamp
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope}
+### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope}
 
 Scope defines the scope of the access key.
 
@@ -186,7 +186,7 @@ Scope defines the scope of the access key.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `roles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles}
+#### `roles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles}
 
 Roles is a set of managed permissions to apply to the access key.
 
@@ -198,7 +198,7 @@ Roles is a set of managed permissions to apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-role}
 
 Role is the name of the role to apply to the access key scope.
 
@@ -213,7 +213,7 @@ Role is the name of the role to apply to the access key scope.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-projects}
+##### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -228,7 +228,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-roles-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -246,7 +246,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects}
+#### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -258,7 +258,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-projects-project}
 
 Project is the name of the project. You can specify * to select all projects.
 
@@ -276,7 +276,7 @@ Project is the name of the project. You can specify * to select all projects.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces}
+#### `spaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces}
 
 Spaces specifies the spaces the access key is allowed to access.
 
@@ -288,7 +288,7 @@ Spaces specifies the spaces the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-project}
 
 Project is the name of the project.
 
@@ -303,7 +303,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `space` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-space}
+##### `space` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-spaces-space}
 
 Space is the name of the space. You can specify * to select all spaces.
 
@@ -321,7 +321,7 @@ Space is the name of the space. You can specify * to select all spaces.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters}
+#### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -333,7 +333,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-project}
 
 Project is the name of the project.
 
@@ -348,7 +348,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-virtualCluster}
+##### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-virtualClusters-virtualCluster}
 
 VirtualCluster is the name of the tenant cluster to access. You can specify * to select all tenant clusters.
 
@@ -366,7 +366,7 @@ VirtualCluster is the name of the tenant cluster to access. You can specify * to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters}
+#### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters}
 
 Clusters specifies the project cluster the access key is allowed to access.
 
@@ -378,7 +378,7 @@ Clusters specifies the project cluster the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-clusters-cluster}
 
 Cluster is the name of the cluster to access. You can specify * to select all clusters.
 
@@ -396,7 +396,7 @@ Cluster is the name of the cluster to access. You can specify * to select all cl
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules}
 
 DEPRECATED: Use Projects, Spaces and VirtualClusters instead
 Rules specifies the rules that should apply to the access key.
@@ -409,7 +409,7 @@ Rules specifies the rules that should apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -425,7 +425,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -437,7 +437,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -453,7 +453,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -480,7 +480,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -500,7 +500,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-namespaces}
+##### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -517,7 +517,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be checked.
 *s are allowed, but only as the full, final step in the path.
@@ -536,7 +536,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-requestTargets}
+##### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-requestTargets}
 
 RequestTargets is a list of request targets that are allowed.
 An empty list implies every request.
@@ -552,7 +552,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-cluster}
 
 Cluster that this rule matches. Only applies to cluster requests.
 If this is set, no requests for non cluster requests are allowed.
@@ -569,7 +569,7 @@ An empty cluster means no restrictions will apply.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters}
 
 VirtualClusters that this rule matches. Only applies to tenant cluster requests.
 An empty list means no restrictions will apply.
@@ -582,7 +582,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-name}
 
 Name of the tenant cluster. Empty means all tenant clusters.
 
@@ -597,7 +597,7 @@ Name of the tenant cluster. Empty means all tenant clusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-rules-virtualClusters-namespace}
 
 Namespace of the tenant cluster. Empty means all namespaces.
 
@@ -618,7 +618,7 @@ Namespace of the tenant cluster. Empty means all namespaces.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allowLoftCli` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-allowLoftCli}
+#### `allowLoftCli` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-scope-allowLoftCli}
 
 AllowLoftCLI allows certain read-only management requests to
 make sure loft cli works correctly with this specific access key.
@@ -644,7 +644,7 @@ Deprecated: Use the `roles` field instead
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-type}
+### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-type}
 
 The type of an access key, which basically describes if the access
 key is user managed or managed by loft itself.
@@ -660,7 +660,7 @@ key is user managed or managed by loft itself.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `identity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity}
+### `identity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity}
 
 If available, contains information about the sso login data for this
 access key
@@ -673,7 +673,7 @@ access key
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `userId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-userId}
+#### `userId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-userId}
 
 The subject of the user
 
@@ -688,7 +688,7 @@ The subject of the user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-username}
 
 The username
 
@@ -703,7 +703,7 @@ The username
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preferredUsername` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-preferredUsername}
+#### `preferredUsername` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-preferredUsername}
 
 The preferred username / display name
 
@@ -718,7 +718,7 @@ The preferred username / display name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-email}
 
 The user email
 
@@ -733,7 +733,7 @@ The user email
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `emailVerified` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-emailVerified}
+#### `emailVerified` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-emailVerified}
 
 If the user email was verified
 
@@ -748,7 +748,7 @@ If the user email was verified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-extraClaims}
+#### `extraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-extraClaims}
 
 ExtraClaims are claims that are not otherwise contained in this struct but may be provided by the OIDC
 provider. Only extra claims that are allowed by the auth config are included.
@@ -764,7 +764,7 @@ provider. Only extra claims that are allowed by the auth config are included.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-groups}
+#### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-groups}
 
 The groups from the identity provider
 
@@ -779,7 +779,7 @@ The groups from the identity provider
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-connector}
+#### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-connector}
 
 Connector is the name of the connector this access key was created from
 
@@ -794,7 +794,7 @@ Connector is the name of the connector this access key was created from
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `connectorData` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-connectorData}
+#### `connectorData` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identity-connectorData}
 
 ConnectorData holds data used by the connector for subsequent requests after initial
 authentication, such as access tokens for upstream providers.
@@ -815,7 +815,7 @@ This data is never shared with end users, OAuth clients, or through the API.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `identityRefresh` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identityRefresh}
+### `identityRefresh` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-identityRefresh}
 
 The last time the identity was refreshed
 
@@ -830,7 +830,7 @@ The last time the identity was refreshed
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `oidcProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider}
+### `oidcProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider}
 
 If the token is a refresh token, contains information about it
 
@@ -842,7 +842,7 @@ If the token is a refresh token, contains information about it
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientId` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-clientId}
+#### `clientId` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-clientId}
 
 ClientId the token was generated for
 
@@ -857,7 +857,7 @@ ClientId the token was generated for
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nonce` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-nonce}
+#### `nonce` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-nonce}
 
 Nonce to use
 
@@ -872,7 +872,7 @@ Nonce to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `redirectUri` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-redirectUri}
+#### `redirectUri` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-redirectUri}
 
 RedirectUri to use
 
@@ -887,7 +887,7 @@ RedirectUri to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-scopes}
+#### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcProvider-scopes}
 
 Scopes to use
 
@@ -905,7 +905,7 @@ Scopes to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `parent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parent}
+### `parent` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parent}
 
 DEPRECATED: do not use anymore
 Parent is used to share OIDC and external token information
@@ -928,7 +928,7 @@ an OIDC token.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `oidcLogin` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin}
+### `oidcLogin` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin}
 
 DEPRECATED: Use identity instead
 If available, contains information about the oidc login data for this
@@ -942,7 +942,7 @@ access key
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `idToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-idToken}
+#### `idToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-idToken}
 
 The current id token that was created during login
 
@@ -957,7 +957,7 @@ The current id token that was created during login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `accessToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-accessToken}
+#### `accessToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-accessToken}
 
 The current access token that was created during login
 
@@ -972,7 +972,7 @@ The current access token that was created during login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `refreshToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-refreshToken}
+#### `refreshToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-refreshToken}
 
 The current refresh token that was created during login
 
@@ -987,7 +987,7 @@ The current refresh token that was created during login
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `lastRefresh` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-lastRefresh}
+#### `lastRefresh` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-oidcLogin-lastRefresh}
 
 The last time the id token was refreshed
 
@@ -1008,7 +1008,7 @@ The last time the id token was refreshed
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -1020,7 +1020,7 @@ The last time the id token was refreshed
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `lastActivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-lastActivity}
+### `lastActivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-lastActivity}
 
 The last time this access key was used to access the api
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/clusters/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/clusters/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `clusters` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters}
+## `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters}
 
 Clusters holds all the allowed clusters
 
@@ -53,7 +53,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata}
+### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata}
 
 
 
@@ -481,7 +481,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -496,7 +496,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -512,7 +512,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -549,7 +549,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -580,7 +580,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -607,7 +607,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec}
 
 
 
@@ -904,7 +904,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics}
+#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics}
 
 Metrics holds the cluster's metrics backend configuration
 
@@ -916,7 +916,7 @@ Metrics holds the cluster's metrics backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -931,7 +931,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -1037,7 +1037,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -1052,7 +1052,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage}
 
 
 
@@ -1064,7 +1064,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -1081,7 +1081,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -1102,7 +1102,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `opencost` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost}
+#### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost}
 
 OpenCost holds the cluster's OpenCost backend configuration
 
@@ -1114,7 +1114,7 @@ OpenCost holds the cluster's OpenCost backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -1129,7 +1129,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -1286,7 +1286,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status}
+### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status}
 
 
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/clusters/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/clusters/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters}
+## `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters}
 
 Clusters holds all the allowed clusters
 
@@ -16,7 +16,7 @@ Clusters holds all the allowed clusters
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-kind}
+### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -35,7 +35,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-apiVersion}
+### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -53,7 +53,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata}
+### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata}
 
 
 
@@ -65,7 +65,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -85,7 +85,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-generateName}
+#### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -111,7 +111,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -133,7 +133,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-selfLink}
+#### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -148,7 +148,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-uid}
+#### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -169,7 +169,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-resourceVersion}
+#### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -193,7 +193,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-generation}
+#### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -209,7 +209,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-creationTimestamp}
+#### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -231,7 +231,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-deletionTimestamp}
+#### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -263,7 +263,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-deletionGracePeriodSeconds}
+#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -281,7 +281,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -299,7 +299,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -317,7 +317,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences}
+#### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -395,7 +395,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -410,7 +410,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -435,7 +435,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-finalizers}
+#### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -462,7 +462,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields}
+#### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -481,7 +481,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -496,7 +496,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -512,7 +512,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -530,7 +530,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -549,7 +549,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -565,7 +565,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -580,7 +580,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -607,7 +607,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec}
+### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec}
 
 
 
@@ -619,7 +619,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-displayName}
 
 If specified this name is displayed in the UI instead of the metadata name
 
@@ -634,7 +634,7 @@ If specified this name is displayed in the UI instead of the metadata name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-description}
 
 Description describes a cluster access object
 
@@ -649,7 +649,7 @@ Description describes a cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner}
+#### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner}
 
 Owner holds the owner of this object
 
@@ -661,7 +661,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner-user}
 
 User specifies a Loft user.
 
@@ -676,7 +676,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner-team}
+##### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -694,7 +694,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config}
+#### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config}
 
 Holds a reference to a secret that holds the kube config to access this cluster
 
@@ -706,7 +706,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-secretName}
 
 
 
@@ -721,7 +721,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-secretNamespace}
 
 
 
@@ -736,7 +736,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-config-key}
 
 
 
@@ -754,7 +754,7 @@ Holds a reference to a secret that holds the kube config to access this cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `local` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-local}
+#### `local` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-local}
 
 Local specifies if it is the local cluster that should be connected, when this is specified, config is optional
 
@@ -769,7 +769,7 @@ Local specifies if it is the local cluster that should be connected, when this i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `networkPeer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-networkPeer}
+#### `networkPeer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-networkPeer}
 
 NetworkPeer specifies if the cluster is connected via tailscale, when this is specified, config is optional
 
@@ -784,7 +784,7 @@ NetworkPeer specifies if the cluster is connected via tailscale, when this is sp
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `managementNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-managementNamespace}
+#### `managementNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-managementNamespace}
 
 The namespace where the cluster components will be installed in
 
@@ -799,7 +799,7 @@ The namespace where the cluster components will be installed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `unusable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-unusable}
+#### `unusable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-unusable}
 
 If unusable is true, no spaces or tenant clusters can be scheduled on this cluster.
 
@@ -814,7 +814,7 @@ If unusable is true, no spaces or tenant clusters can be scheduled on this clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access}
 
 Access holds the access rights for users and teams
 
@@ -826,7 +826,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -856,7 +856,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-subresources}
+##### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -871,7 +871,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -886,7 +886,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -904,7 +904,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metrics` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics}
+#### `metrics` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics}
 
 Metrics holds the cluster's metrics backend configuration
 
@@ -916,7 +916,7 @@ Metrics holds the cluster's metrics backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -931,7 +931,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources}
 
 Resources are compute resource required by the metrics backend
 
@@ -943,7 +943,7 @@ Resources are compute resource required by the metrics backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -959,7 +959,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -977,7 +977,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -1013,7 +1013,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -1037,7 +1037,7 @@ only the result of this request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-retention}
+##### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-retention}
 
 Retention is the metrics data retention period. Default is 1y
 
@@ -1052,7 +1052,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage}
+##### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage}
 
 
 
@@ -1064,7 +1064,7 @@ Retention is the metrics data retention period. Default is 1y
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-storageClass}
 
 StorageClass the storage class to use when provisioning the metrics backend's persistent volume
 If set to "-" or "" dynamic provisioning is disabled
@@ -1081,7 +1081,7 @@ If set to undefined or null (the default), the cluster's default storage class i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-metrics-storage-size}
 
 Size the size of the metrics backend's persistent volume
 
@@ -1102,7 +1102,7 @@ Size the size of the metrics backend's persistent volume
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `opencost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost}
+#### `opencost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost}
 
 OpenCost holds the cluster's OpenCost backend configuration
 
@@ -1114,7 +1114,7 @@ OpenCost holds the cluster's OpenCost backend configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-replicas}
 
 Replicas is the number of desired replicas.
 
@@ -1129,7 +1129,7 @@ Replicas is the number of desired replicas.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources}
 
 Resources are compute resource required by the OpenCost backend
 
@@ -1141,7 +1141,7 @@ Resources are compute resource required by the OpenCost backend
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-limits}
 
 Limits describes the maximum amount of compute resources allowed.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -1157,7 +1157,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-requests}
 
 Requests describes the minimum amount of compute resources required.
 If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -1175,7 +1175,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `claims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-claims}
+##### `claims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-claims}
 
 Claims lists the names of resources, defined in spec.resourceClaims,
 that are used by this container.
@@ -1211,7 +1211,7 @@ inside a container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `request` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-claims-request}
+##### `request` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-opencost-resources-claims-request}
 
 Request is the name chosen for a request in the referenced claim.
 If empty, everything from the claim is made available, otherwise
@@ -1238,7 +1238,7 @@ only the result of this request.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `argoCD` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD}
+#### `argoCD` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD}
 
 ArgoCD holds the cluster's argo cd configuration
 
@@ -1250,7 +1250,7 @@ ArgoCD holds the cluster's argo cd configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD-enabled}
 
 Enabled defines if argo cd is enabled
 
@@ -1265,7 +1265,7 @@ Enabled defines if argo cd is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD-connector}
+##### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-spec-argoCD-connector}
 
 Connector specifies the argo cd connector name
 
@@ -1286,7 +1286,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status}
+### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status}
 
 
 
@@ -1298,22 +1298,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `phase` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-phase}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-#### `reason` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-reason}
+#### `phase` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-phase}
 
 
 
@@ -1328,7 +1313,22 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `message` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-message}
+#### `reason` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-reason}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-message}
 
 
 
@@ -1343,7 +1343,7 @@ Connector specifies the argo cd connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-conditions}
+#### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-conditions}
 
 Conditions holds several conditions the cluster might be in
 
@@ -1358,7 +1358,7 @@ Conditions holds several conditions the cluster might be in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `online` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-online}
+#### `online` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#clusters-status-online}
 
 Online is whether the cluster is currently connected to the coordination
 server.

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/importspace/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/importspace/reference.mdx
@@ -16,7 +16,7 @@ SourceSpace is the space to import into this project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-name}
 
 Name of the space to import
 
@@ -31,7 +31,7 @@ Name of the space to import
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-cluster}
+### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-cluster}
 
 Cluster name of the cluster the space is running on
 
@@ -46,7 +46,7 @@ Cluster name of the cluster the space is running on
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `importName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-importName}
+### `importName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-importName}
 
 ImportName is an optional name to use as the spaceinstance name, if not provided the space
 name will be used

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/importspace/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/importspace/reference.mdx
@@ -16,7 +16,7 @@ SourceSpace is the space to import into this project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-name}
 
 Name of the space to import
 
@@ -31,7 +31,7 @@ Name of the space to import
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `cluster` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-cluster}
+### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpace-cluster}
 
 Cluster name of the cluster the space is running on
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/members/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/members/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `teams` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams}
+## `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams}
 
 Teams holds all the teams that have access to the cluster
 
@@ -28,7 +28,7 @@ Info about the user or team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-name}
 
 Name is the kubernetes name of the object
 
@@ -124,7 +124,7 @@ The user subject
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `users` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users}
+## `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users}
 
 Users holds all the users that have access to the cluster
 
@@ -148,7 +148,7 @@ Info about the user or team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-name}
 
 Name is the kubernetes name of the object
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/members/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/members/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams}
+## `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams}
 
 Teams holds all the teams that have access to the cluster
 
@@ -16,7 +16,7 @@ Teams holds all the teams that have access to the cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `info` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info}
+### `info` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info}
 
 Info about the user or team
 
@@ -28,7 +28,7 @@ Info about the user or team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-name}
 
 Name is the kubernetes name of the object
 
@@ -43,7 +43,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-displayName}
 
 The display name shown in the UI
 
@@ -58,7 +58,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-icon}
 
 Icon is the icon of the user / team
 
@@ -73,7 +73,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-username}
 
 The username that is used to login
 
@@ -88,7 +88,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-email}
 
 The users email address
 
@@ -103,7 +103,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-subject}
+#### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#teams-info-subject}
 
 The user subject
 
@@ -124,7 +124,7 @@ The user subject
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users}
+## `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users}
 
 Users holds all the users that have access to the cluster
 
@@ -136,7 +136,7 @@ Users holds all the users that have access to the cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `info` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info}
+### `info` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info}
 
 Info about the user or team
 
@@ -148,7 +148,7 @@ Info about the user or team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-name}
 
 Name is the kubernetes name of the object
 
@@ -163,7 +163,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-displayName}
 
 The display name shown in the UI
 
@@ -178,7 +178,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-icon}
 
 Icon is the icon of the user / team
 
@@ -193,7 +193,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-username}
 
 The username that is used to login
 
@@ -208,7 +208,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-email}
 
 The users email address
 
@@ -223,7 +223,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-subject}
+#### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#users-info-subject}
 
 The user subject
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/migratespaceinstance/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/migratespaceinstance/reference.mdx
@@ -16,7 +16,7 @@ SourceSpaceInstance is the spaceinstance to migrate into this project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-name}
 
 Name of the spaceinstance to migrate
 
@@ -31,7 +31,7 @@ Name of the spaceinstance to migrate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-namespace}
+### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-namespace}
 
 Namespace of the spaceinstance to migrate
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/migratespaceinstance/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/migratespaceinstance/reference.mdx
@@ -16,7 +16,7 @@ SourceSpaceInstance is the spaceinstance to migrate into this project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-name}
 
 Name of the spaceinstance to migrate
 
@@ -31,7 +31,7 @@ Name of the spaceinstance to migrate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceSpaceInstance-namespace}
 
 Namespace of the spaceinstance to migrate
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/migratevirtualclusterinstance/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/migratevirtualclusterinstance/reference.mdx
@@ -16,7 +16,7 @@ SourceVirtualClusterInstance is the tenant cluster instance to migrate into this
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-name}
 
 Name of the tenant cluster instance to migrate
 
@@ -31,7 +31,7 @@ Name of the tenant cluster instance to migrate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-namespace}
+### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-namespace}
 
 Namespace of the tenant cluster instance to migrate
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/migratevirtualclusterinstance/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/migratevirtualclusterinstance/reference.mdx
@@ -16,7 +16,7 @@ SourceVirtualClusterInstance is the tenant cluster instance to migrate into this
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-name}
 
 Name of the tenant cluster instance to migrate
 
@@ -31,7 +31,7 @@ Name of the tenant cluster instance to migrate
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sourceVirtualClusterInstance-namespace}
 
 Namespace of the tenant cluster instance to migrate
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/reference.mdx
@@ -122,7 +122,7 @@ Project holds the quotas for the whole project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-user}
+#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-user}
 
 User holds the quotas per user / team
 
@@ -277,9 +277,12 @@ IsDefault specifies if the template should be used as a default
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `allowedNodeTypes` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">array|null</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedNodeTypes}
+### `allowedNodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">array|null</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedNodeTypes}
 
-
+AllowedNodeTypes restricts which NodeTypes can be referenced by
+NodeClaims in this project. An entry can be an exact name
+("aws.large") or a provider wildcard ("aws.*"). If unset (nil),
+all NodeTypes are allowed; an empty list disallows all NodeTypes.
 
 </summary>
 
@@ -533,7 +536,7 @@ require specific labels or annotations on namespaces.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata}
 
 
 
@@ -879,7 +882,7 @@ will be "*" indicating all source repositories.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinations` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations}
+##### `destinations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations}
 
 Destinations contains list of destinations available for deployment
 
@@ -891,7 +894,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-server}
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-server}
 
 
 
@@ -906,7 +909,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-namespace}
 
 
 
@@ -921,7 +924,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-name}
 
 
 
@@ -953,7 +956,7 @@ configure sane default values.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-name}
 
 Name of the ArgoCD role to attach to the project.
 
@@ -983,7 +986,7 @@ Description to add to the ArgoCD project.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules}
 
 Rules ist a list of policy rules to attach to the role.
 
@@ -1060,7 +1063,7 @@ always be set to "deny".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-groups}
+##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-groups}
 
 Groups is a list of OIDC group names to bind to the role.
 
@@ -1121,7 +1124,7 @@ If not specified or empty, deny all cluster-scope resources.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist-name}
 
 
 
@@ -1227,7 +1230,7 @@ ClusterResourceBlacklist contains a list of blacklisted cluster level resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist-name}
 
 
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes an app
 
@@ -50,7 +50,7 @@ Description describes an app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `quotas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas}
+### `quotas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas}
 
 Quotas define the quotas inside the project
 
@@ -107,7 +107,7 @@ Quotas define the quotas inside the project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-project}
+#### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-project}
 
 Project holds the quotas for the whole project
 
@@ -122,7 +122,7 @@ Project holds the quotas for the whole project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-quotas-user}
 
 User holds the quotas per user / team
 
@@ -140,7 +140,7 @@ User holds the quotas per user / team
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `allowedClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedClusters}
+### `allowedClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedClusters}
 
 AllowedClusters are target clusters that are allowed to target with
 environments.
@@ -153,7 +153,7 @@ environments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedClusters-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedClusters-name}
 
 Name is the name of the cluster that is allowed to create an environment in.
 
@@ -171,7 +171,7 @@ Name is the name of the cluster that is allowed to create an environment in.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `allowedRunners` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedRunners}
+### `allowedRunners` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedRunners}
 
 AllowedRunners are target runners that are allowed to target with
 
@@ -183,7 +183,7 @@ AllowedRunners are target runners that are allowed to target with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedRunners-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedRunners-name}
 
 Name is the name of the runner that is allowed to create an environment in.
 
@@ -201,7 +201,7 @@ Name is the name of the runner that is allowed to create an environment in.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `allowedTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates}
+### `allowedTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates}
 
 AllowedTemplates are the templates that are allowed to use in this
 project.
@@ -214,7 +214,7 @@ project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-kind}
 
 Kind of the template that is allowed. Currently only supports DevPodWorkspaceTemplate, VirtualClusterTemplate & SpaceTemplate
 
@@ -229,7 +229,7 @@ Kind of the template that is allowed. Currently only supports DevPodWorkspaceTem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-group}
+#### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-group}
 
 Group of the template that is allowed. Currently only supports storage.loft.sh
 
@@ -244,7 +244,7 @@ Group of the template that is allowed. Currently only supports storage.loft.sh
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-name}
 
 Name of the template
 
@@ -259,7 +259,7 @@ Name of the template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `isDefault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-isDefault}
+#### `isDefault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedTemplates-isDefault}
 
 IsDefault specifies if the template should be used as a default
 
@@ -277,7 +277,7 @@ IsDefault specifies if the template should be used as a default
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `allowedNodeTypes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">array|null</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedNodeTypes}
+### `allowedNodeTypes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">array|null</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-allowedNodeTypes}
 
 AllowedNodeTypes restricts which NodeTypes can be referenced by
 NodeClaims in this project. An entry can be an exact name
@@ -295,7 +295,7 @@ all NodeTypes are allowed; an empty list disallows all NodeTypes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `requireTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requireTemplate}
+### `requireTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requireTemplate}
 
 RequireTemplate configures if a template is required for instance creation.
 
@@ -307,7 +307,7 @@ RequireTemplate configures if a template is required for instance creation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requireTemplate-disabled}
+#### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requireTemplate-disabled}
 
 If true, all users within the project will be allowed to create a new instance without a template.
 By default, only admins are allowed to create a new instance without a template.
@@ -326,7 +326,7 @@ By default, only admins are allowed to create a new instance without a template.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `requirePreset` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirePreset}
+### `requirePreset` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirePreset}
 
 RequirePreset configures if a preset is required for instance creation.
 
@@ -338,7 +338,7 @@ RequirePreset configures if a preset is required for instance creation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirePreset-disabled}
+#### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirePreset-disabled}
 
 If true, all users within the project will not be allowed to create a new instance without a preset.
 By default, all users are allowed to create a new instance without a preset.
@@ -357,7 +357,7 @@ By default, all users are allowed to create a new instance without a preset.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `members` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members}
+### `members` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members}
 
 Members are the users and teams that are part of this project
 
@@ -369,7 +369,7 @@ Members are the users and teams that are part of this project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-kind}
 
 Kind is the kind of the member. Currently either User or Team
 
@@ -384,7 +384,7 @@ Kind is the kind of the member. Currently either User or Team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-group}
+#### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-group}
 
 Group of the member. Currently only supports storage.loft.sh
 
@@ -399,7 +399,7 @@ Group of the member. Currently only supports storage.loft.sh
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-members-name}
 
 Name of the member
 
@@ -432,7 +432,7 @@ ClusterRole is the assigned role for the above member
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -444,7 +444,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -474,7 +474,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -489,7 +489,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -504,7 +504,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -522,7 +522,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `namespaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate}
+### `namespaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate}
 
 NamespaceTemplate defines metadata that should be applied to the project's namespace on creation.
 This is useful for environments where admission controllers (e.g., Kyverno)
@@ -536,7 +536,7 @@ require specific labels or annotations on namespaces.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata}
 
 
 
@@ -548,7 +548,7 @@ require specific labels or annotations on namespaces.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -563,7 +563,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -584,7 +584,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `namespacePattern` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern}
+### `namespacePattern` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern}
 
 NamespacePattern specifies template patterns to use for creating each space or tenant cluster's namespace
 
@@ -596,7 +596,7 @@ NamespacePattern specifies template patterns to use for creating each space or t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `space` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern-space}
+#### `space` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern-space}
 
 Space holds the namespace pattern to use for space instances
 
@@ -611,7 +611,7 @@ Space holds the namespace pattern to use for space instances
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern-virtualCluster}
+#### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-namespacePattern-virtualCluster}
 
 VirtualCluster holds the namespace pattern to use for tenant cluster instances
 
@@ -629,7 +629,7 @@ VirtualCluster holds the namespace pattern to use for tenant cluster instances
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `argoCD` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD}
+### `argoCD` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD}
 
 ArgoIntegration holds information about ArgoCD Integration
 
@@ -641,7 +641,7 @@ ArgoIntegration holds information about ArgoCD Integration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-enabled}
 
 Enabled indicates if the ArgoCD Integration is enabled for the project -- this knob only
 enables the syncing of virtualclusters, but does not enable SSO integration or project
@@ -658,7 +658,7 @@ creation (see subsequent spec sections!).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-cluster}
+#### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-cluster}
 
 Cluster defines the name of the cluster that ArgoCD is deployed into -- if not provided this
 will default to 'loft-cluster'.
@@ -674,7 +674,7 @@ will default to 'loft-cluster'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualClusterInstance` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-virtualClusterInstance}
+#### `virtualClusterInstance` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-virtualClusterInstance}
 
 VirtualClusterInstance defines the name of *tenant cluster* (instance) that ArgoCD is
 deployed into. If provided, Cluster will be ignored and Loft will assume that ArgoCD is
@@ -691,7 +691,7 @@ running in the specified tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-namespace}
 
 Namespace defines the namespace in which ArgoCD is running in the cluster.
 
@@ -706,7 +706,7 @@ Namespace defines the namespace in which ArgoCD is running in the cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sso` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso}
+#### `sso` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso}
 
 SSO defines single-sign-on related values for the ArgoCD Integration. Enabling SSO will allow
 users to authenticate to ArgoCD via Loft.
@@ -719,7 +719,7 @@ users to authenticate to ArgoCD via Loft.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-enabled}
 
 Enabled indicates if the ArgoCD SSO Integration is enabled for this project. Enabling this
 will cause Loft to configure SSO authentication via Loft in ArgoCD. If Projects are *not*
@@ -737,7 +737,7 @@ enabled, all users associated with this Project will be assigned either the 'rea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-host}
+##### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-host}
 
 Host defines the ArgoCD host address that will be used for OIDC authentication between loft
 and ArgoCD. If not specified OIDC integration will be skipped, but vclusters/spaces will
@@ -754,7 +754,7 @@ still be synced to ArgoCD.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `assignedRoles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-assignedRoles}
+##### `assignedRoles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-sso-assignedRoles}
 
 AssignedRoles is a list of roles to assign for users who authenticate via Loft -- by default
 this will be the `read-only` role. If any roles are provided this will override the default
@@ -774,7 +774,7 @@ setting.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project}
+#### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project}
 
 Project defines project related values for the ArgoCD Integration. Enabling Project
 integration will cause Loft to generate and manage an ArgoCD appProject that corresponds to
@@ -788,7 +788,7 @@ the Loft Project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-enabled}
 
 Enabled indicates if the ArgoCD Project Integration is enabled for this project. Enabling
 this will cause Loft to create an appProject in ArgoCD that is associated with the Loft
@@ -806,7 +806,7 @@ set in the SSO integration spec.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata}
 
 Metadata defines additional metadata to attach to the loft created project in ArgoCD.
 
@@ -818,7 +818,7 @@ Metadata defines additional metadata to attach to the loft created project in Ar
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraAnnotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-extraAnnotations}
+##### `extraAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-extraAnnotations}
 
 ExtraAnnotations are optional annotations that can be attached to the project in ArgoCD.
 
@@ -833,7 +833,7 @@ ExtraAnnotations are optional annotations that can be attached to the project in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-extraLabels}
+##### `extraLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-extraLabels}
 
 ExtraLabels are optional labels that can be attached to the project in ArgoCD.
 
@@ -848,7 +848,7 @@ ExtraLabels are optional labels that can be attached to the project in ArgoCD.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-metadata-description}
 
 Description to add to the ArgoCD project.
 
@@ -866,7 +866,7 @@ Description to add to the ArgoCD project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sourceRepos` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-sourceRepos}
+##### `sourceRepos` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-sourceRepos}
 
 SourceRepos is a list of source repositories to attach/allow on the project, if not specified
 will be "*" indicating all source repositories.
@@ -882,7 +882,7 @@ will be "*" indicating all source repositories.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations}
+##### `destinations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations}
 
 Destinations contains list of destinations available for deployment
 
@@ -894,7 +894,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-server}
 
 
 
@@ -909,7 +909,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-namespace}
 
 
 
@@ -924,7 +924,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-destinations-name}
 
 
 
@@ -942,7 +942,7 @@ Destinations contains list of destinations available for deployment
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `roles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles}
+##### `roles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles}
 
 Roles is a list of roles that should be attached to the ArgoCD project. If roles are provided
 no loft default roles will be set. If no roles are provided *and* SSO is enabled, loft will
@@ -956,7 +956,7 @@ configure sane default values.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-name}
 
 Name of the ArgoCD role to attach to the project.
 
@@ -971,7 +971,7 @@ Name of the ArgoCD role to attach to the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-description}
 
 Description to add to the ArgoCD project.
 
@@ -986,7 +986,7 @@ Description to add to the ArgoCD project.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules}
 
 Rules ist a list of policy rules to attach to the role.
 
@@ -998,7 +998,7 @@ Rules ist a list of policy rules to attach to the role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `action` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-action}
+##### `action` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-action}
 
 Action is one of "*", "get", "create", "update", "delete", "sync", or "override".
 
@@ -1013,7 +1013,7 @@ Action is one of "*", "get", "create", "update", "delete", "sync", or "override"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `application` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-application}
+##### `application` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-application}
 
 Application is the ArgoCD project/repository to apply the rule to.
 DEPRECATED: Wasn't used. Kind provides a more flexible way to specify the resource type.
@@ -1029,7 +1029,7 @@ DEPRECATED: Wasn't used. Kind provides a more flexible way to specify the resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-kind}
+##### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-kind}
 
 Kind is the kind to apply the rule to
 
@@ -1044,7 +1044,7 @@ Kind is the kind to apply the rule to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `permission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-permission}
+##### `permission` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-rules-permission}
 
 Allow applies the "allow" permission to the rule, if allow is not set, the permission will
 always be set to "deny".
@@ -1063,7 +1063,7 @@ always be set to "deny".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-groups}
+##### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-roles-groups}
 
 Groups is a list of OIDC group names to bind to the role.
 
@@ -1081,7 +1081,7 @@ Groups is a list of OIDC group names to bind to the role.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterResourceWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist}
+##### `clusterResourceWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist}
 
 ClusterResourceWhitelist contains a list of whitelisted cluster level resources
 If not specified or empty, deny all cluster-scope resources.
@@ -1124,7 +1124,7 @@ If not specified or empty, deny all cluster-scope resources.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceWhitelist-name}
 
 
 
@@ -1142,7 +1142,7 @@ If not specified or empty, deny all cluster-scope resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceResourceWhitelist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-namespaceResourceWhitelist}
+##### `namespaceResourceWhitelist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-namespaceResourceWhitelist}
 
 NamespaceResourceWhitelist contains a list of whitelisted namespace level resources
 If not specified or empty, allow all namespace-scope resources.
@@ -1188,7 +1188,7 @@ If not specified or empty, allow all namespace-scope resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterResourceBlacklist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist}
+##### `clusterResourceBlacklist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist}
 
 ClusterResourceBlacklist contains a list of blacklisted cluster level resources
 
@@ -1230,7 +1230,7 @@ ClusterResourceBlacklist contains a list of blacklisted cluster level resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-clusterResourceBlacklist-name}
 
 
 
@@ -1248,7 +1248,7 @@ ClusterResourceBlacklist contains a list of blacklisted cluster level resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceResourceBlacklist` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-namespaceResourceBlacklist}
+##### `namespaceResourceBlacklist` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-namespaceResourceBlacklist}
 
 NamespaceResourceBlacklist contains a list of blacklisted namespace level resources
 
@@ -1293,7 +1293,7 @@ NamespaceResourceBlacklist contains a list of blacklisted namespace level resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sourceNamespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-sourceNamespaces}
+##### `sourceNamespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-argoCD-project-sourceNamespaces}
 
 SourceNamespaces defines the namespaces application resources are allowed to be created in
 
@@ -1314,7 +1314,7 @@ SourceNamespaces defines the namespaces application resources are allowed to be 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vault` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault}
+### `vault` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault}
 
 VaultIntegration holds information about Vault Integration
 
@@ -1326,7 +1326,7 @@ VaultIntegration holds information about Vault Integration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-enabled}
 
 Enabled indicates if the Vault Integration is enabled for the project -- this knob only
 enables the syncing of secrets to or from Vault, but does not setup Kubernetes authentication
@@ -1343,7 +1343,7 @@ methods or Kubernetes secrets engines for vclusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `address` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-address}
+#### `address` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-address}
 
 Address defines the address of the Vault instance to use for this project.
 Will default to the `VAULT_ADDR` environment variable if not provided.
@@ -1359,7 +1359,7 @@ Will default to the `VAULT_ADDR` environment variable if not provided.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `skipTLSVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-skipTLSVerify}
+#### `skipTLSVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-skipTLSVerify}
 
 SkipTLSVerify defines if TLS verification should be skipped when connecting to Vault.
 
@@ -1374,7 +1374,7 @@ SkipTLSVerify defines if TLS verification should be skipped when connecting to V
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-namespace}
 
 Namespace defines the namespace to use when storing secrets in Vault.
 
@@ -1389,7 +1389,7 @@ Namespace defines the namespace to use when storing secrets in Vault.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth}
+#### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth}
 
 Auth defines the authentication method to use for this project.
 
@@ -1401,7 +1401,7 @@ Auth defines the authentication method to use for this project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-token}
+##### `token` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-token}
 
 Token defines the token to use for authentication.
 
@@ -1416,7 +1416,7 @@ Token defines the token to use for authentication.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tokenSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef}
+##### `tokenSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef}
 
 TokenSecretRef defines the Kubernetes secret to use for token authentication.
 Will be used if `token` is not provided.
@@ -1431,7 +1431,7 @@ Secret data should contain the `token` key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef-name}
 
 Name of the referent.
 This field is effectively required, but due to backwards compatibility is
@@ -1466,7 +1466,7 @@ The key of the secret to select from.  Must be a valid secret key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef-optional}
+##### `optional` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-auth-tokenSecretRef-optional}
 
 Specify whether the Secret or its key must be defined
 
@@ -1487,7 +1487,7 @@ Specify whether the Secret or its key must be defined
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-syncInterval}
+#### `syncInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vault-syncInterval}
 
 SyncInterval defines the interval at which to sync secrets from Vault.
 Defaults to `1m.`
@@ -1510,7 +1510,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -1522,7 +1522,7 @@ See https://pkg.go.dev/time#ParseDuration for supported formats.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `quotas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas}
+### `quotas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas}
 
 Quotas holds the quota status
 
@@ -1534,7 +1534,7 @@ Quotas holds the quota status
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project}
+#### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project}
 
 Project is the quota status for the whole project
 
@@ -1546,7 +1546,7 @@ Project is the quota status for the whole project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-limit}
+##### `limit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-limit}
 
 Limit is the amount limited, copied from spec.quotas.project
 
@@ -1561,7 +1561,7 @@ Limit is the amount limited, copied from spec.quotas.project
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `used` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-used}
+##### `used` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-used}
 
 Used is the amount currently used across all clusters
 
@@ -1576,7 +1576,7 @@ Used is the amount currently used across all clusters
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-clusters}
+##### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-clusters}
 
 Clusters holds the used amount per cluster. Maps cluster name to used resources
 
@@ -1588,7 +1588,7 @@ Clusters holds the used amount per cluster. Maps cluster name to used resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `used` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-clusters-used}
+##### `used` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-project-clusters-used}
 
 Used is the amount currently used. Maps resource name, such as pods, to their
 used amount.
@@ -1610,7 +1610,7 @@ used amount.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user}
 
 User is the quota status for each user / team. An example status
 could look like this:
@@ -1643,7 +1643,7 @@ status:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limit` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-limit}
+##### `limit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-limit}
 
 Limit is the amount limited per user / team
 
@@ -1658,7 +1658,7 @@ Limit is the amount limited per user / team
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `used` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used}
+##### `used` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used}
 
 Used is the used amount per user / team
 
@@ -1670,7 +1670,7 @@ Used is the used amount per user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used-users}
 
 Users is a mapping of users to used resources
 
@@ -1685,7 +1685,7 @@ Users is a mapping of users to used resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-used-teams}
 
 Teams is a mapping of teams to used resources
 
@@ -1703,7 +1703,7 @@ Teams is a mapping of teams to used resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters}
+##### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters}
 
 Clusters holds the used amount per cluster. Maps cluster name to used resources
 
@@ -1715,7 +1715,7 @@ Clusters holds the used amount per cluster. Maps cluster name to used resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters-users}
 
 Users is a mapping of users to used resources
 
@@ -1730,7 +1730,7 @@ Users is a mapping of users to used resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-quotas-user-clusters-teams}
 
 Teams is a mapping of teams to used resources
 
@@ -1754,7 +1754,7 @@ Teams is a mapping of teams to used resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions holds several conditions the project might be in
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/spec/vault.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/spec/vault.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#enabled}
+## `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#enabled}
 
 Enabled indicates if the Vault Integration is enabled for the project -- this knob only
 enables the syncing of secrets to or from Vault, but does not setup Kubernetes authentication
@@ -21,7 +21,7 @@ methods or Kubernetes secrets engines for vclusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `address` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#address}
+## `address` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#address}
 
 Address defines the address of the Vault instance to use for this project.
 Will default to the `VAULT_ADDR` environment variable if not provided.
@@ -37,7 +37,7 @@ Will default to the `VAULT_ADDR` environment variable if not provided.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `skipTLSVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#skipTLSVerify}
+## `skipTLSVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#skipTLSVerify}
 
 SkipTLSVerify defines if TLS verification should be skipped when connecting to Vault.
 
@@ -52,7 +52,7 @@ SkipTLSVerify defines if TLS verification should be skipped when connecting to V
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#namespace}
+## `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#namespace}
 
 Namespace defines the namespace to use when storing secrets in Vault.
 
@@ -67,7 +67,7 @@ Namespace defines the namespace to use when storing secrets in Vault.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth}
+## `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth}
 
 Auth defines the authentication method to use for this project.
 
@@ -79,7 +79,7 @@ Auth defines the authentication method to use for this project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-token}
+### `token` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-token}
 
 Token defines the token to use for authentication.
 
@@ -94,7 +94,7 @@ Token defines the token to use for authentication.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `tokenSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef}
+### `tokenSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef}
 
 TokenSecretRef defines the Kubernetes secret to use for token authentication.
 Will be used if `token` is not provided.
@@ -109,7 +109,7 @@ Secret data should contain the `token` key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef-name}
 
 Name of the referent.
 This field is effectively required, but due to backwards compatibility is
@@ -144,7 +144,7 @@ The key of the secret to select from.  Must be a valid secret key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef-optional}
+#### `optional` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#auth-tokenSecretRef-optional}
 
 Specify whether the Secret or its key must be defined
 
@@ -165,7 +165,7 @@ Specify whether the Secret or its key must be defined
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `syncInterval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncInterval}
+## `syncInterval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncInterval}
 
 SyncInterval defines the interval at which to sync secrets from Vault.
 Defaults to `1m.`

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/templates/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/templates/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultVirtualClusterTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultVirtualClusterTemplate}
+## `defaultVirtualClusterTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultVirtualClusterTemplate}
 
 DefaultVirtualClusterTemplate is the default template for the project
 
@@ -19,7 +19,7 @@ DefaultVirtualClusterTemplate is the default template for the project
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualClusterTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates}
+## `virtualClusterTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates}
 
 VirtualClusterTemplates holds all the allowed tenant cluster templates
 
@@ -31,7 +31,7 @@ VirtualClusterTemplates holds all the allowed tenant cluster templates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-kind}
+### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -50,7 +50,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-apiVersion}
+### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -68,7 +68,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata}
+### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata}
 
 
 
@@ -80,7 +80,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -100,7 +100,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-generateName}
+#### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -126,7 +126,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -148,7 +148,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-selfLink}
+#### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -163,7 +163,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-uid}
+#### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -184,7 +184,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-resourceVersion}
+#### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -208,7 +208,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-generation}
+#### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -224,7 +224,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-creationTimestamp}
+#### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -246,7 +246,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-deletionTimestamp}
+#### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -278,7 +278,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-deletionGracePeriodSeconds}
+#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -296,7 +296,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -314,7 +314,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -332,7 +332,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences}
+#### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -410,7 +410,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -425,7 +425,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -450,7 +450,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-finalizers}
+#### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -477,7 +477,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields}
+#### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -496,7 +496,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -511,7 +511,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -527,7 +527,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -545,7 +545,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -564,7 +564,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -580,7 +580,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -595,7 +595,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -622,7 +622,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec}
+### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec}
 
 
 
@@ -634,7 +634,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-displayName}
 
 DisplayName is the name that is shown in the UI
 
@@ -649,7 +649,7 @@ DisplayName is the name that is shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-description}
 
 Description describes the tenant cluster template
 
@@ -664,7 +664,7 @@ Description describes the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner}
+#### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner}
 
 Owner holds the owner of this object
 
@@ -676,7 +676,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner-user}
 
 User specifies a Loft user.
 
@@ -691,7 +691,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner-team}
+##### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -709,7 +709,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template}
+#### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template}
 
 Template holds the tenant cluster template
 
@@ -721,7 +721,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata}
 
 
 
@@ -733,7 +733,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -748,7 +748,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -766,7 +766,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -778,7 +778,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata}
 
 
 
@@ -790,7 +790,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -805,7 +805,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -826,7 +826,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -838,7 +838,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-name}
 
 Name of the target app
 
@@ -853,7 +853,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -869,7 +869,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -884,7 +884,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-version}
 
 Version of the app
 
@@ -899,7 +899,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -914,7 +914,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -932,7 +932,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -944,7 +944,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -959,7 +959,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -974,7 +974,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -989,7 +989,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -1004,7 +1004,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1016,7 +1016,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1028,7 +1028,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1043,7 +1043,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1058,7 +1058,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1079,7 +1079,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -1094,7 +1094,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1106,7 +1106,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1118,7 +1118,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1133,7 +1133,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1148,7 +1148,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1169,7 +1169,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1184,7 +1184,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1199,7 +1199,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1214,7 +1214,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1229,7 +1229,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1244,7 +1244,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1262,7 +1262,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -1277,7 +1277,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -1289,7 +1289,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -1305,7 +1305,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -1319,7 +1319,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -1334,7 +1334,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -1349,7 +1349,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -1370,7 +1370,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-pro}
+##### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -1382,7 +1382,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -1400,7 +1400,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease}
+##### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -1412,7 +1412,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -1424,7 +1424,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -1439,7 +1439,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -1454,7 +1454,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -1469,7 +1469,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -1484,7 +1484,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -1499,7 +1499,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -1517,7 +1517,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-helmRelease-values}
 
 the values for the given chart
 
@@ -1535,7 +1535,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint}
+##### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -1548,7 +1548,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -1560,7 +1560,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -1583,7 +1583,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-forwardToken}
+##### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -1599,7 +1599,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate}
+##### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -1611,7 +1611,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata}
 
 
 
@@ -1623,7 +1623,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1638,7 +1638,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1656,7 +1656,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -1671,7 +1671,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1683,7 +1683,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -1698,7 +1698,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -1713,7 +1713,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -1728,7 +1728,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -1743,7 +1743,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1755,7 +1755,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1767,7 +1767,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1782,7 +1782,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1797,7 +1797,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1818,7 +1818,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -1833,7 +1833,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1845,7 +1845,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1857,7 +1857,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1872,7 +1872,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1887,7 +1887,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1908,7 +1908,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1923,7 +1923,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1938,7 +1938,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1953,7 +1953,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1968,7 +1968,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1983,7 +1983,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -2001,7 +2001,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -2013,7 +2013,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -2028,7 +2028,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -2044,7 +2044,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -2059,7 +2059,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -2074,7 +2074,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -2089,7 +2089,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -2113,7 +2113,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -2125,7 +2125,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -2140,7 +2140,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -2155,7 +2155,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -2170,7 +2170,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -2186,7 +2186,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -2201,7 +2201,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -2216,7 +2216,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -2231,7 +2231,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -2246,7 +2246,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -2261,7 +2261,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -2276,7 +2276,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -2291,7 +2291,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -2306,7 +2306,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -2324,7 +2324,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `versions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions}
+#### `versions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions}
 
 Versions are different versions of the template that can be referenced as well
 
@@ -2336,7 +2336,7 @@ Versions are different versions of the template that can be referenced as well
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template}
+##### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template}
 
 Template holds the space template
 
@@ -2348,7 +2348,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata}
 
 
 
@@ -2360,7 +2360,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -2375,7 +2375,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -2393,7 +2393,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -2405,7 +2405,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -2417,7 +2417,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -2432,7 +2432,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -2453,7 +2453,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -2465,7 +2465,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-name}
 
 Name of the target app
 
@@ -2480,7 +2480,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -2496,7 +2496,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -2511,7 +2511,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-version}
 
 Version of the app
 
@@ -2526,7 +2526,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -2541,7 +2541,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -2559,7 +2559,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -2571,7 +2571,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -2586,7 +2586,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -2601,7 +2601,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -2616,7 +2616,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-username}
 
 The username that is required for this repository
 
@@ -2631,7 +2631,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -2643,7 +2643,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2655,7 +2655,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2670,7 +2670,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2685,7 +2685,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2706,7 +2706,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-password}
 
 The password that is required for this repository
 
@@ -2721,7 +2721,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -2733,7 +2733,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2745,7 +2745,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2760,7 +2760,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2775,7 +2775,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2796,7 +2796,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -2811,7 +2811,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -2826,7 +2826,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -2841,7 +2841,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -2856,7 +2856,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -2871,7 +2871,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -2889,7 +2889,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -2904,7 +2904,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -2916,7 +2916,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -2932,7 +2932,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -2946,7 +2946,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -2961,7 +2961,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -2976,7 +2976,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -2997,7 +2997,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-pro}
+##### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -3009,7 +3009,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -3027,7 +3027,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease}
+##### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -3039,7 +3039,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -3051,7 +3051,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -3066,7 +3066,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -3081,7 +3081,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -3096,7 +3096,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -3111,7 +3111,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -3126,7 +3126,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -3144,7 +3144,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-helmRelease-values}
 
 the values for the given chart
 
@@ -3162,7 +3162,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint}
+##### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -3175,7 +3175,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -3187,7 +3187,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -3210,7 +3210,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-forwardToken}
+##### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -3226,7 +3226,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate}
+##### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -3238,7 +3238,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata}
 
 
 
@@ -3250,7 +3250,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -3265,7 +3265,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -3283,7 +3283,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -3298,7 +3298,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -3310,7 +3310,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -3325,7 +3325,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -3340,7 +3340,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -3355,7 +3355,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -3370,7 +3370,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -3382,7 +3382,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -3394,7 +3394,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -3409,7 +3409,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -3424,7 +3424,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -3445,7 +3445,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -3460,7 +3460,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -3472,7 +3472,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -3484,7 +3484,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -3499,7 +3499,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -3514,7 +3514,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -3535,7 +3535,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -3550,7 +3550,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -3565,7 +3565,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -3580,7 +3580,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -3595,7 +3595,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -3610,7 +3610,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -3628,7 +3628,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -3640,7 +3640,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -3655,7 +3655,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -3671,7 +3671,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -3686,7 +3686,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -3701,7 +3701,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -3716,7 +3716,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -3740,7 +3740,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -3752,7 +3752,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -3767,7 +3767,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -3782,7 +3782,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -3797,7 +3797,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -3813,7 +3813,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -3828,7 +3828,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -3843,7 +3843,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -3858,7 +3858,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -3873,7 +3873,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -3888,7 +3888,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -3903,7 +3903,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -3918,7 +3918,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -3933,7 +3933,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -3951,7 +3951,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-version}
 
 Version is the version. Needs to be in X.X.X format.
 
@@ -3969,7 +3969,7 @@ Version is the version. Needs to be in X.X.X format.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access}
 
 Access holds the access rights for users and teams
 
@@ -3981,7 +3981,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -4011,7 +4011,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-subresources}
+##### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -4026,7 +4026,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -4041,7 +4041,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -4059,7 +4059,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaceTemplateRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-spaceTemplateRef}
+#### `spaceTemplateRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-spaceTemplateRef}
 
 DEPRECATED: SpaceTemplate to use to create the tenant cluster space if it does not exist
 
@@ -4071,7 +4071,7 @@ DEPRECATED: SpaceTemplate to use to create the tenant cluster space if it does n
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-spaceTemplateRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-spaceTemplateRef-name}
 
 Name of the space template
 
@@ -4092,7 +4092,7 @@ Name of the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status}
+### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status}
 
 
 
@@ -4104,7 +4104,7 @@ Name of the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps}
 
 
 
@@ -4116,7 +4116,7 @@ Name of the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-name}
 
 Name is the kubernetes name of the object
 
@@ -4131,7 +4131,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-displayName}
 
 The display name shown in the UI
 
@@ -4146,7 +4146,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-icon}
+##### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-icon}
 
 Icon is the icon of the user / team
 
@@ -4161,7 +4161,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-username}
 
 The username that is used to login
 
@@ -4176,7 +4176,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-email}
+##### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-email}
 
 The users email address
 
@@ -4191,7 +4191,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-subject}
+##### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-subject}
 
 The user subject
 
@@ -4215,7 +4215,7 @@ The user subject
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultSpaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultSpaceTemplate}
+## `defaultSpaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultSpaceTemplate}
 
 DefaultSpaceTemplate
 
@@ -4230,7 +4230,7 @@ DefaultSpaceTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spaceTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates}
+## `spaceTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates}
 
 SpaceTemplates holds all the allowed space templates
 
@@ -4242,7 +4242,7 @@ SpaceTemplates holds all the allowed space templates
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-kind}
+### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -4261,7 +4261,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-apiVersion}
+### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -4279,7 +4279,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata}
+### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata}
 
 
 
@@ -4291,7 +4291,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -4311,7 +4311,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generateName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-generateName}
+#### `generateName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-generateName}
 
 GenerateName is an optional prefix, used by the server, to generate a unique
 name ONLY IF the Name field has not been provided.
@@ -4337,7 +4337,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-namespace}
 
 Namespace defines the space within which each name must be unique. An empty namespace is
 equivalent to the "default" namespace, but "default" is the canonical representation.
@@ -4359,7 +4359,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `selfLink` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-selfLink}
+#### `selfLink` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-selfLink}
 
 Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
 
@@ -4374,7 +4374,7 @@ Deprecated: selfLink is a legacy read-only field that is no longer populated by 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-uid}
+#### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-uid}
 
 UID is the unique in time and space value for this object. It is typically generated by
 the server on successful creation of a resource and is not allowed to change on PUT
@@ -4395,7 +4395,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resourceVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-resourceVersion}
+#### `resourceVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-resourceVersion}
 
 An opaque value that represents the internal version of this object that can
 be used by clients to determine when objects have changed. May be used for optimistic
@@ -4419,7 +4419,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `generation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-generation}
+#### `generation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-generation}
 
 A sequence number representing a specific generation of the desired state.
 Populated by the system. Read-only.
@@ -4435,7 +4435,7 @@ Populated by the system. Read-only.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `creationTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-creationTimestamp}
+#### `creationTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-creationTimestamp}
 
 CreationTimestamp is a timestamp representing the server time when this object was
 created. It is not guaranteed to be set in happens-before order across separate operations.
@@ -4457,7 +4457,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deletionTimestamp` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-deletionTimestamp}
+#### `deletionTimestamp` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-deletionTimestamp}
 
 DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 field is set by the server when a graceful deletion is requested by the user, and is not
@@ -4489,7 +4489,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-deletionGracePeriodSeconds}
+#### `deletionGracePeriodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-deletionGracePeriodSeconds}
 
 Number of seconds allowed for this object to gracefully terminate before
 it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -4507,7 +4507,7 @@ Read-only.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -4525,7 +4525,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/lab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata. They are not
@@ -4543,7 +4543,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/ann
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ownerReferences` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences}
+#### `ownerReferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences}
 
 List of objects depended by this object. If ALL objects in the list have
 been deleted, this object will be garbage collected. If this object is managed by a controller,
@@ -4621,7 +4621,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `controller` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences-controller}
+##### `controller` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences-controller}
 
 If true, this reference points to the managing controller.
 
@@ -4636,7 +4636,7 @@ If true, this reference points to the managing controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blockOwnerDeletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences-blockOwnerDeletion}
+##### `blockOwnerDeletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-ownerReferences-blockOwnerDeletion}
 
 If true, AND if the owner has the "foregroundDeletion" finalizer, then
 the owner cannot be deleted from the key-value store until this
@@ -4661,7 +4661,7 @@ otherwise 422 (Unprocessable Entity) will be returned.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `finalizers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-finalizers}
+#### `finalizers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-finalizers}
 
 Must be empty before the object is deleted from the registry. Each entry
 is an identifier for the responsible component that will remove the entry
@@ -4688,7 +4688,7 @@ are not vulnerable to ordering changes in the list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `managedFields` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields}
+#### `managedFields` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields}
 
 ManagedFields maps workflow-id and version to the set of fields
 that are managed by that workflow. This is mostly for internal
@@ -4707,7 +4707,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -4722,7 +4722,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -4738,7 +4738,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -4756,7 +4756,7 @@ set because it cannot be automatically converted.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `time` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-time}
+##### `time` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-time}
 
 Time is the timestamp of when the ManagedFields entry was added. The
 timestamp will also be updated if a field is added, the manager
@@ -4775,7 +4775,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -4791,7 +4791,7 @@ There is currently only one possible value: "FieldsV1"
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fieldsV1` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsV1}
+##### `fieldsV1` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsV1}
 
 FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 
@@ -4806,7 +4806,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -4833,7 +4833,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec}
+### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec}
 
 
 
@@ -4845,7 +4845,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-displayName}
 
 DisplayName is the name that is shown in the UI
 
@@ -4860,7 +4860,7 @@ DisplayName is the name that is shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-description}
 
 Description describes the space template
 
@@ -4875,7 +4875,7 @@ Description describes the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner}
+#### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner}
 
 Owner holds the owner of this object
 
@@ -4887,7 +4887,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner-user}
+##### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner-user}
 
 User specifies a Loft user.
 
@@ -4902,7 +4902,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner-team}
+##### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -4920,7 +4920,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template}
+#### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template}
 
 Template holds the space template
 
@@ -4932,7 +4932,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata}
 
 
 
@@ -4944,7 +4944,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -4959,7 +4959,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -4977,7 +4977,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -4989,7 +4989,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata}
 
 
 
@@ -5001,7 +5001,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -5016,7 +5016,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -5037,7 +5037,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -5052,7 +5052,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -5064,7 +5064,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -5079,7 +5079,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -5094,7 +5094,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -5109,7 +5109,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -5124,7 +5124,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -5136,7 +5136,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -5148,7 +5148,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -5163,7 +5163,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -5178,7 +5178,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -5199,7 +5199,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -5214,7 +5214,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -5226,7 +5226,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -5238,7 +5238,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -5253,7 +5253,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -5268,7 +5268,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -5289,7 +5289,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -5304,7 +5304,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -5319,7 +5319,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -5334,7 +5334,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -5349,7 +5349,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -5364,7 +5364,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -5382,7 +5382,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -5394,7 +5394,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-name}
 
 Name of the target app
 
@@ -5409,7 +5409,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -5425,7 +5425,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -5440,7 +5440,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-version}
 
 Version of the app
 
@@ -5455,7 +5455,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -5470,7 +5470,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -5488,7 +5488,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access}
 
 The space access
 
@@ -5500,7 +5500,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -5516,7 +5516,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -5530,7 +5530,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -5545,7 +5545,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -5560,7 +5560,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -5584,7 +5584,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -5596,7 +5596,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -5611,7 +5611,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -5626,7 +5626,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -5641,7 +5641,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -5657,7 +5657,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -5672,7 +5672,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -5687,7 +5687,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -5702,7 +5702,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -5717,7 +5717,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -5732,7 +5732,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -5747,7 +5747,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -5762,7 +5762,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -5777,7 +5777,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -5795,7 +5795,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `versions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions}
+#### `versions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions}
 
 Versions are different space template versions that can be referenced as well
 
@@ -5807,7 +5807,7 @@ Versions are different space template versions that can be referenced as well
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template}
+##### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template}
 
 Template holds the space template
 
@@ -5819,7 +5819,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata}
 
 
 
@@ -5831,7 +5831,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -5846,7 +5846,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -5864,7 +5864,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -5876,7 +5876,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -5888,7 +5888,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -5903,7 +5903,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -5924,7 +5924,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -5939,7 +5939,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -5951,7 +5951,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -5966,7 +5966,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -5981,7 +5981,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -5996,7 +5996,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-username}
 
 The username that is required for this repository
 
@@ -6011,7 +6011,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -6023,7 +6023,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -6035,7 +6035,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -6050,7 +6050,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -6065,7 +6065,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -6086,7 +6086,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-password}
 
 The password that is required for this repository
 
@@ -6101,7 +6101,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -6113,7 +6113,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -6125,7 +6125,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -6140,7 +6140,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -6155,7 +6155,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -6176,7 +6176,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -6191,7 +6191,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -6206,7 +6206,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -6221,7 +6221,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -6236,7 +6236,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -6251,7 +6251,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -6269,7 +6269,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -6281,7 +6281,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-name}
 
 Name of the target app
 
@@ -6296,7 +6296,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -6312,7 +6312,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -6327,7 +6327,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-version}
 
 Version of the app
 
@@ -6342,7 +6342,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -6357,7 +6357,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -6375,7 +6375,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access}
 
 The space access
 
@@ -6387,7 +6387,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -6403,7 +6403,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -6417,7 +6417,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -6432,7 +6432,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -6447,7 +6447,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -6471,7 +6471,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -6483,7 +6483,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -6498,7 +6498,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -6513,7 +6513,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -6528,7 +6528,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -6544,7 +6544,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -6559,7 +6559,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -6574,7 +6574,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -6589,7 +6589,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -6604,7 +6604,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -6619,7 +6619,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -6634,7 +6634,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -6649,7 +6649,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -6664,7 +6664,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -6682,7 +6682,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-version}
 
 Version is the version. Needs to be in X.X.X format.
 
@@ -6700,7 +6700,7 @@ Version is the version. Needs to be in X.X.X format.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access}
 
 Access holds the access rights for users and teams
 
@@ -6712,7 +6712,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -6742,7 +6742,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-subresources}
+##### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -6757,7 +6757,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -6772,7 +6772,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -6793,7 +6793,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status}
+### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status}
 
 
 
@@ -6805,7 +6805,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps}
 
 
 
@@ -6817,7 +6817,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-name}
 
 Name is the kubernetes name of the object
 
@@ -6832,7 +6832,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-displayName}
 
 The display name shown in the UI
 
@@ -6847,7 +6847,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-icon}
+##### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-icon}
 
 Icon is the icon of the user / team
 
@@ -6862,7 +6862,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-username}
 
 The username that is used to login
 
@@ -6877,7 +6877,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-email}
+##### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-email}
 
 The users email address
 
@@ -6892,7 +6892,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-subject}
+##### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-subject}
 
 The user subject
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/templates/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/projects/templates/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultVirtualClusterTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultVirtualClusterTemplate}
+## `defaultVirtualClusterTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultVirtualClusterTemplate}
 
 DefaultVirtualClusterTemplate is the default template for the project
 
@@ -19,7 +19,7 @@ DefaultVirtualClusterTemplate is the default template for the project
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualClusterTemplates` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates}
+## `virtualClusterTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates}
 
 VirtualClusterTemplates holds all the allowed tenant cluster templates
 
@@ -68,7 +68,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata}
+### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata}
 
 
 
@@ -496,7 +496,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -511,7 +511,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -527,7 +527,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -564,7 +564,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -595,7 +595,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -622,7 +622,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec}
 
 
 
@@ -721,7 +721,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-metadata}
 
 
 
@@ -778,7 +778,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-instanceTemplate-metadata}
 
 
 
@@ -944,7 +944,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -1560,7 +1560,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -1611,7 +1611,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-metadata}
 
 
 
@@ -1683,7 +1683,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -2348,7 +2348,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-metadata}
 
 
 
@@ -2405,7 +2405,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -2571,7 +2571,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -3187,7 +3187,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -3238,7 +3238,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-metadata}
 
 
 
@@ -3310,7 +3310,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-spec-versions-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -4092,7 +4092,7 @@ Name of the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status}
+### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status}
 
 
 
@@ -4116,7 +4116,7 @@ Name of the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterTemplates-status-apps-name}
 
 Name is the kubernetes name of the object
 
@@ -4215,7 +4215,7 @@ The user subject
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultSpaceTemplate` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultSpaceTemplate}
+## `defaultSpaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultSpaceTemplate}
 
 DefaultSpaceTemplate
 
@@ -4230,7 +4230,7 @@ DefaultSpaceTemplate
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spaceTemplates` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates}
+## `spaceTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates}
 
 SpaceTemplates holds all the allowed space templates
 
@@ -4279,7 +4279,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata}
+### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata}
 
 
 
@@ -4707,7 +4707,7 @@ workflow used when modifying the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manager` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-manager}
+##### `manager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-manager}
 
 Manager is an identifier of the workflow managing these fields.
 
@@ -4722,7 +4722,7 @@ Manager is an identifier of the workflow managing these fields.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-operation}
+##### `operation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-operation}
 
 Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 The only valid values for this field are 'Apply' and 'Update'.
@@ -4738,7 +4738,7 @@ The only valid values for this field are 'Apply' and 'Update'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-apiVersion}
 
 APIVersion defines the version of this resource that this field set
 applies to. The format is "group/version" just like the top-level
@@ -4775,7 +4775,7 @@ because another manager took it over.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fieldsType` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsType}
+##### `fieldsType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-fieldsType}
 
 FieldsType is the discriminator for the different fields format and version.
 There is currently only one possible value: "FieldsV1"
@@ -4806,7 +4806,7 @@ FieldsV1 holds the first JSON version format as described in the "FieldsV1" type
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subresource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-subresource}
+##### `subresource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-metadata-managedFields-subresource}
 
 Subresource is the name of the subresource used to update that object, or
 empty string if the object was updated through the main resource. The
@@ -4833,7 +4833,7 @@ it always corresponds to the version of the main resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spec` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec}
 
 
 
@@ -4932,7 +4932,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-metadata}
 
 
 
@@ -4989,7 +4989,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-instanceTemplate-metadata}
 
 
 
@@ -5064,7 +5064,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -5819,7 +5819,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-metadata}
 
 
 
@@ -5876,7 +5876,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -5951,7 +5951,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -6793,7 +6793,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `status` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status}
+### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status}
 
 
 
@@ -6817,7 +6817,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spaceTemplates-status-apps-name}
 
 Name is the kubernetes name of the object
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/selves/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/selves/reference.mdx
@@ -62,7 +62,7 @@ The name of the currently logged in user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-name}
 
 Name is the kubernetes name of the object
 
@@ -164,7 +164,7 @@ Teams are the teams the user is part of
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-name}
 
 Name is the kubernetes name of the object
 
@@ -272,7 +272,7 @@ The name of the currently logged in team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-name}
 
 Name is the kubernetes name of the object
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/selves/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/selves/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `accessKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-accessKey}
+### `accessKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-accessKey}
 
 AccessKey is an optional access key to use instead of the provided one
 
@@ -38,7 +38,7 @@ AccessKey is an optional access key to use instead of the provided one
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -50,7 +50,7 @@ AccessKey is an optional access key to use instead of the provided one
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user}
+### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user}
 
 The name of the currently logged in user
 
@@ -62,7 +62,7 @@ The name of the currently logged in user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-name}
 
 Name is the kubernetes name of the object
 
@@ -77,7 +77,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-displayName}
 
 The display name shown in the UI
 
@@ -92,7 +92,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-icon}
 
 Icon is the icon of the user / team
 
@@ -107,7 +107,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-username}
 
 The username that is used to login
 
@@ -122,7 +122,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-email}
 
 The users email address
 
@@ -137,7 +137,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-subject}
+#### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-subject}
 
 The user subject
 
@@ -152,7 +152,7 @@ The user subject
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams}
 
 Teams are the teams the user is part of
 
@@ -164,7 +164,7 @@ Teams are the teams the user is part of
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-name}
 
 Name is the kubernetes name of the object
 
@@ -179,7 +179,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-displayName}
 
 The display name shown in the UI
 
@@ -194,7 +194,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-icon}
+##### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-icon}
 
 Icon is the icon of the user / team
 
@@ -209,7 +209,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-username}
 
 The username that is used to login
 
@@ -224,7 +224,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-email}
+##### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-email}
 
 The users email address
 
@@ -239,7 +239,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-subject}
+##### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-user-teams-subject}
 
 The user subject
 
@@ -260,7 +260,7 @@ The user subject
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team}
+### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team}
 
 The name of the currently logged in team
 
@@ -272,7 +272,7 @@ The name of the currently logged in team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-name}
 
 Name is the kubernetes name of the object
 
@@ -287,7 +287,7 @@ Name is the kubernetes name of the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-displayName}
+#### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-displayName}
 
 The display name shown in the UI
 
@@ -302,7 +302,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-icon}
+#### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-icon}
 
 Icon is the icon of the user / team
 
@@ -317,7 +317,7 @@ Icon is the icon of the user / team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-username}
+#### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-username}
 
 The username that is used to login
 
@@ -332,7 +332,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-email}
+#### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-email}
 
 The users email address
 
@@ -347,7 +347,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-subject}
+#### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-team-subject}
 
 The user subject
 
@@ -365,7 +365,7 @@ The user subject
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `accessKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKey}
+### `accessKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKey}
 
 The name of the currently used access key
 
@@ -380,7 +380,7 @@ The name of the currently used access key
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `accessKeyScope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope}
+### `accessKeyScope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope}
 
 The scope of the currently used access key
 
@@ -392,7 +392,7 @@ The scope of the currently used access key
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `roles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles}
+#### `roles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles}
 
 Roles is a set of managed permissions to apply to the access key.
 
@@ -404,7 +404,7 @@ Roles is a set of managed permissions to apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-role}
+##### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-role}
 
 Role is the name of the role to apply to the access key scope.
 
@@ -419,7 +419,7 @@ Role is the name of the role to apply to the access key scope.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-projects}
+##### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -434,7 +434,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-roles-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -452,7 +452,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `projects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-projects}
+#### `projects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-projects}
 
 Projects specifies the projects the access key should have access to.
 
@@ -464,7 +464,7 @@ Projects specifies the projects the access key should have access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-projects-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-projects-project}
 
 Project is the name of the project. You can specify * to select all projects.
 
@@ -482,7 +482,7 @@ Project is the name of the project. You can specify * to select all projects.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces}
+#### `spaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces}
 
 Spaces specifies the spaces the access key is allowed to access.
 
@@ -494,7 +494,7 @@ Spaces specifies the spaces the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces-project}
 
 Project is the name of the project.
 
@@ -509,7 +509,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `space` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces-space}
+##### `space` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-spaces-space}
 
 Space is the name of the space. You can specify * to select all spaces.
 
@@ -527,7 +527,7 @@ Space is the name of the space. You can specify * to select all spaces.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters}
+#### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters}
 
 VirtualClusters specifies the tenant clusters the access key is allowed to access.
 
@@ -539,7 +539,7 @@ VirtualClusters specifies the tenant clusters the access key is allowed to acces
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters-project}
 
 Project is the name of the project.
 
@@ -554,7 +554,7 @@ Project is the name of the project.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters-virtualCluster}
+##### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-virtualClusters-virtualCluster}
 
 VirtualCluster is the name of the tenant cluster to access. You can specify * to select all tenant clusters.
 
@@ -572,7 +572,7 @@ VirtualCluster is the name of the tenant cluster to access. You can specify * to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-clusters}
+#### `clusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-clusters}
 
 Clusters specifies the project cluster the access key is allowed to access.
 
@@ -584,7 +584,7 @@ Clusters specifies the project cluster the access key is allowed to access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-clusters-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-clusters-cluster}
 
 Cluster is the name of the cluster to access. You can specify * to select all clusters.
 
@@ -602,7 +602,7 @@ Cluster is the name of the cluster to access. You can specify * to select all cl
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules}
 
 DEPRECATED: Use Projects, Spaces and VirtualClusters instead
 Rules specifies the rules that should apply to the access key.
@@ -615,7 +615,7 @@ Rules specifies the rules that should apply to the access key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-verbs}
 
 The verbs that match this rule.
 An empty list implies every verb.
@@ -631,7 +631,7 @@ An empty list implies every verb.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources}
 
 Resources that this rule matches. An empty list implies all kinds in all API groups.
 
@@ -643,7 +643,7 @@ Resources that this rule matches. An empty list implies all kinds in all API gro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `group` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-group}
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-group}
 
 Group is the name of the API group that contains the resources.
 The empty string represents the core API group.
@@ -659,7 +659,7 @@ The empty string represents the core API group.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -686,7 +686,7 @@ An empty list implies all resources and subresources in this API groups apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-resources-resourceNames}
 
 ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
@@ -706,7 +706,7 @@ An empty list implies that every instance of the resource is matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-namespaces}
+##### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-namespaces}
 
 Namespaces that this rule matches.
 The empty string "" matches non-namespaced resources.
@@ -723,7 +723,7 @@ An empty list implies every namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-nonResourceURLs}
 
 NonResourceURLs is a set of URL paths that should be checked.
 *s are allowed, but only as the full, final step in the path.
@@ -742,7 +742,7 @@ Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requestTargets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-requestTargets}
+##### `requestTargets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-requestTargets}
 
 RequestTargets is a list of request targets that are allowed.
 An empty list implies every request.
@@ -758,7 +758,7 @@ An empty list implies every request.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-cluster}
+##### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-cluster}
 
 Cluster that this rule matches. Only applies to cluster requests.
 If this is set, no requests for non cluster requests are allowed.
@@ -775,7 +775,7 @@ An empty cluster means no restrictions will apply.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualClusters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters}
+##### `virtualClusters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters}
 
 VirtualClusters that this rule matches. Only applies to tenant cluster requests.
 An empty list means no restrictions will apply.
@@ -788,7 +788,7 @@ An empty list means no restrictions will apply.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters-name}
 
 Name of the tenant cluster. Empty means all tenant clusters.
 
@@ -803,7 +803,7 @@ Name of the tenant cluster. Empty means all tenant clusters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-rules-virtualClusters-namespace}
 
 Namespace of the tenant cluster. Empty means all namespaces.
 
@@ -824,7 +824,7 @@ Namespace of the tenant cluster. Empty means all namespaces.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `allowLoftCli` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-allowLoftCli}
+#### `allowLoftCli` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyScope-allowLoftCli}
 
 AllowLoftCLI allows certain read-only management requests to
 make sure loft cli works correctly with this specific access key.
@@ -850,7 +850,7 @@ Deprecated: Use the `roles` field instead
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `accessKeyType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyType}
+### `accessKeyType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-accessKeyType}
 
 The type of the currently used access key
 
@@ -865,7 +865,7 @@ The type of the currently used access key
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-subject}
+### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-subject}
 
 The subject of the currently logged in user
 
@@ -880,7 +880,7 @@ The subject of the currently logged in user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `uid` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uid}
+### `uid` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-uid}
 
 UID is the user uid
 
@@ -895,7 +895,7 @@ UID is the user uid
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-groups}
+### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-groups}
 
 The groups of the currently logged in user
 
@@ -910,7 +910,7 @@ The groups of the currently logged in user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `chatAuthToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-chatAuthToken}
+### `chatAuthToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-chatAuthToken}
 
 ChatAuthToken is the token used to authenticate with the in-product chat widget in the UI
 
@@ -925,7 +925,7 @@ ChatAuthToken is the token used to authenticate with the in-product chat widget 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `instanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-instanceID}
+### `instanceID` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-instanceID}
 
 InstanceID is the loft instance id
 
@@ -940,7 +940,7 @@ InstanceID is the loft instance id
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `loftHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-loftHost}
+### `loftHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-loftHost}
 
 LoftHost is the host of the loft instance
 
@@ -955,7 +955,7 @@ LoftHost is the host of the loft instance
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `projectNamespacePrefix` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-projectNamespacePrefix}
+### `projectNamespacePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-projectNamespacePrefix}
 
 ProjectNamespacePrefix is the prefix used to name project namespaces after defaulting has been applied
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/sharedsecrets/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/sharedsecrets/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a shared secret
 
@@ -50,7 +50,7 @@ Description describes a shared secret
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `data` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-data}
+### `data` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-data}
 
 Data contains the secret data. Each key must consist of alphanumeric
 characters, '-', '_' or '.'. The serialized form of the secret data is a
@@ -113,7 +113,7 @@ data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams which will be transformed
 to Roles and RoleBindings
@@ -126,7 +126,7 @@ to Roles and RoleBindings
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -156,7 +156,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -171,7 +171,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -186,7 +186,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -207,7 +207,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -219,7 +219,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions holds several conditions the project might be in
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/spaceinstances/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/spaceinstances/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a space instance
 
@@ -50,7 +50,7 @@ Description describes a space instance
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `templateRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef}
+### `templateRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef}
 
 TemplateRef holds the space template reference
 
@@ -107,7 +107,7 @@ TemplateRef holds the space template reference
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-name}
 
 Name holds the name of the template to reference.
 
@@ -122,7 +122,7 @@ Name holds the name of the template to reference.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-version}
 
 Version holds the template version to use. Version is expected to
 be in semantic versioning format. Alternatively, you can also exchange
@@ -140,7 +140,7 @@ the latest major, minor or patch version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncOnce` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-syncOnce}
+#### `syncOnce` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-syncOnce}
 
 SyncOnce tells the controller to sync the instance once with the template.
 This is useful if you want to sync an instance after a template was changed.
@@ -161,7 +161,7 @@ instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
+### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
 
 Template is the inline template to use for space creation. This is mutually
 exclusive with templateRef.
@@ -174,7 +174,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -186,7 +186,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -201,7 +201,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -219,7 +219,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -231,7 +231,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -243,7 +243,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -258,7 +258,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -279,7 +279,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -294,7 +294,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -306,7 +306,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -321,7 +321,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -336,7 +336,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -351,7 +351,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -366,7 +366,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -378,7 +378,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -390,7 +390,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -405,7 +405,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -420,7 +420,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -441,7 +441,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -456,7 +456,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -468,7 +468,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -480,7 +480,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -495,7 +495,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -510,7 +510,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -531,7 +531,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -546,7 +546,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -561,7 +561,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -576,7 +576,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -591,7 +591,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -606,7 +606,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -624,7 +624,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -636,7 +636,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
 
 Name of the target app
 
@@ -651,7 +651,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -667,7 +667,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -682,7 +682,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
 
 Version of the app
 
@@ -697,7 +697,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -712,7 +712,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -730,7 +730,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
 
 The space access
 
@@ -742,7 +742,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -758,7 +758,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -772,7 +772,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -787,7 +787,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -802,7 +802,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -826,7 +826,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef}
+### `clusterRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef}
 
 ClusterRef is the reference to the connected cluster holding
 this space
@@ -839,7 +839,7 @@ this space
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-cluster}
+#### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-cluster}
 
 Cluster is the connected cluster the space will be created in
 
@@ -854,7 +854,7 @@ Cluster is the connected cluster the space will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding the space
 
@@ -872,7 +872,7 @@ Namespace is the namespace inside the connected cluster holding the space
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
 
 Parameters are values to pass to the template.
 The values should be encoded as YAML string where each parameter is represented as a top-level field key.
@@ -888,7 +888,7 @@ The values should be encoded as YAML string where each parameter is represented 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `extraAccessRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules}
+### `extraAccessRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules}
 
 ExtraAccessRules defines extra rules which users and teams should have which access to the tenant
 cluster.
@@ -901,7 +901,7 @@ cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-users}
 
 Users this rule matches. * means all users.
 
@@ -916,7 +916,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-teams}
 
 Teams that this rule matches.
 
@@ -931,7 +931,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -949,7 +949,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -961,7 +961,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -991,7 +991,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -1006,7 +1006,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -1021,7 +1021,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -1042,7 +1042,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -1054,7 +1054,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `phase` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
+### `phase` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
 
 Phase describes the current phase the space instance is in
 
@@ -1069,7 +1069,7 @@ Phase describes the current phase the space instance is in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `reason` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
+### `reason` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
 
 Reason describes the reason in machine-readable form
 
@@ -1084,7 +1084,7 @@ Reason describes the reason in machine-readable form
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `message` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
+### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
 
 Message describes the reason in human-readable form
 
@@ -1099,7 +1099,7 @@ Message describes the reason in human-readable form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions holds several conditions the tenant cluster might be in
 
@@ -1114,7 +1114,7 @@ Conditions holds several conditions the tenant cluster might be in
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spaceObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects}
+### `spaceObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects}
 
 SpaceObjects are the objects that were applied within the tenant cluster space
 
@@ -1126,7 +1126,7 @@ SpaceObjects are the objects that were applied within the tenant cluster space
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `lastAppliedObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-lastAppliedObjects}
+#### `lastAppliedObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-lastAppliedObjects}
 
 LastAppliedObjects holds the status for the objects that were applied
 
@@ -1141,7 +1141,7 @@ LastAppliedObjects holds the status for the objects that were applied
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts}
 
 Charts are the charts that were applied
 
@@ -1153,7 +1153,7 @@ Charts are the charts that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-name}
 
 Name of the chart that was applied
 
@@ -1168,7 +1168,7 @@ Name of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-namespace}
 
 Namespace of the chart that was applied
 
@@ -1183,7 +1183,7 @@ Namespace of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-lastAppliedChartConfigHash}
+##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-lastAppliedChartConfigHash}
 
 LastAppliedChartConfigHash is the last applied configuration
 
@@ -1201,7 +1201,7 @@ LastAppliedChartConfigHash is the last applied configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps}
 
 Apps are the apps that were applied
 
@@ -1213,7 +1213,7 @@ Apps are the apps that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-name}
 
 Name of the target app
 
@@ -1228,7 +1228,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1244,7 +1244,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1259,7 +1259,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-version}
 
 Version of the app
 
@@ -1274,7 +1274,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1289,7 +1289,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-parameters}
 
 Parameters to use for the app
 
@@ -1310,7 +1310,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `space` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space}
+### `space` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space}
 
 Space is the template rendered with all the parameters
 
@@ -1322,7 +1322,7 @@ Space is the template rendered with all the parameters
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata}
 
 
 
@@ -1334,7 +1334,7 @@ Space is the template rendered with all the parameters
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata-labels}
 
 Labels are labels on the object
 
@@ -1349,7 +1349,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1367,7 +1367,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -1379,7 +1379,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata}
 
 
 
@@ -1391,7 +1391,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1406,7 +1406,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1427,7 +1427,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -1442,7 +1442,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1454,7 +1454,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-name}
 
 Name is the chart name in the repository
 
@@ -1469,7 +1469,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-version}
 
 Version is the chart version in the repository
 
@@ -1484,7 +1484,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -1499,7 +1499,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-username}
 
 The username that is required for this repository
 
@@ -1514,7 +1514,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1526,7 +1526,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1538,7 +1538,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1553,7 +1553,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1568,7 +1568,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1589,7 +1589,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-password}
 
 The password that is required for this repository
 
@@ -1604,7 +1604,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1616,7 +1616,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1628,7 +1628,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1643,7 +1643,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1658,7 +1658,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1679,7 +1679,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1694,7 +1694,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1709,7 +1709,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1724,7 +1724,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1739,7 +1739,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1754,7 +1754,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1772,7 +1772,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -1784,7 +1784,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-name}
 
 Name of the target app
 
@@ -1799,7 +1799,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1815,7 +1815,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1830,7 +1830,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-version}
 
 Version of the app
 
@@ -1845,7 +1845,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1860,7 +1860,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-apps-parameters}
 
 Parameters to use for the app
 
@@ -1878,7 +1878,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access}
 
 The space access
 
@@ -1890,7 +1890,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -1906,7 +1906,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -1920,7 +1920,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -1935,7 +1935,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -1950,7 +1950,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -1974,7 +1974,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ignoreReconciliation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
+### `ignoreReconciliation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
 
 IgnoreReconciliation tells the controller to ignore reconciliation for this instance -- this
 is primarily used when migrating tenant cluster instances from project to project; this

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/spaceinstances/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/spaceinstances/reference.mdx
@@ -174,7 +174,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -231,7 +231,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -306,7 +306,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -1322,7 +1322,7 @@ Space is the template rendered with all the parameters
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-metadata}
 
 
 
@@ -1379,7 +1379,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-instanceTemplate-metadata}
 
 
 
@@ -1454,7 +1454,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-space-charts-name}
 
 Name is the chart name in the repository
 
@@ -1974,7 +1974,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ignoreReconciliation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
+### `ignoreReconciliation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
 
 IgnoreReconciliation tells the controller to ignore reconciliation for this instance -- this
 is primarily used when migrating tenant cluster instances from project to project; this

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/spacetemplates/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/spacetemplates/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that is shown in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that is shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes the space template
 
@@ -50,7 +50,7 @@ Description describes the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
+### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
 
 Template holds the space template
 
@@ -107,7 +107,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -119,7 +119,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -134,7 +134,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -152,7 +152,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -164,7 +164,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -176,7 +176,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -191,7 +191,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -212,7 +212,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -227,7 +227,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -239,7 +239,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -254,7 +254,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -269,7 +269,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -284,7 +284,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -299,7 +299,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -311,7 +311,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -323,7 +323,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -338,7 +338,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -353,7 +353,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -374,7 +374,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -389,7 +389,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -401,7 +401,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -413,7 +413,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -428,7 +428,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -443,7 +443,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -464,7 +464,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -479,7 +479,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -494,7 +494,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -509,7 +509,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -524,7 +524,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -539,7 +539,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -557,7 +557,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -569,7 +569,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
 
 Name of the target app
 
@@ -584,7 +584,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -600,7 +600,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -615,7 +615,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
 
 Version of the app
 
@@ -630,7 +630,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -645,7 +645,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -663,7 +663,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
 
 The space access
 
@@ -675,7 +675,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -691,7 +691,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -705,7 +705,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -720,7 +720,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -735,7 +735,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -759,7 +759,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -771,7 +771,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
+#### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -786,7 +786,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
+#### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -801,7 +801,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -816,7 +816,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
+#### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -832,7 +832,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
+#### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -847,7 +847,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
+#### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -862,7 +862,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
+#### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -877,7 +877,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
+#### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -892,7 +892,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
+#### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -907,7 +907,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
+#### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -922,7 +922,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
+#### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -937,7 +937,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
+#### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -952,7 +952,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
+#### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -970,7 +970,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `versions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
+### `versions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
 
 Versions are different space template versions that can be referenced as well
 
@@ -982,7 +982,7 @@ Versions are different space template versions that can be referenced as well
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template}
+#### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template}
 
 Template holds the space template
 
@@ -994,7 +994,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
 
 
 
@@ -1006,7 +1006,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -1021,7 +1021,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1039,7 +1039,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate}
 
 InstanceTemplate holds the space instance template
 
@@ -1051,7 +1051,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -1063,7 +1063,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1078,7 +1078,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1099,7 +1099,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -1114,7 +1114,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1126,7 +1126,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -1141,7 +1141,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -1156,7 +1156,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -1171,7 +1171,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-username}
 
 The username that is required for this repository
 
@@ -1186,7 +1186,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1198,7 +1198,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1210,7 +1210,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1225,7 +1225,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1240,7 +1240,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1261,7 +1261,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-password}
 
 The password that is required for this repository
 
@@ -1276,7 +1276,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1288,7 +1288,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1300,7 +1300,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1315,7 +1315,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1330,7 +1330,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1351,7 +1351,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1366,7 +1366,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1381,7 +1381,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1396,7 +1396,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1411,7 +1411,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1426,7 +1426,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1444,7 +1444,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -1456,7 +1456,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-name}
 
 Name of the target app
 
@@ -1471,7 +1471,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1487,7 +1487,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1502,7 +1502,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-version}
 
 Version of the app
 
@@ -1517,7 +1517,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1532,7 +1532,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -1550,7 +1550,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access}
 
 The space access
 
@@ -1562,7 +1562,7 @@ The space access
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -1578,7 +1578,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -1592,7 +1592,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -1607,7 +1607,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -1622,7 +1622,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -1646,7 +1646,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -1658,7 +1658,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -1673,7 +1673,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -1688,7 +1688,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -1703,7 +1703,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -1719,7 +1719,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -1734,7 +1734,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -1749,7 +1749,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -1764,7 +1764,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -1779,7 +1779,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -1794,7 +1794,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -1809,7 +1809,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -1824,7 +1824,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -1839,7 +1839,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -1857,7 +1857,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
 
 Version is the version. Needs to be in X.X.X format.
 
@@ -1875,7 +1875,7 @@ Version is the version. Needs to be in X.X.X format.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -1887,7 +1887,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -1917,7 +1917,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -1932,7 +1932,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -1947,7 +1947,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -1968,7 +1968,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/spacetemplates/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/spacetemplates/reference.mdx
@@ -107,7 +107,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -164,7 +164,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -239,7 +239,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -994,7 +994,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
 
 
 
@@ -1051,7 +1051,7 @@ InstanceTemplate holds the space instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -1126,7 +1126,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/teams/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/teams/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 The display name shown in the UI
 
@@ -35,7 +35,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a cluster access object
 
@@ -50,7 +50,7 @@ Description describes a cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
+### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
 
 The username of the team that will be used for identification and docker registry namespace
 
@@ -110,7 +110,7 @@ The username of the team that will be used for identification and docker registr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-users}
+### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-users}
 
 The loft users that belong to a team
 
@@ -125,7 +125,7 @@ The loft users that belong to a team
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
+### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
 
 The groups defined in a token that belong to a team
 
@@ -140,7 +140,7 @@ The groups defined in a token that belong to a team
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets}
 
 ImagePullSecrets holds secret references to image pull
 secrets the team has access to.
@@ -153,7 +153,7 @@ secrets the team has access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
+#### `apiGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
 
 APIGroup is the api group of the secret
 
@@ -168,7 +168,7 @@ APIGroup is the api group of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
 
 Kind is the kind of the secret
 
@@ -183,7 +183,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretName}
 
 
 
@@ -198,7 +198,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretNamespace}
+#### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretNamespace}
 
 
 
@@ -213,7 +213,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-key}
+#### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-key}
 
 
 
@@ -231,7 +231,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRoles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles}
+### `clusterRoles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles}
 
 ClusterRoles define the cluster roles that the users should have assigned in the cluster.
 
@@ -243,7 +243,7 @@ ClusterRoles define the cluster roles that the users should have assigned in the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles-name}
 
 Name is the cluster role to assign
 
@@ -261,7 +261,7 @@ Name is the cluster role to assign
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -273,7 +273,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -303,7 +303,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -318,7 +318,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -333,7 +333,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -354,7 +354,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/teams/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/teams/reference.mdx
@@ -153,7 +153,7 @@ secrets the team has access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroup` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
+#### `apiGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
 
 APIGroup is the api group of the secret
 
@@ -168,7 +168,7 @@ APIGroup is the api group of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
 
 Kind is the kind of the secret
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/users/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/users/reference.mdx
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `username` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
+### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
 
 The username that is used to login
 
@@ -140,7 +140,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `subject` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
+### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
 
 The user subject as presented by the token
 
@@ -319,7 +319,7 @@ secrets the user has access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroup` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
+#### `apiGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
 
 APIGroup is the api group of the secret
 
@@ -334,7 +334,7 @@ APIGroup is the api group of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
 
 Kind is the kind of the secret
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/users/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/users/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 The display name shown in the UI
 
@@ -35,7 +35,7 @@ The display name shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a cluster access object
 
@@ -50,7 +50,7 @@ Description describes a cluster access object
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
+### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-username}
 
 The username that is used to login
 
@@ -110,7 +110,7 @@ The username that is used to login
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `icon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-icon}
+### `icon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-icon}
 
 The URL to an icon that should be shown for the user
 
@@ -125,7 +125,7 @@ The URL to an icon that should be shown for the user
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `email` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-email}
+### `email` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-email}
 
 The users email address
 
@@ -140,7 +140,7 @@ The users email address
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `subject` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
+### `subject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-subject}
 
 The user subject as presented by the token
 
@@ -155,7 +155,7 @@ The user subject as presented by the token
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `groups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
+### `groups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-groups}
 
 The groups the user has access to
 
@@ -170,7 +170,7 @@ The groups the user has access to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ssoGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ssoGroups}
+### `ssoGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-ssoGroups}
 
 SSOGroups is used to remember groups that were
 added from sso.
@@ -186,7 +186,7 @@ added from sso.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef}
+### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef}
 
 A reference to the user password
 
@@ -198,7 +198,7 @@ A reference to the user password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-secretName}
 
 
 
@@ -213,7 +213,7 @@ A reference to the user password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-secretNamespace}
+#### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-secretNamespace}
 
 
 
@@ -228,7 +228,7 @@ A reference to the user password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-key}
+#### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-passwordRef-key}
 
 
 
@@ -246,7 +246,7 @@ A reference to the user password
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `codesRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef}
+### `codesRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef}
 
 A reference to the users access keys
 
@@ -258,7 +258,7 @@ A reference to the users access keys
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-secretName}
 
 
 
@@ -273,7 +273,7 @@ A reference to the users access keys
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-secretNamespace}
+#### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-secretNamespace}
 
 
 
@@ -288,7 +288,7 @@ A reference to the users access keys
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-key}
+#### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-codesRef-key}
 
 
 
@@ -306,7 +306,7 @@ A reference to the users access keys
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets}
 
 ImagePullSecrets holds secret references to image pull
 secrets the user has access to.
@@ -319,7 +319,7 @@ secrets the user has access to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
+#### `apiGroup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-apiGroup}
 
 APIGroup is the api group of the secret
 
@@ -334,7 +334,7 @@ APIGroup is the api group of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-kind}
 
 Kind is the kind of the secret
 
@@ -349,7 +349,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretName}
 
 
 
@@ -364,7 +364,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretNamespace}
+#### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-secretNamespace}
 
 
 
@@ -379,7 +379,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-key}
+#### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-imagePullSecrets-key}
 
 
 
@@ -397,7 +397,7 @@ Kind is the kind of the secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `tokenGeneration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-tokenGeneration}
+### `tokenGeneration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-tokenGeneration}
 
 TokenGeneration can be used to invalidate all user tokens
 
@@ -412,7 +412,7 @@ TokenGeneration can be used to invalidate all user tokens
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-disabled}
+### `disabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-disabled}
 
 If disabled is true, a user will not be able to login anymore. All other user resources
 are unaffected and other users can still interact with this user
@@ -428,7 +428,7 @@ are unaffected and other users can still interact with this user
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRoles` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles}
+### `clusterRoles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles}
 
 ClusterRoles define the cluster roles that the users should have assigned in the cluster.
 
@@ -440,7 +440,7 @@ ClusterRoles define the cluster roles that the users should have assigned in the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRoles-name}
 
 Name is the cluster role to assign
 
@@ -458,7 +458,7 @@ Name is the cluster role to assign
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -470,7 +470,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -500,7 +500,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -515,7 +515,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -530,7 +530,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -548,7 +548,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraClaims}
+### `extraClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraClaims}
 
 ExtraClaims are additional claims that have been added to the user by an admin.
 
@@ -566,7 +566,7 @@ ExtraClaims are additional claims that have been added to the user by an admin.
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -578,7 +578,7 @@ ExtraClaims are additional claims that have been added to the user by an admin.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-teams}
+### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-teams}
 
 Teams the user is currently part of
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclusterinstances/kubeconfig/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclusterinstances/kubeconfig/reference.mdx
@@ -81,7 +81,7 @@ ClientCert, if set to true, will return kube config with generated client certs 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubeConfig}
 
 KubeConfig holds the final kubeconfig output
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclusterinstances/kubeconfig/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclusterinstances/kubeconfig/reference.mdx
@@ -4,7 +4,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -16,7 +16,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certificateTTL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-certificateTTL}
+### `certificateTTL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-certificateTTL}
 
 CertificateTTL holds the ttl (in seconds) to set for the certificate associated with the
 returned kubeconfig.
@@ -36,7 +36,7 @@ which is typically one year.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-server}
+### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-server}
 
 Server allows user to override server in the kubeconfig.
 
@@ -51,7 +51,7 @@ Server allows user to override server in the kubeconfig.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clientCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clientCert}
+### `clientCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clientCert}
 
 ClientCert, if set to true, will return kube config with generated client certs instead of platform token
 
@@ -69,7 +69,7 @@ ClientCert, if set to true, will return kube config with generated client certs 
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -81,7 +81,7 @@ ClientCert, if set to true, will return kube config with generated client certs 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubeConfig}
 
 KubeConfig holds the final kubeconfig output
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclusterinstances/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclusterinstances/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that should be displayed in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that should be displayed in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes a tenant cluster instance
 
@@ -50,7 +50,7 @@ Description describes a tenant cluster instance
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `templateRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef}
+### `templateRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef}
 
 TemplateRef holds the tenant cluster template reference
 
@@ -107,7 +107,7 @@ TemplateRef holds the tenant cluster template reference
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-name}
 
 Name holds the name of the template to reference.
 
@@ -122,7 +122,7 @@ Name holds the name of the template to reference.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-version}
 
 Version holds the template version to use. Version is expected to
 be in semantic versioning format. Alternatively, you can also exchange
@@ -140,7 +140,7 @@ the latest major, minor or patch version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncOnce` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-syncOnce}
+#### `syncOnce` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-syncOnce}
 
 SyncOnce tells the controller to sync the instance once with the template.
 This is useful if you want to sync an instance after a template was changed.
@@ -161,7 +161,7 @@ instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
+### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
 
 Template is the inline template to use for tenant cluster creation. This is mutually
 exclusive with templateRef.
@@ -174,7 +174,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -186,7 +186,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -201,7 +201,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -219,7 +219,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -231,7 +231,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -243,7 +243,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -258,7 +258,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -279,7 +279,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -291,7 +291,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
 
 Name of the target app
 
@@ -306,7 +306,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -322,7 +322,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -337,7 +337,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
 
 Version of the app
 
@@ -352,7 +352,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -367,7 +367,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -385,7 +385,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -397,7 +397,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -412,7 +412,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -427,7 +427,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -442,7 +442,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -457,7 +457,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -469,7 +469,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -481,7 +481,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -496,7 +496,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -511,7 +511,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -532,7 +532,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -547,7 +547,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -559,7 +559,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -571,7 +571,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -586,7 +586,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -601,7 +601,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -622,7 +622,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -637,7 +637,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -652,7 +652,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -667,7 +667,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -682,7 +682,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -697,7 +697,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -715,7 +715,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -730,7 +730,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -742,7 +742,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -758,7 +758,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -772,7 +772,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -787,7 +787,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -802,7 +802,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -823,7 +823,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro}
+#### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -835,7 +835,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -853,7 +853,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease}
+#### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -865,7 +865,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -877,7 +877,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -892,7 +892,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -907,7 +907,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -922,7 +922,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -937,7 +937,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -952,7 +952,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -970,7 +970,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-values}
 
 the values for the given chart
 
@@ -988,7 +988,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint}
+#### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -1001,7 +1001,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -1013,7 +1013,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -1036,7 +1036,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-forwardToken}
+#### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -1052,7 +1052,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate}
+#### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -1064,7 +1064,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
 
 
 
@@ -1076,7 +1076,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1091,7 +1091,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1109,7 +1109,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -1124,7 +1124,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1136,7 +1136,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -1151,7 +1151,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -1166,7 +1166,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -1181,7 +1181,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -1196,7 +1196,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1208,7 +1208,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1220,7 +1220,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1235,7 +1235,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1250,7 +1250,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1271,7 +1271,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -1286,7 +1286,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1298,7 +1298,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1310,7 +1310,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1325,7 +1325,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1340,7 +1340,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1361,7 +1361,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1376,7 +1376,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1391,7 +1391,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1406,7 +1406,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1421,7 +1421,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1436,7 +1436,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1454,7 +1454,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -1466,7 +1466,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -1481,7 +1481,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1497,7 +1497,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1512,7 +1512,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -1527,7 +1527,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1542,7 +1542,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -1566,7 +1566,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef}
+### `clusterRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef}
 
 ClusterRef is the reference to the connected cluster holding
 this tenant cluster
@@ -1579,7 +1579,7 @@ this tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `cluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-cluster}
+#### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-cluster}
 
 Cluster is the connected cluster the space will be created in
 
@@ -1594,7 +1594,7 @@ Cluster is the connected cluster the space will be created in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-namespace}
 
 Namespace is the namespace inside the connected cluster holding the space
 
@@ -1609,7 +1609,7 @@ Namespace is the namespace inside the connected cluster holding the space
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-virtualCluster}
+#### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-clusterRef-virtualCluster}
 
 VirtualCluster is the name of the tenant cluster inside the namespace
 
@@ -1627,7 +1627,7 @@ VirtualCluster is the name of the tenant cluster inside the namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
 
 Parameters are values to pass to the template.
 The values should be encoded as YAML string where each parameter is represented as a top-level field key.
@@ -1643,7 +1643,7 @@ The values should be encoded as YAML string where each parameter is represented 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `extraAccessRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules}
+### `extraAccessRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules}
 
 ExtraAccessRules defines extra rules which users and teams should have which access to the tenant
 cluster.
@@ -1656,7 +1656,7 @@ cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-users}
 
 Users this rule matches. * means all users.
 
@@ -1671,7 +1671,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-teams}
 
 Teams that this rule matches.
 
@@ -1686,7 +1686,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-extraAccessRules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -1704,7 +1704,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access to the tenant cluster object itself
 
@@ -1716,7 +1716,7 @@ Access to the tenant cluster object itself
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -1746,7 +1746,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -1761,7 +1761,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -1776,7 +1776,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -1794,7 +1794,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `networkPeer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-networkPeer}
+### `networkPeer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-networkPeer}
 
 NetworkPeer specifies if the cluster is connected via tailscale.
 
@@ -1809,7 +1809,7 @@ NetworkPeer specifies if the cluster is connected via tailscale.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-external}
+### `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-external}
 
 External specifies if the tenant cluster is managed by the platform agent or externally.
 
@@ -1824,7 +1824,7 @@ External specifies if the tenant cluster is managed by the platform agent or ext
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `standalone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-standalone}
+### `standalone` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-standalone}
 
 Standalone specifies if the tenant cluster is standalone and not hosted in another Kubernetes cluster.
 
@@ -1842,7 +1842,7 @@ Standalone specifies if the tenant cluster is standalone and not hosted in anoth
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 
@@ -1854,7 +1854,7 @@ Standalone specifies if the tenant cluster is standalone and not hosted in anoth
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `phase` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
+### `phase` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
 
 Phase describes the current phase the tenant cluster instance is in
 
@@ -1869,7 +1869,7 @@ Phase describes the current phase the tenant cluster instance is in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `reason` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
+### `reason` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
 
 Reason describes the reason in machine-readable form why the cluster is in the current
 phase
@@ -1885,7 +1885,7 @@ phase
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `message` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
+### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
 
 Message describes the reason in human-readable form why the cluster is in the current
 phase
@@ -1901,7 +1901,7 @@ phase
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serviceUID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-serviceUID}
+### `serviceUID` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-serviceUID}
 
 ServiceUID is the service uid of the tenant cluster to uniquely identify it.
 
@@ -1916,7 +1916,7 @@ ServiceUID is the service uid of the tenant cluster to uniquely identify it.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubernetesVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubernetesVersion}
+### `kubernetesVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-kubernetesVersion}
 
 KubernetesVersion is the Kubernetes version of the tenant cluster.
 
@@ -1931,7 +1931,7 @@ KubernetesVersion is the Kubernetes version of the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `deployHash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-deployHash}
+### `deployHash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-deployHash}
 
 DeployHash is the hash of the last deployed values.
 
@@ -1946,7 +1946,7 @@ DeployHash is the hash of the last deployed values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
 
 Conditions holds several conditions the tenant cluster might be in
 
@@ -1961,7 +1961,7 @@ Conditions holds several conditions the tenant cluster might be in
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualClusterObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects}
+### `virtualClusterObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects}
 
 VirtualClusterObjects are the objects that were applied within the tenant cluster itself
 
@@ -1973,7 +1973,7 @@ VirtualClusterObjects are the objects that were applied within the tenant cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `lastAppliedObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-lastAppliedObjects}
+#### `lastAppliedObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-lastAppliedObjects}
 
 LastAppliedObjects holds the status for the objects that were applied
 
@@ -1988,7 +1988,7 @@ LastAppliedObjects holds the status for the objects that were applied
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts}
 
 Charts are the charts that were applied
 
@@ -2000,7 +2000,7 @@ Charts are the charts that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-name}
 
 Name of the chart that was applied
 
@@ -2015,7 +2015,7 @@ Name of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-namespace}
 
 Namespace of the chart that was applied
 
@@ -2030,7 +2030,7 @@ Namespace of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-lastAppliedChartConfigHash}
+##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-charts-lastAppliedChartConfigHash}
 
 LastAppliedChartConfigHash is the last applied configuration
 
@@ -2048,7 +2048,7 @@ LastAppliedChartConfigHash is the last applied configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps}
 
 Apps are the apps that were applied
 
@@ -2060,7 +2060,7 @@ Apps are the apps that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-name}
 
 Name of the target app
 
@@ -2075,7 +2075,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -2091,7 +2091,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -2106,7 +2106,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-version}
 
 Version of the app
 
@@ -2121,7 +2121,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -2136,7 +2136,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualClusterObjects-apps-parameters}
 
 Parameters to use for the app
 
@@ -2157,7 +2157,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spaceObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects}
+### `spaceObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects}
 
 SpaceObjects are the objects that were applied within the tenant cluster space
 
@@ -2169,7 +2169,7 @@ SpaceObjects are the objects that were applied within the tenant cluster space
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `lastAppliedObjects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-lastAppliedObjects}
+#### `lastAppliedObjects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-lastAppliedObjects}
 
 LastAppliedObjects holds the status for the objects that were applied
 
@@ -2184,7 +2184,7 @@ LastAppliedObjects holds the status for the objects that were applied
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts}
 
 Charts are the charts that were applied
 
@@ -2196,7 +2196,7 @@ Charts are the charts that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-name}
 
 Name of the chart that was applied
 
@@ -2211,7 +2211,7 @@ Name of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-namespace}
 
 Namespace of the chart that was applied
 
@@ -2226,7 +2226,7 @@ Namespace of the chart that was applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-lastAppliedChartConfigHash}
+##### `lastAppliedChartConfigHash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-charts-lastAppliedChartConfigHash}
 
 LastAppliedChartConfigHash is the last applied configuration
 
@@ -2244,7 +2244,7 @@ LastAppliedChartConfigHash is the last applied configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps}
 
 Apps are the apps that were applied
 
@@ -2256,7 +2256,7 @@ Apps are the apps that were applied
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-name}
 
 Name of the target app
 
@@ -2271,7 +2271,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -2287,7 +2287,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -2302,7 +2302,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-version}
 
 Version of the app
 
@@ -2317,7 +2317,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -2332,7 +2332,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-spaceObjects-apps-parameters}
 
 Parameters to use for the app
 
@@ -2353,7 +2353,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster}
+### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster}
 
 VirtualCluster is the template rendered with all the parameters
 
@@ -2365,7 +2365,7 @@ VirtualCluster is the template rendered with all the parameters
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata}
 
 
 
@@ -2377,7 +2377,7 @@ VirtualCluster is the template rendered with all the parameters
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata-labels}
 
 Labels are labels on the object
 
@@ -2392,7 +2392,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -2410,7 +2410,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -2422,7 +2422,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata}
 
 
 
@@ -2434,7 +2434,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -2449,7 +2449,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -2470,7 +2470,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -2482,7 +2482,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-name}
 
 Name of the target app
 
@@ -2497,7 +2497,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -2513,7 +2513,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -2528,7 +2528,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-version}
 
 Version of the app
 
@@ -2543,7 +2543,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -2558,7 +2558,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-apps-parameters}
 
 Parameters to use for the app
 
@@ -2576,7 +2576,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts}
 
 Charts are helm charts that should get deployed
 
@@ -2588,7 +2588,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-name}
 
 Name is the chart name in the repository
 
@@ -2603,7 +2603,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-version}
 
 Version is the chart version in the repository
 
@@ -2618,7 +2618,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -2633,7 +2633,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-username}
 
 The username that is required for this repository
 
@@ -2648,7 +2648,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -2660,7 +2660,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2672,7 +2672,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2687,7 +2687,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2702,7 +2702,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2723,7 +2723,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-password}
 
 The password that is required for this repository
 
@@ -2738,7 +2738,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -2750,7 +2750,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2762,7 +2762,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2777,7 +2777,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2792,7 +2792,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2813,7 +2813,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -2828,7 +2828,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -2843,7 +2843,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -2858,7 +2858,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -2873,7 +2873,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -2888,7 +2888,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -2906,7 +2906,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -2921,7 +2921,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -2933,7 +2933,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -2949,7 +2949,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -2963,7 +2963,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -2978,7 +2978,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -2993,7 +2993,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -3014,7 +3014,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-pro}
+#### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -3026,7 +3026,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -3044,7 +3044,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease}
+#### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -3056,7 +3056,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -3068,7 +3068,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -3083,7 +3083,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -3098,7 +3098,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -3113,7 +3113,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -3128,7 +3128,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -3143,7 +3143,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -3161,7 +3161,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-helmRelease-values}
 
 the values for the given chart
 
@@ -3179,7 +3179,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint}
+#### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -3192,7 +3192,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -3204,7 +3204,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -3227,7 +3227,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-forwardToken}
+#### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -3243,7 +3243,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate}
+#### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -3255,7 +3255,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata}
 
 
 
@@ -3267,7 +3267,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -3282,7 +3282,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -3300,7 +3300,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -3315,7 +3315,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -3327,7 +3327,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -3342,7 +3342,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -3357,7 +3357,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -3372,7 +3372,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -3387,7 +3387,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -3399,7 +3399,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -3411,7 +3411,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -3426,7 +3426,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -3441,7 +3441,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -3462,7 +3462,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -3477,7 +3477,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -3489,7 +3489,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -3501,7 +3501,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -3516,7 +3516,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -3531,7 +3531,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -3552,7 +3552,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -3567,7 +3567,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -3582,7 +3582,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -3597,7 +3597,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -3612,7 +3612,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -3627,7 +3627,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -3645,7 +3645,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -3657,7 +3657,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -3672,7 +3672,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -3688,7 +3688,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -3703,7 +3703,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -3718,7 +3718,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -3733,7 +3733,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -3757,7 +3757,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ignoreReconciliation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
+### `ignoreReconciliation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
 
 IgnoreReconciliation tells the controller to ignore reconciliation for this instance -- this
 is primarily used when migrating tenant cluster instances from project to project; this

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclusterinstances/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclusterinstances/reference.mdx
@@ -174,7 +174,7 @@ exclusive with templateRef.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -231,7 +231,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -397,7 +397,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -1013,7 +1013,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -1064,7 +1064,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
 
 
 
@@ -1136,7 +1136,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -2365,7 +2365,7 @@ VirtualCluster is the template rendered with all the parameters
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-metadata}
 
 
 
@@ -2422,7 +2422,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-instanceTemplate-metadata}
 
 
 
@@ -2588,7 +2588,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-charts-name}
 
 Name is the chart name in the repository
 
@@ -3204,7 +3204,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -3255,7 +3255,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-metadata}
 
 
 
@@ -3327,7 +3327,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-virtualCluster-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -3757,7 +3757,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ignoreReconciliation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
+### `ignoreReconciliation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-ignoreReconciliation}
 
 IgnoreReconciliation tells the controller to ignore reconciliation for this instance -- this
 is primarily used when migrating tenant cluster instances from project to project; this

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclustertemplates/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclustertemplates/reference.mdx
@@ -107,7 +107,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -164,7 +164,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -330,7 +330,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -946,7 +946,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -997,7 +997,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
 
 
 
@@ -1069,7 +1069,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -1734,7 +1734,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
 
 
 
@@ -1791,7 +1791,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -1957,7 +1957,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -2573,7 +2573,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -2624,7 +2624,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata}
 
 
 
@@ -2696,7 +2696,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 

--- a/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclustertemplates/reference.mdx
+++ b/platform_versioned_docs/version-4.10.0/api/_partials/resources/virtualclustertemplates/reference.mdx
@@ -8,7 +8,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
 
 
 
@@ -20,7 +20,7 @@ import Metadata from "../metadata/reference.mdx"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
 
 DisplayName is the name that is shown in the UI
 
@@ -35,7 +35,7 @@ DisplayName is the name that is shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
 
 Description describes the tenant cluster template
 
@@ -50,7 +50,7 @@ Description describes the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `owner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
 
 Owner holds the owner of this object
 
@@ -62,7 +62,7 @@ Owner holds the owner of this object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `user` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
 
 User specifies a Loft user.
 
@@ -77,7 +77,7 @@ User specifies a Loft user.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `team` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
 
 Team specifies a Loft team.
 
@@ -95,7 +95,7 @@ Team specifies a Loft team.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
+### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
 
 Template holds the tenant cluster template
 
@@ -107,7 +107,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
 
 
 
@@ -119,7 +119,7 @@ Template holds the tenant cluster template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -134,7 +134,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -152,7 +152,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
+#### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -164,7 +164,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata}
 
 
 
@@ -176,7 +176,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -191,7 +191,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -212,7 +212,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
+#### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -224,7 +224,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-name}
 
 Name of the target app
 
@@ -239,7 +239,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -255,7 +255,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -270,7 +270,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-version}
 
 Version of the app
 
@@ -285,7 +285,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -300,7 +300,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -318,7 +318,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
+#### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -330,7 +330,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -345,7 +345,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -360,7 +360,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -375,7 +375,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-username}
 
 The username that is required for this repository
 
@@ -390,7 +390,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -402,7 +402,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -414,7 +414,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -429,7 +429,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -444,7 +444,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -465,7 +465,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-password}
 
 The password that is required for this repository
 
@@ -480,7 +480,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -492,7 +492,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -504,7 +504,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -519,7 +519,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -534,7 +534,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -555,7 +555,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -570,7 +570,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -585,7 +585,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -600,7 +600,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -615,7 +615,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -630,7 +630,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -648,7 +648,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
+#### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -663,7 +663,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
+#### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -675,7 +675,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -691,7 +691,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -705,7 +705,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -720,7 +720,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -735,7 +735,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -756,7 +756,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro}
+#### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -768,7 +768,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -786,7 +786,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease}
+#### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -798,7 +798,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -810,7 +810,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -825,7 +825,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -840,7 +840,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -855,7 +855,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -870,7 +870,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -885,7 +885,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -903,7 +903,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-helmRelease-values}
 
 the values for the given chart
 
@@ -921,7 +921,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint}
+#### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -934,7 +934,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -946,7 +946,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -969,7 +969,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-forwardToken}
+#### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -985,7 +985,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate}
+#### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -997,7 +997,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata}
 
 
 
@@ -1009,7 +1009,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1024,7 +1024,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1042,7 +1042,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -1057,7 +1057,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1069,7 +1069,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -1084,7 +1084,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -1099,7 +1099,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -1114,7 +1114,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -1129,7 +1129,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -1141,7 +1141,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1153,7 +1153,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1168,7 +1168,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1183,7 +1183,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1204,7 +1204,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -1219,7 +1219,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -1231,7 +1231,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -1243,7 +1243,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -1258,7 +1258,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -1273,7 +1273,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -1294,7 +1294,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -1309,7 +1309,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -1324,7 +1324,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -1339,7 +1339,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -1354,7 +1354,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -1369,7 +1369,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -1387,7 +1387,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -1399,7 +1399,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -1414,7 +1414,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1430,7 +1430,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1445,7 +1445,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -1460,7 +1460,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1475,7 +1475,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -1499,7 +1499,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -1511,7 +1511,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
+#### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -1526,7 +1526,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
+#### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -1541,7 +1541,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -1556,7 +1556,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
+#### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -1572,7 +1572,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
+#### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -1587,7 +1587,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
+#### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -1602,7 +1602,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
+#### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -1617,7 +1617,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
+#### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -1632,7 +1632,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
+#### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -1647,7 +1647,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
+#### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -1662,7 +1662,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
+#### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -1677,7 +1677,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
+#### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -1692,7 +1692,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
+#### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -1710,7 +1710,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `versions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
+### `versions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions}
 
 Versions are different versions of the template that can be referenced as well
 
@@ -1722,7 +1722,7 @@ Versions are different versions of the template that can be referenced as well
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template}
+#### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template}
 
 Template holds the space template
 
@@ -1734,7 +1734,7 @@ Template holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata}
 
 
 
@@ -1746,7 +1746,7 @@ Template holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-labels}
 
 Labels are labels on the object
 
@@ -1761,7 +1761,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1779,7 +1779,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `instanceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate}
+##### `instanceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate}
 
 InstanceTemplate holds the tenant cluster instance template
 
@@ -1791,7 +1791,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata}
 
 
 
@@ -1803,7 +1803,7 @@ InstanceTemplate holds the tenant cluster instance template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -1818,7 +1818,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-instanceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -1839,7 +1839,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -1851,7 +1851,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-name}
 
 Name of the target app
 
@@ -1866,7 +1866,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -1882,7 +1882,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -1897,7 +1897,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-version}
 
 Version of the app
 
@@ -1912,7 +1912,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -1927,7 +1927,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-apps-parameters}
 
 Parameters to use for the app
 
@@ -1945,7 +1945,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts}
 
 Charts are helm charts that should get deployed
 
@@ -1957,7 +1957,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-name}
 
 Name is the chart name in the repository
 
@@ -1972,7 +1972,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-version}
 
 Version is the chart version in the repository
 
@@ -1987,7 +1987,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -2002,7 +2002,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-username}
 
 The username that is required for this repository
 
@@ -2017,7 +2017,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -2029,7 +2029,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2041,7 +2041,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2056,7 +2056,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2071,7 +2071,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2092,7 +2092,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-password}
 
 The password that is required for this repository
 
@@ -2107,7 +2107,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -2119,7 +2119,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2131,7 +2131,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2146,7 +2146,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2161,7 +2161,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2182,7 +2182,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -2197,7 +2197,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -2212,7 +2212,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -2227,7 +2227,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -2242,7 +2242,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -2257,7 +2257,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -2275,7 +2275,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-objects}
 
 Objects are Kubernetes style YAMLs that should get deployed into the tenant cluster
 
@@ -2290,7 +2290,7 @@ Objects are Kubernetes style YAMLs that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access}
+##### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access}
 
 Access defines the access of users and teams to the tenant cluster.
 
@@ -2302,7 +2302,7 @@ Access defines the access of users and teams to the tenant cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultClusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-defaultClusterRole}
+##### `defaultClusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-defaultClusterRole}
 
 Specifies which cluster role should get applied to users or teams that do not
 match a rule below.
@@ -2318,7 +2318,7 @@ match a rule below.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules}
 
 Rules defines which users and teams should have which access to the tenant
 cluster. If no rule matches an authenticated incoming user, the user will get cluster admin
@@ -2332,7 +2332,7 @@ access.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-users}
+##### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-users}
 
 Users this rule matches. * means all users.
 
@@ -2347,7 +2347,7 @@ Users this rule matches. * means all users.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-teams}
+##### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-teams}
 
 Teams that this rule matches.
 
@@ -2362,7 +2362,7 @@ Teams that this rule matches.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-access-rules-clusterRole}
 
 ClusterRole is the cluster role that should be assigned to the
 
@@ -2383,7 +2383,7 @@ ClusterRole is the cluster role that should be assigned to the
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-pro}
+##### `pro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-pro}
 
 Pro defines the pro settings for the tenant cluster
 
@@ -2395,7 +2395,7 @@ Pro defines the pro settings for the tenant cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-pro-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-pro-enabled}
 
 Enabled defines if the tenant cluster is a pro cluster or not
 
@@ -2413,7 +2413,7 @@ Enabled defines if the tenant cluster is a pro cluster or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helmRelease` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease}
+##### `helmRelease` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease}
 
 HelmRelease is the helm release configuration for the tenant cluster.
 
@@ -2425,7 +2425,7 @@ HelmRelease is the helm release configuration for the tenant cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart}
 
 infos about what chart to deploy
 
@@ -2437,7 +2437,7 @@ infos about what chart to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-name}
 
 the name of the helm chart
 
@@ -2452,7 +2452,7 @@ the name of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-repo}
 
 the repo of the helm chart
 
@@ -2467,7 +2467,7 @@ the repo of the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-username}
 
 The username that is required for this repository
 
@@ -2482,7 +2482,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-password}
 
 The password that is required for this repository
 
@@ -2497,7 +2497,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-version}
 
 the version of the helm chart to use
 
@@ -2512,7 +2512,7 @@ the version of the helm chart to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-chart-insecureSkipTlsVerify}
 
 InsecureSkipTlsVerify skips the TLS verification for the helm chart
 
@@ -2530,7 +2530,7 @@ InsecureSkipTlsVerify skips the TLS verification for the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-helmRelease-values}
 
 the values for the given chart
 
@@ -2548,7 +2548,7 @@ the values for the given chart
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `accessPoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint}
+##### `accessPoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint}
 
 AccessPoint defines settings to expose the tenant cluster directly via an ingress rather than
 through the (default) Loft proxy
@@ -2561,7 +2561,7 @@ through the (default) Loft proxy
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress}
 
 Ingress defines tenant cluster access via ingress
 
@@ -2573,7 +2573,7 @@ Ingress defines tenant cluster access via ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-accessPoint-ingress-enabled}
 
 Enabled defines if the tenant cluster access point (via ingress) is enabled or not; requires
 the connected cluster to have the `loft.sh/ingress-suffix` annotation set to define the domain
@@ -2596,7 +2596,7 @@ name suffix used for the ingress.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `forwardToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-forwardToken}
+##### `forwardToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-forwardToken}
 
 ForwardToken signals the proxy to pass through the used token to the virtual Kubernetes
 api server and do a TokenReview there.
@@ -2612,7 +2612,7 @@ api server and do a TokenReview there.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `spaceTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate}
+##### `spaceTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate}
 
 SpaceTemplate holds the space template
 
@@ -2624,7 +2624,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata}
 
 
 
@@ -2636,7 +2636,7 @@ SpaceTemplate holds the space template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata-labels}
 
 Labels are labels on the object
 
@@ -2651,7 +2651,7 @@ Labels are labels on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-metadata-annotations}
 
 Annotations are annotations on the object
 
@@ -2669,7 +2669,7 @@ Annotations are annotations on the object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-objects}
+##### `objects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-objects}
 
 Objects are Kubernetes style yamls that should get deployed into the tenant cluster namespace
 
@@ -2684,7 +2684,7 @@ Objects are Kubernetes style yamls that should get deployed into the tenant clus
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `charts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts}
+##### `charts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts}
 
 Charts are helm charts that should get deployed
 
@@ -2696,7 +2696,7 @@ Charts are helm charts that should get deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-name}
 
 Name is the chart name in the repository
 
@@ -2711,7 +2711,7 @@ Name is the chart name in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-version}
 
 Version is the chart version in the repository
 
@@ -2726,7 +2726,7 @@ Version is the chart version in the repository
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repoURL` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-repoURL}
+##### `repoURL` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-repoURL}
 
 RepoURL is the repo url where the chart can be found
 
@@ -2741,7 +2741,7 @@ RepoURL is the repo url where the chart can be found
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-username}
 
 The username that is required for this repository
 
@@ -2756,7 +2756,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `usernameRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef}
+##### `usernameRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef}
 
 The username that is required for this repository
 
@@ -2768,7 +2768,7 @@ The username that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2780,7 +2780,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2795,7 +2795,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2810,7 +2810,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-usernameRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2831,7 +2831,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-password}
 
 The password that is required for this repository
 
@@ -2846,7 +2846,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `passwordRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef}
+##### `passwordRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef}
 
 The password that is required for this repository
 
@@ -2858,7 +2858,7 @@ The password that is required for this repository
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `projectSecretRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef}
+##### `projectSecretRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef}
 
 ProjectSecretRef holds the reference to a project secret
 
@@ -2870,7 +2870,7 @@ ProjectSecretRef holds the reference to a project secret
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-project}
 
 Project is the project name where the secret is located in.
 
@@ -2885,7 +2885,7 @@ Project is the project name where the secret is located in.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-name}
 
 Name of the project secret to use.
 
@@ -2900,7 +2900,7 @@ Name of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-passwordRef-projectSecretRef-key}
 
 Key of the project secret to use.
 
@@ -2921,7 +2921,7 @@ Key of the project secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-insecureSkipTlsVerify}
+##### `insecureSkipTlsVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-insecureSkipTlsVerify}
 
 If tls certificate checks for the chart download should be skipped
 
@@ -2936,7 +2936,7 @@ If tls certificate checks for the chart download should be skipped
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-releaseName}
 
 ReleaseName is the preferred release name of the app
 
@@ -2951,7 +2951,7 @@ ReleaseName is the preferred release name of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-releaseNamespace}
+##### `releaseNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-releaseNamespace}
 
 ReleaseNamespace is the preferred release namespace of the app
 
@@ -2966,7 +2966,7 @@ ReleaseNamespace is the preferred release namespace of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-values}
 
 Values are the values that should get passed to the chart
 
@@ -2981,7 +2981,7 @@ Values are the values that should get passed to the chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-wait}
+##### `wait` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-wait}
 
 Wait determines if Loft should wait during deploy for the app to become ready
 
@@ -2996,7 +2996,7 @@ Wait determines if Loft should wait during deploy for the app to become ready
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-charts-timeout}
 
 Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
 
@@ -3014,7 +3014,7 @@ Timeout is the time to wait for any individual Kubernetes operation (like Jobs f
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps}
+##### `apps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps}
 
 Apps specifies the apps that should get deployed by this template
 
@@ -3026,7 +3026,7 @@ Apps specifies the apps that should get deployed by this template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-name}
 
 Name of the target app
 
@@ -3041,7 +3041,7 @@ Name of the target app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-namespace}
 
 Namespace specifies in which target namespace the app should
 get deployed in
@@ -3057,7 +3057,7 @@ get deployed in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `releaseName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-releaseName}
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-releaseName}
 
 ReleaseName is the name of the app release
 
@@ -3072,7 +3072,7 @@ ReleaseName is the name of the app release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-version}
 
 Version of the app
 
@@ -3087,7 +3087,7 @@ Version of the app
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hash` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-hash}
+##### `hash` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-hash}
 
 Hash is the hash of the app configuration
 
@@ -3102,7 +3102,7 @@ Hash is the hash of the app configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-template-spaceTemplate-apps-parameters}
 
 Parameters to use for the app
 
@@ -3126,7 +3126,7 @@ Parameters to use for the app
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
+#### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters}
 
 Parameters define additional app parameters that will set helm values
 
@@ -3138,7 +3138,7 @@ Parameters define additional app parameters that will set helm values
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `variable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
+##### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-variable}
 
 Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 
@@ -3153,7 +3153,7 @@ Variable is the path of the variable. Can be foo or foo.bar for nested objects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `label` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
+##### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-label}
 
 Label is the label to show for this parameter
 
@@ -3168,7 +3168,7 @@ Label is the label to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `description` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
+##### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-description}
 
 Description is the description to show for this parameter
 
@@ -3183,7 +3183,7 @@ Description is the description to show for this parameter
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-type}
 
 Type of the parameter. Can be one of:
 string, multiline, boolean, number and password
@@ -3199,7 +3199,7 @@ string, multiline, boolean, number and password
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-options}
 
 Options is a slice of strings, where each string represents a mutually exclusive choice.
 
@@ -3214,7 +3214,7 @@ Options is a slice of strings, where each string represents a mutually exclusive
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
+##### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-min}
 
 Min is the minimum number if type is number
 
@@ -3229,7 +3229,7 @@ Min is the minimum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
+##### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-max}
 
 Max is the maximum number if type is number
 
@@ -3244,7 +3244,7 @@ Max is the maximum number if type is number
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `required` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
+##### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-required}
 
 Required specifies if this parameter is required
 
@@ -3259,7 +3259,7 @@ Required specifies if this parameter is required
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `defaultValue` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
+##### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-defaultValue}
 
 DefaultValue is the default value if none is specified
 
@@ -3274,7 +3274,7 @@ DefaultValue is the default value if none is specified
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `placeholder` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
+##### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-placeholder}
 
 Placeholder shown in the UI
 
@@ -3289,7 +3289,7 @@ Placeholder shown in the UI
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `invalidation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
+##### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-invalidation}
 
 Invalidation regex that if matched will reject the input
 
@@ -3304,7 +3304,7 @@ Invalidation regex that if matched will reject the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `validation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
+##### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-validation}
 
 Validation regex that if matched will allow the input
 
@@ -3319,7 +3319,7 @@ Validation regex that if matched will allow the input
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `section` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
+##### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-parameters-section}
 
 Section where this app should be displayed. Apps with the same section name will be grouped together
 
@@ -3337,7 +3337,7 @@ Section where this app should be displayed. Apps with the same section name will
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-versions-version}
 
 Version is the version. Needs to be in X.X.X format.
 
@@ -3355,7 +3355,7 @@ Version is the version. Needs to be in X.X.X format.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `access` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
 
 Access holds the access rights for users and teams
 
@@ -3367,7 +3367,7 @@ Access holds the access rights for users and teams
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
 
 Name is an optional name that is used for this access rule
 
@@ -3397,7 +3397,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestri
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `subresources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
 
 Subresources defines the sub resources that are allowed by this access rule
 
@@ -3412,7 +3412,7 @@ Subresources defines the sub resources that are allowed by this access rule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `users` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
 
 Users specifies which users should be able to access this secret with the aforementioned verbs
 
@@ -3427,7 +3427,7 @@ Users specifies which users should be able to access this secret with the aforem
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `teams` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
 
 Teams specifies which teams should be able to access this secret with the aforementioned verbs
 
@@ -3445,7 +3445,7 @@ Teams specifies which teams should be able to access this secret with the aforem
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `spaceTemplateRef` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-spaceTemplateRef}
+### `spaceTemplateRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-spaceTemplateRef}
 
 DEPRECATED: SpaceTemplate to use to create the tenant cluster space if it does not exist
 
@@ -3457,7 +3457,7 @@ DEPRECATED: SpaceTemplate to use to create the tenant cluster space if it does n
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-spaceTemplateRef-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-spaceTemplateRef-name}
 
 Name of the space template
 
@@ -3478,7 +3478,7 @@ Name of the space template
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
 
 
 

--- a/vcluster/_partials/config/controlPlane.mdx
+++ b/vcluster/_partials/config/controlPlane.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane}
+## `controlPlane` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane}
 
 Configure vCluster's control plane components and deployment.
 
@@ -14,7 +14,7 @@ Configure vCluster's control plane components and deployment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-endpoint}
+### `endpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-endpoint}
 
 Endpoint is the endpoint of the virtual cluster. This is used to connect to the virtual cluster.
 
@@ -29,7 +29,7 @@ Endpoint is the endpoint of the virtual cluster. This is used to connect to the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
+### `distro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -41,7 +41,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s}
+#### `k8s` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -53,7 +53,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -68,7 +68,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-version}
 
 Version is the Kubernetes version to use.
 
@@ -83,7 +83,7 @@ Version is the Kubernetes version to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer}
+##### `apiServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -95,7 +95,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -110,7 +110,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -125,7 +125,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -143,7 +143,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager}
+##### `controllerManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -155,7 +155,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -170,7 +170,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -185,7 +185,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -203,7 +203,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler}
+##### `scheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler.
 
@@ -215,7 +215,7 @@ Scheduler holds configuration specific to starting the scheduler.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -230,7 +230,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -245,7 +245,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -263,7 +263,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image}
 
 Image is the distro image
 
@@ -275,7 +275,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -291,7 +291,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -306,7 +306,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -324,7 +324,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -339,7 +339,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-env}
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -354,7 +354,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -369,7 +369,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -390,7 +390,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `standalone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone}
+### `standalone` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone}
 
 Standalone holds configuration for standalone mode. Standalone mode is set automatically when no container is detected and
 also implies privateNodes.enabled.
@@ -403,7 +403,7 @@ also implies privateNodes.enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-enabled}
 
 Enabled defines if standalone mode should be enabled.
 
@@ -418,7 +418,7 @@ Enabled defines if standalone mode should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">/var/lib/vcluster</span> <span className="config-field-enum"></span> {#controlPlane-standalone-dataDir}
+#### `dataDir` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">/var/lib/vcluster</span> <span className="config-field-enum"></span> {#controlPlane-standalone-dataDir}
 
 DataDir defines the data directory for the standalone mode.
 
@@ -433,7 +433,7 @@ DataDir defines the data directory for the standalone mode.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `autoNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes}
+#### `autoNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes}
 
 AutoNodes automatically deploys nodes for standalone mode.
 
@@ -445,7 +445,7 @@ AutoNodes automatically deploys nodes for standalone mode.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `provider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-provider}
+##### `provider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-provider}
 
 Provider is the node provider of the nodes in this pool.
 
@@ -460,7 +460,7 @@ Provider is the node provider of the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `quantity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-quantity}
+##### `quantity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-quantity}
 
 Quantity is the number of nodes to deploy for standalone mode.
 
@@ -475,7 +475,7 @@ Quantity is the number of nodes to deploy for standalone mode.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector}
+##### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -488,7 +488,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -503,7 +503,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -518,7 +518,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -533,7 +533,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -554,7 +554,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode}
+#### `joinNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode}
 
 JoinNode holds configuration for the standalone control plane node.
 
@@ -566,7 +566,7 @@ JoinNode holds configuration for the standalone control plane node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-enabled}
 
 Enabled defines if the standalone node should be joined into the cluster. If false, only the control plane binaries will be executed and no node will show up in the actual cluster.
 
@@ -581,7 +581,7 @@ Enabled defines if the standalone node should be joined into the cluster. If fal
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `preInstallCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-preInstallCommands}
+##### `preInstallCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-preInstallCommands}
 
 PreInstallCommands are commands that will be executed before containerd, kubelet etc. is installed.
 
@@ -596,7 +596,7 @@ PreInstallCommands are commands that will be executed before containerd, kubelet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-preJoinCommands}
+##### `preJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-preJoinCommands}
 
 PreJoinCommands are commands that will be executed before kubeadm join is executed.
 
@@ -611,7 +611,7 @@ PreJoinCommands are commands that will be executed before kubeadm join is execut
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-postJoinCommands}
+##### `postJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-postJoinCommands}
 
 PostJoinCommands are commands that will be executed after kubeadm join is executed.
 
@@ -626,7 +626,7 @@ PostJoinCommands are commands that will be executed after kubeadm join is execut
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd}
+##### `containerd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd}
 
 Containerd holds configuration for the containerd join process.
 
@@ -638,7 +638,7 @@ Containerd holds configuration for the containerd join process.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-enabled}
 
 Enabled defines if containerd should be installed and configured by vCluster.
 
@@ -653,7 +653,7 @@ Enabled defines if containerd should be installed and configured by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry}
 
 Registry holds configuration for how containerd should be configured to use a registries.
 
@@ -665,7 +665,7 @@ Registry holds configuration for how containerd should be configured to use a re
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-configPath}
+##### `configPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-configPath}
 
 ConfigPath is the path to the containerd registry config.
 
@@ -680,7 +680,7 @@ ConfigPath is the path to the containerd registry config.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors}
+##### `mirrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors}
 
 Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -692,7 +692,7 @@ Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-server}
 
 Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -707,7 +707,7 @@ Server is the fallback server to use for the containerd registry mirror. E.g. ht
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror.
 
@@ -722,7 +722,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -737,7 +737,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -752,7 +752,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -767,7 +767,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts}
+##### `hosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts}
 
 Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -779,7 +779,7 @@ Hosts holds configuration for the containerd registry mirror hosts. See https://
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-server}
 
 Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
 
@@ -794,7 +794,7 @@ Server is the server to use for the containerd registry mirror host. E.g. http:/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror host.
 
@@ -809,7 +809,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror ho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -824,7 +824,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -839,7 +839,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -860,7 +860,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth}
 
 Auth holds configuration for the containerd registry auth. See https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials for more details.
 
@@ -872,7 +872,7 @@ Auth holds configuration for the containerd registry auth. See https://github.co
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-username}
 
 Username is the username for the containerd registry.
 
@@ -887,7 +887,7 @@ Username is the username for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-password}
 
 Password is the password for the containerd registry.
 
@@ -902,7 +902,7 @@ Password is the password for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-identityToken}
+##### `identityToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-identityToken}
 
 IdentityToken is the token for the containerd registry.
 
@@ -917,7 +917,7 @@ IdentityToken is the token for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-auth}
 
 Auth is the auth config for the containerd registry.
 
@@ -938,7 +938,7 @@ Auth is the auth config for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-pauseImage}
+##### `pauseImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-pauseImage}
 
 PauseImage is the image for the pause container.
 
@@ -956,7 +956,7 @@ PauseImage is the image for the pause container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-caCertPath}
+##### `caCertPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-caCertPath}
 
 CACertPath is the path to the SSL certificate authority used to
 secure communications between node and control-plane.
@@ -973,7 +973,7 @@ Defaults to "/etc/kubernetes/pki/ca.crt".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-skipPhases}
+##### `skipPhases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-skipPhases}
 
 SkipPhases is a list of phases to skip during command execution.
 The list of phases can be obtained with the "kubeadm join --help" command.
@@ -989,7 +989,7 @@ The list of phases can be obtained with the "kubeadm join --help" command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration}
+##### `nodeRegistration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration}
 
 NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
 
@@ -1001,7 +1001,7 @@ NodeRegistration holds configuration for the node registration similar to the ku
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-criSocket}
+##### `criSocket` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-criSocket}
 
 CRI socket is the socket for the CRI.
 
@@ -1016,7 +1016,7 @@ CRI socket is the socket for the CRI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs}
+##### `kubeletExtraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs}
 
 KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
 kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
@@ -1032,7 +1032,7 @@ Extra arguments will override existing default arguments. Duplicate extra argume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-name}
 
 Name is the name of the argument.
 
@@ -1047,7 +1047,7 @@ Name is the name of the argument.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-value}
 
 Value is the value of the argument.
 
@@ -1065,7 +1065,7 @@ Value is the value of the argument.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints}
+##### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints}
 
 Taints are additional taints to set for the kubelet.
 
@@ -1077,7 +1077,7 @@ Taints are additional taints to set for the kubelet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -1092,7 +1092,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -1107,7 +1107,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -1127,7 +1127,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-ignorePreflightErrors}
+##### `ignorePreflightErrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-ignorePreflightErrors}
 
 IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
 Value 'all' ignores errors from all checks.
@@ -1143,7 +1143,7 @@ Value 'all' ignores errors from all checks.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-imagePullPolicy}
 
 ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
 The value of this field must be one of "Always", "IfNotPresent" or "Never".
@@ -1169,7 +1169,7 @@ If this field is unset kubeadm will default it to "IfNotPresent", or pull the re
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore}
+### `backingStore` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore}
 
 BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
 
@@ -1181,7 +1181,7 @@ BackingStore defines which backing store to use for virtual cluster. If not defi
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd}
+#### `etcd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd}
 
 Etcd defines that etcd should be used as the backend for the virtual cluster
 
@@ -1193,7 +1193,7 @@ Etcd defines that etcd should be used as the backend for the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded}
+##### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -1205,7 +1205,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -1220,7 +1220,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-migrateFromDeployedEtcd}
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -1235,7 +1235,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-snapshotCount}
+##### `snapshotCount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -1250,7 +1250,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to the embedded etcd.
 
@@ -1268,7 +1268,7 @@ ExtraArgs are additional arguments to pass to the embedded etcd.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy}
+##### `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -1280,7 +1280,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -1295,7 +1295,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet}
+##### `statefulSet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -1307,7 +1307,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -1322,7 +1322,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+##### `enableServiceLinks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -1337,7 +1337,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -1349,7 +1349,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -1365,7 +1365,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -1380,7 +1380,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -1398,7 +1398,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -1413,7 +1413,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-env}
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -1428,7 +1428,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -1443,7 +1443,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -1455,7 +1455,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -1470,7 +1470,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -1488,7 +1488,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods}
+##### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -1500,7 +1500,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1515,7 +1515,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -1533,7 +1533,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability}
+##### `highAvailability` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -1545,7 +1545,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -1563,7 +1563,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling}
+##### `scheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -1575,7 +1575,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -1590,7 +1590,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -1605,7 +1605,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -1620,7 +1620,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -1635,7 +1635,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -1650,7 +1650,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -1668,7 +1668,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security}
+##### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -1680,7 +1680,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -1695,7 +1695,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -1713,7 +1713,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence}
+##### `persistence` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -1725,7 +1725,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -1737,7 +1737,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -1752,7 +1752,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -1767,7 +1767,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -1782,7 +1782,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -1797,7 +1797,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -1815,7 +1815,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -1830,7 +1830,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -1845,7 +1845,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -1857,7 +1857,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -1872,7 +1872,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -1888,7 +1888,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -1904,7 +1904,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -1920,7 +1920,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -1938,7 +1938,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -1962,7 +1962,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1977,7 +1977,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -1995,7 +1995,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -2007,7 +2007,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -2022,7 +2022,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -2040,7 +2040,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService}
+##### `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -2052,7 +2052,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 
@@ -2073,7 +2073,7 @@ Annotations are extra annotations for the external etcd headless service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external}
+##### `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external}
 
 External defines to use a self-hosted external etcd that is not deployed by the helm chart
 
@@ -2085,7 +2085,7 @@ External defines to use a self-hosted external etcd that is not deployed by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-enabled}
 
 Enabled defines if the external etcd should be used.
 
@@ -2100,7 +2100,7 @@ Enabled defines if the external etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-endpoint}
+##### `endpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-endpoint}
 
 Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379
 
@@ -2115,7 +2115,7 @@ Endpoint holds the endpoint of the external etcd server, e.g. my-example-service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls}
+##### `tls` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls}
 
 TLS defines the tls configuration for the external etcd server
 
@@ -2127,7 +2127,7 @@ TLS defines the tls configuration for the external etcd server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-caFile}
 
 CaFile is the path to the ca file
 
@@ -2142,7 +2142,7 @@ CaFile is the path to the ca file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-certFile}
 
 CertFile is the path to the cert file
 
@@ -2157,7 +2157,7 @@ CertFile is the path to the cert file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-keyFile}
 
 KeyFile is the path to the key file
 
@@ -2181,7 +2181,7 @@ KeyFile is the path to the key file
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database}
+#### `database` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database}
 
 Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
 
@@ -2193,7 +2193,7 @@ Database defines that a database backend should be used as the backend for the v
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded}
+##### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -2205,7 +2205,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -2220,7 +2220,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -2238,7 +2238,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-identityProvider}
+##### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -2255,7 +2255,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -2270,7 +2270,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -2285,7 +2285,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -2300,7 +2300,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -2318,7 +2318,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external}
+##### `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -2330,7 +2330,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -2345,7 +2345,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -2363,7 +2363,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-identityProvider}
+##### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -2380,7 +2380,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -2395,7 +2395,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -2410,7 +2410,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -2425,7 +2425,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -2440,7 +2440,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-connector}
+##### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.
@@ -2467,7 +2467,7 @@ This is optional.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns}
+### `coredns` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns}
 
 CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
 
@@ -2479,7 +2479,7 @@ CoreDNS defines everything related to the coredns that is deployed and used with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-coredns-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-coredns-enabled}
 
 Enabled defines if coredns is enabled
 
@@ -2494,7 +2494,7 @@ Enabled defines if coredns is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-coredns-embedded}
+#### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-coredns-embedded}
 
 Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
 
@@ -2509,7 +2509,7 @@ Embedded defines if vCluster will start the embedded coredns service within the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-security}
+#### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-security}
 
 Security defines pod or container security context.
 
@@ -2521,7 +2521,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -2536,7 +2536,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -2554,7 +2554,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-service}
+#### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-service}
 
 Service holds extra options for the coredns service deployed within the virtual cluster
 
@@ -2566,7 +2566,7 @@ Service holds extra options for the coredns service deployed within the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-spec}
+##### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-spec}
 
 Spec holds extra options for the coredns service
 
@@ -2581,7 +2581,7 @@ Spec holds extra options for the coredns service
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2596,7 +2596,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -2614,7 +2614,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment}
+#### `deployment` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment}
 
 Deployment holds extra options for the coredns deployment deployed within the virtual cluster
 
@@ -2626,7 +2626,7 @@ Deployment holds extra options for the coredns deployment deployed within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-image}
 
 Image is the coredns image to use
 
@@ -2641,7 +2641,7 @@ Image is the coredns image to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-replicas}
 
 Replicas is the amount of coredns pods to run.
 
@@ -2656,7 +2656,7 @@ Replicas is the amount of coredns pods to run.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-nodeSelector}
 
 NodeSelector is the node selector to use for coredns.
 
@@ -2671,7 +2671,7 @@ NodeSelector is the node selector to use for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-affinity}
+##### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -2686,7 +2686,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -2701,7 +2701,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources}
 
 Resources are the desired resources for coredns.
 
@@ -2713,7 +2713,7 @@ Resources are the desired resources for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-limits}
 
 Limits are resource limits for the container
 
@@ -2728,7 +2728,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -2746,7 +2746,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods}
+##### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods}
 
 Pods is additional metadata for the coredns pods.
 
@@ -2758,7 +2758,7 @@ Pods is additional metadata for the coredns pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2773,7 +2773,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -2791,7 +2791,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2806,7 +2806,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-labels}
 
 Labels are extra labels for this resource.
 
@@ -2821,7 +2821,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
 
@@ -2839,7 +2839,7 @@ TopologySpreadConstraints are the topology spread constraints for the CoreDNS po
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteConfig}
+#### `overwriteConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteConfig}
 
 OverwriteConfig can be used to overwrite the coredns config
 
@@ -2854,7 +2854,7 @@ OverwriteConfig can be used to overwrite the coredns config
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteManifests}
+#### `overwriteManifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteManifests}
 
 OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
 
@@ -2869,7 +2869,7 @@ OverwriteManifests can be used to overwrite the coredns manifests used to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-priorityClassName}
 
 PriorityClassName specifies the priority class name for the CoreDNS pods.
 
@@ -2887,7 +2887,7 @@ PriorityClassName specifies the priority class name for the CoreDNS pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-proxy}
+### `proxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-proxy}
 
 Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
 
@@ -2899,7 +2899,7 @@ Proxy defines options for the virtual cluster control plane proxy that is used t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#controlPlane-proxy-bindAddress}
+#### `bindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#controlPlane-proxy-bindAddress}
 
 BindAddress under which vCluster will expose the proxy.
 
@@ -2914,7 +2914,7 @@ BindAddress under which vCluster will expose the proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#controlPlane-proxy-port}
+#### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#controlPlane-proxy-port}
 
 Port under which vCluster will expose the proxy. Changing port is currently not supported.
 
@@ -2929,7 +2929,7 @@ Port under which vCluster will expose the proxy. Changing port is currently not 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-proxy-extraSANs}
+#### `extraSANs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-proxy-extraSANs}
 
 ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 
@@ -2947,7 +2947,7 @@ ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper}
+### `hostPathMapper` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper}
 
 HostPathMapper defines if vCluster should rewrite host paths.
 
@@ -2959,7 +2959,7 @@ HostPathMapper defines if vCluster should rewrite host paths.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-enabled}
 
 Enabled specifies if the host path mapper will be used
 
@@ -2974,7 +2974,7 @@ Enabled specifies if the host path mapper will be used
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-central}
+#### `central` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-central}
 
 Central specifies if the central host path mapper will be used
 
@@ -2992,7 +2992,7 @@ Central specifies if the central host path mapper will be used
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-ingress}
+### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-ingress}
 
 Ingress defines options for vCluster ingress deployed by Helm.
 
@@ -3004,7 +3004,7 @@ Ingress defines options for vCluster ingress deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-ingress-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-ingress-enabled}
 
 Enabled defines if the control plane ingress should be enabled
 
@@ -3019,7 +3019,7 @@ Enabled defines if the control plane ingress should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-ingress-host}
+#### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-ingress-host}
 
 Host is the host where vCluster will be reachable
 
@@ -3034,7 +3034,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#controlPlane-ingress-pathType}
+#### `pathType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#controlPlane-ingress-pathType}
 
 PathType is the path type of the ingress
 
@@ -3049,7 +3049,7 @@ PathType is the path type of the ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-spec}
 
 Spec allows you to configure extra ingress options.
 
@@ -3064,7 +3064,7 @@ Spec allows you to configure extra ingress options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3079,7 +3079,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-labels}
 
 Labels are extra labels for this resource.
 
@@ -3097,7 +3097,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `tlsRoute` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute}
+### `tlsRoute` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute}
 
 TLSRoute defines options for vCluster TLS route deployed by Helm.
 
@@ -3109,7 +3109,7 @@ TLSRoute defines options for vCluster TLS route deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-enabled}
 
 Enabled defines if the control plane should be exposed via a gateway api tls route. Make sure to enable tls passthrough in the gateway via tls.mode to "Passthrough"
 
@@ -3124,7 +3124,7 @@ Enabled defines if the control plane should be exposed via a gateway api tls rou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">gateway.networking.k8s.io/v1</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">gateway.networking.k8s.io/v1</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-apiVersion}
 
 APIVersion is the version of the gateway api tls route.
 
@@ -3139,7 +3139,7 @@ APIVersion is the version of the gateway api tls route.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-host}
+#### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-host}
 
 Host is the host where vCluster will be reachable
 
@@ -3154,7 +3154,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `parentRefs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-parentRefs}
+#### `parentRefs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-parentRefs}
 
 ParentRefs are the parent references for the TLS route
 
@@ -3169,7 +3169,7 @@ ParentRefs are the parent references for the TLS route
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-spec}
 
 Spec allows you to configure extra tls route options.
 
@@ -3184,7 +3184,7 @@ Spec allows you to configure extra tls route options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3199,7 +3199,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-labels}
 
 Labels are extra labels for this resource.
 
@@ -3217,7 +3217,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-service}
+### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-service}
 
 Service defines options for vCluster service deployed by Helm.
 
@@ -3229,7 +3229,7 @@ Service defines options for vCluster service deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-service-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-service-enabled}
 
 Enabled defines if the control plane service should be enabled
 
@@ -3244,7 +3244,7 @@ Enabled defines if the control plane service should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-service-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-service-spec}
 
 Spec allows you to configure extra service options.
 
@@ -3259,7 +3259,7 @@ Spec allows you to configure extra service options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-kubeletNodePort}
+#### `kubeletNodePort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-kubeletNodePort}
 
 KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
 
@@ -3274,7 +3274,7 @@ KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-httpsNodePort}
+#### `httpsNodePort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-httpsNodePort}
 
 HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 
@@ -3289,7 +3289,7 @@ HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3304,7 +3304,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -3322,7 +3322,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet}
+### `statefulSet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet}
 
 StatefulSet defines options for vCluster statefulSet deployed by Helm.
 
@@ -3334,7 +3334,7 @@ StatefulSet defines options for vCluster statefulSet deployed by Helm.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability}
+#### `highAvailability` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability}
 
 HighAvailability holds options related to high availability.
 
@@ -3346,7 +3346,7 @@ HighAvailability holds options related to high availability.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-replicas}
 
 Replicas is the amount of replicas to use for the statefulSet.
 
@@ -3361,7 +3361,7 @@ Replicas is the amount of replicas to use for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-leaseDuration}
+##### `leaseDuration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-leaseDuration}
 
 LeaseDuration is the time to lease for the leader.
 
@@ -3376,7 +3376,7 @@ LeaseDuration is the time to lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-renewDeadline}
+##### `renewDeadline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-renewDeadline}
 
 RenewDeadline is the deadline to renew a lease for the leader.
 
@@ -3391,7 +3391,7 @@ RenewDeadline is the deadline to renew a lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-retryPeriod}
+##### `retryPeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-retryPeriod}
 
 RetryPeriod is the time until a replica will retry to get a lease.
 
@@ -3409,7 +3409,7 @@ RetryPeriod is the time until a replica will retry to get a lease.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources}
 
 Resources are the resource requests and limits for the statefulSet container.
 
@@ -3421,7 +3421,7 @@ Resources are the resource requests and limits for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:10Gi memory:4Gi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:10Gi memory:4Gi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -3436,7 +3436,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:1Gi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:1Gi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -3454,7 +3454,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling}
+#### `scheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling}
 
 Scheduling holds options related to scheduling.
 
@@ -3466,7 +3466,7 @@ Scheduling holds options related to scheduling.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -3481,7 +3481,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -3496,7 +3496,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -3511,7 +3511,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -3526,7 +3526,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -3541,7 +3541,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -3559,7 +3559,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security}
+#### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security}
 
 Security defines pod or container security context.
 
@@ -3571,7 +3571,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -3586,7 +3586,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -3604,7 +3604,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes}
+#### `probes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes}
 
 Probes enables or disables the main container probes.
 
@@ -3616,7 +3616,7 @@ Probes enables or disables the main container probes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe}
+##### `livenessProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe}
 
 LivenessProbe specifies if the liveness probe for the container should be enabled
 
@@ -3628,7 +3628,7 @@ LivenessProbe specifies if the liveness probe for the container should be enable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3643,7 +3643,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -3658,7 +3658,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initialDelaySeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-initialDelaySeconds}
+##### `initialDelaySeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-initialDelaySeconds}
 
 Time (in seconds) to wait before starting the liveness probe
 
@@ -3673,7 +3673,7 @@ Time (in seconds) to wait before starting the liveness probe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -3688,7 +3688,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -3706,7 +3706,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe}
+##### `readinessProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe}
 
 ReadinessProbe specifies if the readiness probe for the container should be enabled
 
@@ -3718,7 +3718,7 @@ ReadinessProbe specifies if the readiness probe for the container should be enab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3733,7 +3733,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -3748,7 +3748,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -3763,7 +3763,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -3781,7 +3781,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe}
+##### `startupProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe}
 
 StartupProbe specifies if the startup probe for the container should be enabled
 
@@ -3793,7 +3793,7 @@ StartupProbe specifies if the startup probe for the container should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3808,7 +3808,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-failureThreshold}
 
 Number of consecutive failures allowed before failing the pod
 
@@ -3823,7 +3823,7 @@ Number of consecutive failures allowed before failing the pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -3838,7 +3838,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -3859,7 +3859,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence}
+#### `persistence` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence}
 
 Persistence defines options around persistence for the statefulSet.
 
@@ -3871,7 +3871,7 @@ Persistence defines options around persistence for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -3883,7 +3883,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
 based on the chosen distro and other options if this is required.
@@ -3899,7 +3899,7 @@ based on the chosen distro and other options if this is required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -3914,7 +3914,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -3929,7 +3929,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -3944,7 +3944,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -3962,7 +3962,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -3977,7 +3977,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-dataVolume}
+##### `dataVolume` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-dataVolume}
 
 Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
 
@@ -3992,7 +3992,7 @@ Allows you to override the dataVolume. Only works correctly if volumeClaim.enabl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-binariesVolume}
+##### `binariesVolume` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-binariesVolume}
 
 BinariesVolume defines a binaries volume that is used to retrieve
 distro specific executables to be run by the syncer controller.
@@ -4009,7 +4009,7 @@ This volume doesn't need to be persistent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -4024,7 +4024,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -4036,7 +4036,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -4051,7 +4051,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -4067,7 +4067,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -4083,7 +4083,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -4099,7 +4099,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -4117,7 +4117,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -4141,7 +4141,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-enableServiceLinks}
+#### `enableServiceLinks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -4156,7 +4156,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4171,7 +4171,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -4186,7 +4186,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods}
+#### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods}
 
 Additional labels or annotations for the statefulSet pods.
 
@@ -4198,7 +4198,7 @@ Additional labels or annotations for the statefulSet pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4213,7 +4213,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -4231,7 +4231,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image}
 
 Image is the image for the controlPlane statefulSet container
 It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
@@ -4245,7 +4245,7 @@ If you still want to use the pure OSS build, set the repository to 'loft-sh/vclu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -4261,7 +4261,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -4276,7 +4276,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -4294,7 +4294,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -4309,7 +4309,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-workingDir}
+#### `workingDir` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-workingDir}
 
 WorkingDir specifies in what folder the main process should get started.
 
@@ -4324,7 +4324,7 @@ WorkingDir specifies in what folder the main process should get started.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-command}
+#### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-command}
 
 Command allows you to override the main command.
 
@@ -4339,7 +4339,7 @@ Command allows you to override the main command.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-args}
+#### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-args}
 
 Args allows you to override the main arguments.
 
@@ -4354,7 +4354,7 @@ Args allows you to override the main arguments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-env}
+#### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-env}
 
 Env are additional environment variables for the statefulSet container.
 
@@ -4369,7 +4369,7 @@ Env are additional environment variables for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsPolicy}
+#### `dnsPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsPolicy}
 
 Set DNS policy for the pod.
 
@@ -4384,7 +4384,7 @@ Set DNS policy for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig}
+#### `dnsConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig}
 
 Specifies the DNS parameters of a pod.
 
@@ -4396,7 +4396,7 @@ Specifies the DNS parameters of a pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-nameservers}
+##### `nameservers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-nameservers}
 
 A list of DNS name server IP addresses.
 This will be appended to the base nameservers generated from DNSPolicy.
@@ -4413,7 +4413,7 @@ Duplicated nameservers will be removed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-searches}
+##### `searches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-searches}
 
 A list of DNS search domains for host-name lookup.
 This will be appended to the base search paths generated from DNSPolicy.
@@ -4430,7 +4430,7 @@ Duplicated search paths will be removed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options}
 
 A list of DNS resolver options.
 This will be merged with the base options generated from DNSPolicy.
@@ -4445,7 +4445,7 @@ will override those that appear in the base DNSPolicy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-name}
 
 Required.
 
@@ -4460,7 +4460,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-value}
 
 
 
@@ -4481,7 +4481,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `initContainers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-initContainers}
+#### `initContainers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-initContainers}
 
 InitContainers are additional init containers for the statefulSet.
 
@@ -4496,7 +4496,7 @@ InitContainers are additional init containers for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `sidecarContainers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-sidecarContainers}
+#### `sidecarContainers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-sidecarContainers}
 
 SidecarContainers are additional sidecar containers for the statefulSet.
 
@@ -4511,7 +4511,7 @@ SidecarContainers are additional sidecar containers for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hostAliases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases}
+#### `hostAliases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases}
 
 HostAliases allows you to add custom entries to the /etc/hosts file of each Pod created.
 
@@ -4523,7 +4523,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases-ip}
+##### `ip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases-ip}
 
 
 
@@ -4538,7 +4538,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostnames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases-hostnames}
+##### `hostnames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases-hostnames}
 
 
 
@@ -4556,7 +4556,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-runtimeClassName}
+#### `runtimeClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for the statefulSet pods.
 
@@ -4574,7 +4574,7 @@ RuntimeClassName is the runtime class to set for the statefulSet pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor}
+### `serviceMonitor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor}
 
 ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
 
@@ -4586,7 +4586,7 @@ ServiceMonitor can be used to automatically create a service monitor for vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-enabled}
 
 Enabled configures if Helm should create the service monitor.
 
@@ -4601,7 +4601,7 @@ Enabled configures if Helm should create the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-labels}
 
 Labels are the extra labels to add to the service monitor.
 
@@ -4616,7 +4616,7 @@ Labels are the extra labels to add to the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-annotations}
 
 Annotations are the extra annotations to add to the service monitor.
 
@@ -4634,7 +4634,7 @@ Annotations are the extra annotations to add to the service monitor.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced}
+### `advanced` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced}
 
 Advanced holds additional configuration for the vCluster control plane.
 
@@ -4646,7 +4646,7 @@ Advanced holds additional configuration for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-defaultImageRegistry}
+#### `defaultImageRegistry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
@@ -4662,7 +4662,7 @@ upload all required vCluster images to a single private repository and set this 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler}
+#### `virtualScheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
@@ -4675,7 +4675,7 @@ Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4693,7 +4693,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount}
+#### `serviceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -4705,7 +4705,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -4720,7 +4720,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -4735,7 +4735,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets}
+##### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -4747,7 +4747,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -4765,7 +4765,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4780,7 +4780,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -4798,7 +4798,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount}
+#### `workloadServiceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -4810,7 +4810,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -4825,7 +4825,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -4840,7 +4840,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets}
+##### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -4852,7 +4852,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -4870,7 +4870,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4885,7 +4885,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -4903,7 +4903,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService}
+#### `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -4915,7 +4915,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4930,7 +4930,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-labels}
 
 Labels are extra labels for this resource.
 
@@ -4948,7 +4948,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `konnectivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity}
+#### `konnectivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity}
 
 Konnectivity holds dedicated konnectivity configuration. This is only available when privateNodes.enabled is true.
 
@@ -4960,7 +4960,7 @@ Konnectivity holds dedicated konnectivity configuration. This is only available 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server}
 
 Server holds configuration for the konnectivity server.
 
@@ -4972,7 +4972,7 @@ Server holds configuration for the konnectivity server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-enabled}
 
 Enabled defines if the konnectivity server should be enabled.
 
@@ -4987,7 +4987,7 @@ Enabled defines if the konnectivity server should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity server.
 
@@ -5005,7 +5005,7 @@ ExtraArgs are additional arguments to pass to the konnectivity server.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `agent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent}
+##### `agent` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent}
 
 Agent holds configuration for the konnectivity agent.
 
@@ -5017,7 +5017,7 @@ Agent holds configuration for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-enabled}
 
 Enabled defines if the konnectivity agent should be enabled.
 
@@ -5032,7 +5032,7 @@ Enabled defines if the konnectivity agent should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-replicas}
 
 Replicas is the number of replicas for the konnectivity agent.
 
@@ -5047,7 +5047,7 @@ Replicas is the number of replicas for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-image}
 
 Image is the image for the konnectivity agent.
 
@@ -5062,7 +5062,7 @@ Image is the image for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -5077,7 +5077,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-nodeSelector}
 
 NodeSelector is the node selector for the konnectivity agent.
 
@@ -5092,7 +5092,7 @@ NodeSelector is the node selector for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-priorityClassName}
 
 PriorityClassName is the priority class name for the konnectivity agent.
 
@@ -5107,7 +5107,7 @@ PriorityClassName is the priority class name for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-tolerations}
 
 Tolerations is the tolerations for the konnectivity agent.
 
@@ -5122,7 +5122,7 @@ Tolerations is the tolerations for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraEnv}
 
 ExtraEnv is the extra environment variables for the konnectivity agent.
 
@@ -5137,7 +5137,7 @@ ExtraEnv is the extra environment variables for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity agent.
 
@@ -5158,7 +5158,7 @@ ExtraArgs are additional arguments to pass to the konnectivity agent.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry}
+#### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry}
 
 Registry allows enabling an embedded docker image registry in vCluster. This is useful for air-gapped environments or when you don't have a public registry available to distribute images.
 
@@ -5170,7 +5170,7 @@ Registry allows enabling an embedded docker image registry in vCluster. This is 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-enabled}
 
 Enabled defines if the embedded registry should be enabled.
 
@@ -5185,7 +5185,7 @@ Enabled defines if the embedded registry should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `anonymousPull` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-anonymousPull}
+##### `anonymousPull` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-anonymousPull}
 
 AnonymousPull allows enabling anonymous pull for the embedded registry. This allows anybody to pull images from the registry without authentication.
 
@@ -5200,7 +5200,7 @@ AnonymousPull allows enabling anonymous pull for the embedded registry. This all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-config}
+##### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-config}
 
 Config is the regular docker registry config. See https://distribution.github.io/distribution/about/configuration/ for more details.
 
@@ -5218,7 +5218,7 @@ Config is the regular docker registry config. See https://distribution.github.io
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `cloudControllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-cloudControllerManager}
+#### `cloudControllerManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-cloudControllerManager}
 
 CloudControllerManager holds configuration for the embedded cloud controller manager. This is only available when private nodes are enabled.
 The cloud controller manager is responsible for setting the node's ip addresses as well as the provider id for the node and other node metadata.
@@ -5231,7 +5231,7 @@ The cloud controller manager is responsible for setting the node's ip addresses 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-cloudControllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-cloudControllerManager-enabled}
 
 Enabled defines if the embedded cloud controller manager should be enabled. This defaults to true, but can be disabled if you want to use
 an external cloud controller manager such as AWS or GCP. The cloud controller manager is responsible for setting the node's ip addresses as well
@@ -5251,7 +5251,7 @@ as the provider id for the node and other node metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata}
+#### `globalMetadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -5263,7 +5263,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -5281,7 +5281,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `kubeVip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip}
+#### `kubeVip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip}
 
 KubeVip holds configuration for embedded kube-vip that announces the virtual cluster endpoint IP on layer 2.
 
@@ -5293,7 +5293,7 @@ KubeVip holds configuration for embedded kube-vip that announces the virtual clu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-enabled}
 
 Enabled defines if embedded kube-vip should be enabled.
 
@@ -5308,7 +5308,7 @@ Enabled defines if embedded kube-vip should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `interface` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-interface}
+##### `interface` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-interface}
 
 Interface is the network interface on which the VIP is announced.
 
@@ -5323,7 +5323,7 @@ Interface is the network interface on which the VIP is announced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gateway` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-gateway}
+##### `gateway` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-gateway}
 
 Gateway is the gateway address in CIDR notation (e.g., 10.100.0.1/24).
 This is used to configure policy-based routing for the VIP and must include the subnet prefix.
@@ -5342,7 +5342,7 @@ This is used to configure policy-based routing for the VIP and must include the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `podDisruptionBudget` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget}
+#### `podDisruptionBudget` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget}
 
 PodDisruptionBudget limits how many pods of an application can be voluntarily disrupted at once
 to ensure availability during maintenance or scaling operations.
@@ -5355,7 +5355,7 @@ to ensure availability during maintenance or scaling operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-enabled}
 
 Enabled defines if the pod disruption budget should be enabled.
 
@@ -5370,7 +5370,7 @@ Enabled defines if the pod disruption budget should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `minAvailable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-minAvailable}
+##### `minAvailable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-minAvailable}
 
 MinAvailable describes the minimal number or percentage of available pods.
 
@@ -5385,7 +5385,7 @@ MinAvailable describes the minimal number or percentage of available pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxUnavailable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-maxUnavailable}
+##### `maxUnavailable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-maxUnavailable}
 
 MaxUnavailable describes the minimal number or percentage of unavailable pods.
 
@@ -5400,7 +5400,7 @@ MaxUnavailable describes the minimal number or percentage of unavailable pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `unhealthyPodEvictionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-unhealthyPodEvictionPolicy}
+##### `unhealthyPodEvictionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-unhealthyPodEvictionPolicy}
 
 UnhealthyPodEvictionPolicy defines the criteria when unhealthy pods should be considered for eviction.
 Currently supported values are:

--- a/vcluster/_partials/config/controlPlane/advanced.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds additional configuration for the vCluster control plane.
 
@@ -14,7 +14,7 @@ Advanced holds additional configuration for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-defaultImageRegistry}
+### `defaultImageRegistry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
@@ -30,7 +30,7 @@ upload all required vCluster images to a single private repository and set this 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-virtualScheduler}
+### `virtualScheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
@@ -43,7 +43,7 @@ Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-virtualScheduler-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -61,7 +61,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -73,7 +73,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -88,7 +88,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -103,7 +103,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -115,7 +115,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -133,7 +133,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -148,7 +148,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -166,7 +166,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount}
+### `workloadServiceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -178,7 +178,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -193,7 +193,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -208,7 +208,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -220,7 +220,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -238,7 +238,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -253,7 +253,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -271,7 +271,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -283,7 +283,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -298,7 +298,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-labels}
 
 Labels are extra labels for this resource.
 
@@ -316,7 +316,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `konnectivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity}
+### `konnectivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity}
 
 Konnectivity holds dedicated konnectivity configuration. This is only available when privateNodes.enabled is true.
 
@@ -328,7 +328,7 @@ Konnectivity holds dedicated konnectivity configuration. This is only available 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-server}
+#### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-server}
 
 Server holds configuration for the konnectivity server.
 
@@ -340,7 +340,7 @@ Server holds configuration for the konnectivity server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-enabled}
 
 Enabled defines if the konnectivity server should be enabled.
 
@@ -355,7 +355,7 @@ Enabled defines if the konnectivity server should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity server.
 
@@ -373,7 +373,7 @@ ExtraArgs are additional arguments to pass to the konnectivity server.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `agent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent}
+#### `agent` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent}
 
 Agent holds configuration for the konnectivity agent.
 
@@ -385,7 +385,7 @@ Agent holds configuration for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-enabled}
 
 Enabled defines if the konnectivity agent should be enabled.
 
@@ -400,7 +400,7 @@ Enabled defines if the konnectivity agent should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-replicas}
 
 Replicas is the number of replicas for the konnectivity agent.
 
@@ -415,7 +415,7 @@ Replicas is the number of replicas for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-image}
 
 Image is the image for the konnectivity agent.
 
@@ -430,7 +430,7 @@ Image is the image for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -445,7 +445,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-nodeSelector}
 
 NodeSelector is the node selector for the konnectivity agent.
 
@@ -460,7 +460,7 @@ NodeSelector is the node selector for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-priorityClassName}
 
 PriorityClassName is the priority class name for the konnectivity agent.
 
@@ -475,7 +475,7 @@ PriorityClassName is the priority class name for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-tolerations}
 
 Tolerations is the tolerations for the konnectivity agent.
 
@@ -490,7 +490,7 @@ Tolerations is the tolerations for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraEnv}
 
 ExtraEnv is the extra environment variables for the konnectivity agent.
 
@@ -505,7 +505,7 @@ ExtraEnv is the extra environment variables for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity agent.
 
@@ -526,7 +526,7 @@ ExtraArgs are additional arguments to pass to the konnectivity agent.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-registry}
+### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-registry}
 
 Registry allows enabling an embedded docker image registry in vCluster. This is useful for air-gapped environments or when you don't have a public registry available to distribute images.
 
@@ -538,7 +538,7 @@ Registry allows enabling an embedded docker image registry in vCluster. This is 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-registry-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-registry-enabled}
 
 Enabled defines if the embedded registry should be enabled.
 
@@ -553,7 +553,7 @@ Enabled defines if the embedded registry should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `anonymousPull` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-registry-anonymousPull}
+#### `anonymousPull` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-registry-anonymousPull}
 
 AnonymousPull allows enabling anonymous pull for the embedded registry. This allows anybody to pull images from the registry without authentication.
 
@@ -568,7 +568,7 @@ AnonymousPull allows enabling anonymous pull for the embedded registry. This all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-registry-config}
+#### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-registry-config}
 
 Config is the regular docker registry config. See https://distribution.github.io/distribution/about/configuration/ for more details.
 
@@ -586,7 +586,7 @@ Config is the regular docker registry config. See https://distribution.github.io
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cloudControllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-cloudControllerManager}
+### `cloudControllerManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-cloudControllerManager}
 
 CloudControllerManager holds configuration for the embedded cloud controller manager. This is only available when private nodes are enabled.
 The cloud controller manager is responsible for setting the node's ip addresses as well as the provider id for the node and other node metadata.
@@ -599,7 +599,7 @@ The cloud controller manager is responsible for setting the node's ip addresses 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-cloudControllerManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-cloudControllerManager-enabled}
 
 Enabled defines if the embedded cloud controller manager should be enabled. This defaults to true, but can be disabled if you want to use
 an external cloud controller manager such as AWS or GCP. The cloud controller manager is responsible for setting the node's ip addresses as well
@@ -619,7 +619,7 @@ as the provider id for the node and other node metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-globalMetadata}
+### `globalMetadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -631,7 +631,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-globalMetadata-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -649,7 +649,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip}
+### `kubeVip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip}
 
 KubeVip holds configuration for embedded kube-vip that announces the virtual cluster endpoint IP on layer 2.
 
@@ -661,7 +661,7 @@ KubeVip holds configuration for embedded kube-vip that announces the virtual clu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-kubeVip-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-kubeVip-enabled}
 
 Enabled defines if embedded kube-vip should be enabled.
 
@@ -676,7 +676,7 @@ Enabled defines if embedded kube-vip should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `interface` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip-interface}
+#### `interface` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip-interface}
 
 Interface is the network interface on which the VIP is announced.
 
@@ -691,7 +691,7 @@ Interface is the network interface on which the VIP is announced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `gateway` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip-gateway}
+#### `gateway` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip-gateway}
 
 Gateway is the gateway address in CIDR notation (e.g., 10.100.0.1/24).
 This is used to configure policy-based routing for the VIP and must include the subnet prefix.
@@ -710,7 +710,7 @@ This is used to configure policy-based routing for the VIP and must include the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `podDisruptionBudget` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget}
+### `podDisruptionBudget` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget}
 
 PodDisruptionBudget limits how many pods of an application can be voluntarily disrupted at once
 to ensure availability during maintenance or scaling operations.
@@ -723,7 +723,7 @@ to ensure availability during maintenance or scaling operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-enabled}
 
 Enabled defines if the pod disruption budget should be enabled.
 
@@ -738,7 +738,7 @@ Enabled defines if the pod disruption budget should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `minAvailable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-minAvailable}
+#### `minAvailable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-minAvailable}
 
 MinAvailable describes the minimal number or percentage of available pods.
 
@@ -753,7 +753,7 @@ MinAvailable describes the minimal number or percentage of available pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `maxUnavailable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-maxUnavailable}
+#### `maxUnavailable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-maxUnavailable}
 
 MaxUnavailable describes the minimal number or percentage of unavailable pods.
 
@@ -768,7 +768,7 @@ MaxUnavailable describes the minimal number or percentage of unavailable pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `unhealthyPodEvictionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-unhealthyPodEvictionPolicy}
+#### `unhealthyPodEvictionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-unhealthyPodEvictionPolicy}
 
 UnhealthyPodEvictionPolicy defines the criteria when unhealthy pods should be considered for eviction.
 Currently supported values are:

--- a/vcluster/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultImageRegistry}
+## `defaultImageRegistry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.

--- a/vcluster/_partials/config/controlPlane/advanced/globalMetadata.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/globalMetadata.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#globalMetadata}
+## `globalMetadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -14,7 +14,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#globalMetadata-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster/_partials/config/controlPlane/advanced/headlessService.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/headlessService.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#headlessService}
+## `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -14,7 +14,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -29,7 +29,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/controlPlane/advanced/kubeVip.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/kubeVip.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `kubeVip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip}
+## `kubeVip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip}
 
 KubeVip holds configuration for embedded kube-vip that announces the virtual cluster endpoint IP on layer 2.
 
@@ -14,7 +14,7 @@ KubeVip holds configuration for embedded kube-vip that announces the virtual clu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVip-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVip-enabled}
 
 Enabled defines if embedded kube-vip should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if embedded kube-vip should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `interface` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip-interface}
+### `interface` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip-interface}
 
 Interface is the network interface on which the VIP is announced.
 
@@ -44,7 +44,7 @@ Interface is the network interface on which the VIP is announced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `gateway` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip-gateway}
+### `gateway` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip-gateway}
 
 Gateway is the gateway address in CIDR notation (e.g., 10.100.0.1/24).
 This is used to configure policy-based routing for the VIP and must include the subnet prefix.

--- a/vcluster/_partials/config/controlPlane/advanced/serviceAccount.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/serviceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount}
+## `serviceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -14,7 +14,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#serviceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/controlPlane/advanced/virtualScheduler.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/virtualScheduler.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualScheduler}
+## `virtualScheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
@@ -15,7 +15,7 @@ Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#virtualScheduler-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount}
+## `workloadServiceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -14,7 +14,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#workloadServiceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/controlPlane/backingStore.mdx
+++ b/vcluster/_partials/config/controlPlane/backingStore.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore}
+## `backingStore` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore}
 
 BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
 
@@ -14,7 +14,7 @@ BackingStore defines which backing store to use for virtual cluster. If not defi
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd}
+### `etcd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd}
 
 Etcd defines that etcd should be used as the backend for the virtual cluster
 
@@ -26,7 +26,7 @@ Etcd defines that etcd should be used as the backend for the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded}
+#### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -38,7 +38,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -53,7 +53,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -68,7 +68,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-snapshotCount}
+##### `snapshotCount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -83,7 +83,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to the embedded etcd.
 
@@ -101,7 +101,7 @@ ExtraArgs are additional arguments to pass to the embedded etcd.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy}
+#### `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -113,7 +113,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -128,7 +128,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet}
+##### `statefulSet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -140,7 +140,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -155,7 +155,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+##### `enableServiceLinks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -170,7 +170,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -182,7 +182,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -198,7 +198,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -213,7 +213,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -231,7 +231,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -246,7 +246,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-env}
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -261,7 +261,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -276,7 +276,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -288,7 +288,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -303,7 +303,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -321,7 +321,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods}
+##### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -333,7 +333,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -348,7 +348,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -366,7 +366,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
+##### `highAvailability` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -378,7 +378,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -396,7 +396,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling}
+##### `scheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -408,7 +408,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -423,7 +423,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -438,7 +438,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -453,7 +453,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -468,7 +468,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -483,7 +483,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -501,7 +501,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security}
+##### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -513,7 +513,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -528,7 +528,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -546,7 +546,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence}
+##### `persistence` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -558,7 +558,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -570,7 +570,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -585,7 +585,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -600,7 +600,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -615,7 +615,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -630,7 +630,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -648,7 +648,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -663,7 +663,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -678,7 +678,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -690,7 +690,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -705,7 +705,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -721,7 +721,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -737,7 +737,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -753,7 +753,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -771,7 +771,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -795,7 +795,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -810,7 +810,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -828,7 +828,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -840,7 +840,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -855,7 +855,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -873,7 +873,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService}
+##### `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -885,7 +885,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 
@@ -906,7 +906,7 @@ Annotations are extra annotations for the external etcd headless service
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external}
+#### `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external}
 
 External defines to use a self-hosted external etcd that is not deployed by the helm chart
 
@@ -918,7 +918,7 @@ External defines to use a self-hosted external etcd that is not deployed by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-external-enabled}
 
 Enabled defines if the external etcd should be used.
 
@@ -933,7 +933,7 @@ Enabled defines if the external etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-endpoint}
+##### `endpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-endpoint}
 
 Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379
 
@@ -948,7 +948,7 @@ Endpoint holds the endpoint of the external etcd server, e.g. my-example-service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls}
+##### `tls` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls}
 
 TLS defines the tls configuration for the external etcd server
 
@@ -960,7 +960,7 @@ TLS defines the tls configuration for the external etcd server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-caFile}
 
 CaFile is the path to the ca file
 
@@ -975,7 +975,7 @@ CaFile is the path to the ca file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-certFile}
 
 CertFile is the path to the cert file
 
@@ -990,7 +990,7 @@ CertFile is the path to the cert file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-keyFile}
 
 KeyFile is the path to the key file
 
@@ -1014,7 +1014,7 @@ KeyFile is the path to the key file
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database}
+### `database` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database}
 
 Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
 
@@ -1026,7 +1026,7 @@ Database defines that a database backend should be used as the backend for the v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded}
+#### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -1038,7 +1038,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1053,7 +1053,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -1071,7 +1071,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-identityProvider}
+##### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -1088,7 +1088,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1103,7 +1103,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1118,7 +1118,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1133,7 +1133,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -1151,7 +1151,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external}
+#### `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -1163,7 +1163,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1178,7 +1178,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -1196,7 +1196,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-identityProvider}
+##### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -1213,7 +1213,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1228,7 +1228,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1243,7 +1243,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1258,7 +1258,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-external-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-external-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -1273,7 +1273,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-connector}
+##### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster/_partials/config/controlPlane/backingStore/database/embedded.mdx
+++ b/vcluster/_partials/config/controlPlane/backingStore/database/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -47,7 +47,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-identityProvider}
+### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -64,7 +64,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -79,7 +79,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-certFile}
+### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -94,7 +94,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-caFile}
+### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -109,7 +109,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/vcluster/_partials/config/controlPlane/backingStore/database/external.mdx
+++ b/vcluster/_partials/config/controlPlane/backingStore/database/external.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external}
+## `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#external-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -47,7 +47,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-identityProvider}
+### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -64,7 +64,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -79,7 +79,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-certFile}
+### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -94,7 +94,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-caFile}
+### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -109,7 +109,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#external-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#external-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -124,7 +124,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-connector}
+### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
+++ b/vcluster/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -14,7 +14,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -29,7 +29,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet}
+### `statefulSet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -41,7 +41,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -56,7 +56,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enableServiceLinks}
+#### `enableServiceLinks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -71,7 +71,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -83,7 +83,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -99,7 +99,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -114,7 +114,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -132,7 +132,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -147,7 +147,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-env}
+#### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -162,7 +162,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -177,7 +177,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -189,7 +189,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -204,7 +204,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -222,7 +222,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods}
+#### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -234,7 +234,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -249,7 +249,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -267,7 +267,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability}
+#### `highAvailability` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -279,7 +279,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -297,7 +297,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling}
+#### `scheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -309,7 +309,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -324,7 +324,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -339,7 +339,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -354,7 +354,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -369,7 +369,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -384,7 +384,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -402,7 +402,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-security}
+#### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -414,7 +414,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -429,7 +429,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -447,7 +447,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence}
+#### `persistence` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -459,7 +459,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -471,7 +471,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -486,7 +486,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -501,7 +501,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -516,7 +516,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -531,7 +531,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -549,7 +549,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -564,7 +564,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -579,7 +579,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -591,7 +591,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -606,7 +606,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -622,7 +622,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -638,7 +638,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -654,7 +654,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -672,7 +672,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -696,7 +696,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -711,7 +711,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -729,7 +729,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-service}
+### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -741,7 +741,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-service-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -756,7 +756,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -774,7 +774,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -786,7 +786,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 

--- a/vcluster/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
+++ b/vcluster/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-migrateFromDeployedEtcd}
+### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -44,7 +44,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-snapshotCount}
+### `snapshotCount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -59,7 +59,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to the embedded etcd.
 

--- a/vcluster/_partials/config/controlPlane/coredns.mdx
+++ b/vcluster/_partials/config/controlPlane/coredns.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns}
+## `coredns` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns}
 
 CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
 
@@ -14,7 +14,7 @@ CoreDNS defines everything related to the coredns that is deployed and used with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#coredns-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#coredns-enabled}
 
 Enabled defines if coredns is enabled
 
@@ -29,7 +29,7 @@ Enabled defines if coredns is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#coredns-embedded}
+### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#coredns-embedded}
 
 Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
 
@@ -44,7 +44,7 @@ Embedded defines if vCluster will start the embedded coredns service within the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-security}
+### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-security}
 
 Security defines pod or container security context.
 
@@ -56,7 +56,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -71,7 +71,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -89,7 +89,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-service}
+### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-service}
 
 Service holds extra options for the coredns service deployed within the virtual cluster
 
@@ -101,7 +101,7 @@ Service holds extra options for the coredns service deployed within the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#coredns-service-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#coredns-service-spec}
 
 Spec holds extra options for the coredns service
 
@@ -116,7 +116,7 @@ Spec holds extra options for the coredns service
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -131,7 +131,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -149,7 +149,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment}
+### `deployment` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment}
 
 Deployment holds extra options for the coredns deployment deployed within the virtual cluster
 
@@ -161,7 +161,7 @@ Deployment holds extra options for the coredns deployment deployed within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-image}
 
 Image is the coredns image to use
 
@@ -176,7 +176,7 @@ Image is the coredns image to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#coredns-deployment-replicas}
+#### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#coredns-deployment-replicas}
 
 Replicas is the amount of coredns pods to run.
 
@@ -191,7 +191,7 @@ Replicas is the amount of coredns pods to run.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-nodeSelector}
 
 NodeSelector is the node selector to use for coredns.
 
@@ -206,7 +206,7 @@ NodeSelector is the node selector to use for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-affinity}
+#### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -221,7 +221,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -236,7 +236,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-resources}
 
 Resources are the desired resources for coredns.
 
@@ -248,7 +248,7 @@ Resources are the desired resources for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-limits}
 
 Limits are resource limits for the container
 
@@ -263,7 +263,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -281,7 +281,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-pods}
+#### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-pods}
 
 Pods is additional metadata for the coredns pods.
 
@@ -293,7 +293,7 @@ Pods is additional metadata for the coredns pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -308,7 +308,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -326,7 +326,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -341,7 +341,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-labels}
 
 Labels are extra labels for this resource.
 
@@ -356,7 +356,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
 
@@ -374,7 +374,7 @@ TopologySpreadConstraints are the topology spread constraints for the CoreDNS po
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteConfig}
+### `overwriteConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteConfig}
 
 OverwriteConfig can be used to overwrite the coredns config
 
@@ -389,7 +389,7 @@ OverwriteConfig can be used to overwrite the coredns config
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteManifests}
+### `overwriteManifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteManifests}
 
 OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
 
@@ -404,7 +404,7 @@ OverwriteManifests can be used to overwrite the coredns manifests used to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-priorityClassName}
 
 PriorityClassName specifies the priority class name for the CoreDNS pods.
 

--- a/vcluster/_partials/config/controlPlane/distro.mdx
+++ b/vcluster/_partials/config/controlPlane/distro.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro}
+## `distro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -14,7 +14,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s}
+### `k8s` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -26,7 +26,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -41,7 +41,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-version}
 
 Version is the Kubernetes version to use.
 
@@ -56,7 +56,7 @@ Version is the Kubernetes version to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-apiServer}
+#### `apiServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -68,7 +68,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -83,7 +83,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -98,7 +98,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -116,7 +116,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager}
+#### `controllerManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -128,7 +128,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -143,7 +143,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -158,7 +158,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -176,7 +176,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-scheduler}
+#### `scheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler.
 
@@ -188,7 +188,7 @@ Scheduler holds configuration specific to starting the scheduler.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -203,7 +203,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -218,7 +218,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -236,7 +236,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-image}
 
 Image is the distro image
 
@@ -248,7 +248,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#distro-k8s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#distro-k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -264,7 +264,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#distro-k8s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#distro-k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -279,7 +279,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#distro-k8s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#distro-k8s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -297,7 +297,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -312,7 +312,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-env}
+#### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -327,7 +327,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -342,7 +342,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k8s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 

--- a/vcluster/_partials/config/controlPlane/distro/k8s.mdx
+++ b/vcluster/_partials/config/controlPlane/distro/k8s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s}
+## `k8s` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -14,7 +14,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-version}
+### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-version}
 
 Version is the Kubernetes version to use.
 
@@ -44,7 +44,7 @@ Version is the Kubernetes version to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-apiServer}
+### `apiServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -56,7 +56,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-apiServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -71,7 +71,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-command}
+#### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -86,7 +86,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -104,7 +104,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-controllerManager}
+### `controllerManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -116,7 +116,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-controllerManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -131,7 +131,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-command}
+#### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -146,7 +146,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -164,7 +164,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-scheduler}
+### `scheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler.
 
@@ -176,7 +176,7 @@ Scheduler holds configuration specific to starting the scheduler.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-scheduler-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -191,7 +191,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-command}
+#### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -206,7 +206,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -224,7 +224,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-image}
+### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-image}
 
 Image is the distro image
 
@@ -236,7 +236,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#k8s-image-registry}
+#### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -252,7 +252,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#k8s-image-repository}
+#### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -267,7 +267,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#k8s-image-tag}
+#### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#k8s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -285,7 +285,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -300,7 +300,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-env}
+### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -315,7 +315,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k8s-resources}
+### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k8s-resources}
 
 Resources for the distro init container
 
@@ -330,7 +330,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k8s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k8s-securityContext}
 
 Security options can be used for the distro init container
 

--- a/vcluster/_partials/config/controlPlane/hostPathMapper.mdx
+++ b/vcluster/_partials/config/controlPlane/hostPathMapper.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper}
+## `hostPathMapper` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper}
 
 HostPathMapper defines if vCluster should rewrite host paths.
 
@@ -14,7 +14,7 @@ HostPathMapper defines if vCluster should rewrite host paths.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-enabled}
 
 Enabled specifies if the host path mapper will be used
 
@@ -29,7 +29,7 @@ Enabled specifies if the host path mapper will be used
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-central}
+### `central` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-central}
 
 Central specifies if the central host path mapper will be used
 

--- a/vcluster/_partials/config/controlPlane/ingress.mdx
+++ b/vcluster/_partials/config/controlPlane/ingress.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingress}
+## `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingress}
 
 Ingress defines options for vCluster ingress deployed by Helm.
 
@@ -14,7 +14,7 @@ Ingress defines options for vCluster ingress deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingress-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingress-enabled}
 
 Enabled defines if the control plane ingress should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane ingress should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#ingress-host}
+### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#ingress-host}
 
 Host is the host where vCluster will be reachable
 
@@ -44,7 +44,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#ingress-pathType}
+### `pathType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#ingress-pathType}
 
 PathType is the path type of the ingress
 
@@ -59,7 +59,7 @@ PathType is the path type of the ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#ingress-spec}
+### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#ingress-spec}
 
 Spec allows you to configure extra ingress options.
 
@@ -74,7 +74,7 @@ Spec allows you to configure extra ingress options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#ingress-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#ingress-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#ingress-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#ingress-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/controlPlane/proxy.mdx
+++ b/vcluster/_partials/config/controlPlane/proxy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
+## `proxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
 
 Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
 
@@ -14,7 +14,7 @@ Proxy defines options for the virtual cluster control plane proxy that is used t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#proxy-bindAddress}
+### `bindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#proxy-bindAddress}
 
 BindAddress under which vCluster will expose the proxy.
 
@@ -29,7 +29,7 @@ BindAddress under which vCluster will expose the proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#proxy-port}
+### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#proxy-port}
 
 Port under which vCluster will expose the proxy. Changing port is currently not supported.
 
@@ -44,7 +44,7 @@ Port under which vCluster will expose the proxy. Changing port is currently not 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#proxy-extraSANs}
+### `extraSANs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#proxy-extraSANs}
 
 ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 

--- a/vcluster/_partials/config/controlPlane/service.mdx
+++ b/vcluster/_partials/config/controlPlane/service.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#service}
+## `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#service}
 
 Service defines options for vCluster service deployed by Helm.
 
@@ -14,7 +14,7 @@ Service defines options for vCluster service deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#service-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#service-enabled}
 
 Enabled defines if the control plane service should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane service should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#service-spec}
+### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#service-spec}
 
 Spec allows you to configure extra service options.
 
@@ -44,7 +44,7 @@ Spec allows you to configure extra service options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-kubeletNodePort}
+### `kubeletNodePort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-kubeletNodePort}
 
 KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
 
@@ -59,7 +59,7 @@ KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-httpsNodePort}
+### `httpsNodePort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-httpsNodePort}
 
 HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 
@@ -74,7 +74,7 @@ HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/controlPlane/serviceMonitor.mdx
+++ b/vcluster/_partials/config/controlPlane/serviceMonitor.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceMonitor}
+## `serviceMonitor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceMonitor}
 
 ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
 
@@ -14,7 +14,7 @@ ServiceMonitor can be used to automatically create a service monitor for vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceMonitor-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceMonitor-enabled}
 
 Enabled configures if Helm should create the service monitor.
 
@@ -29,7 +29,7 @@ Enabled configures if Helm should create the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-labels}
 
 Labels are the extra labels to add to the service monitor.
 
@@ -44,7 +44,7 @@ Labels are the extra labels to add to the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-annotations}
 
 Annotations are the extra annotations to add to the service monitor.
 

--- a/vcluster/_partials/config/controlPlane/standalone.mdx
+++ b/vcluster/_partials/config/controlPlane/standalone.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `standalone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone}
+## `standalone` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone}
 
 Standalone holds configuration for standalone mode. Standalone mode is set automatically when no container is detected and
 also implies privateNodes.enabled.
@@ -15,7 +15,7 @@ also implies privateNodes.enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-enabled}
 
 Enabled defines if standalone mode should be enabled.
 
@@ -30,7 +30,7 @@ Enabled defines if standalone mode should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">/var/lib/vcluster</span> <span className="config-field-enum"></span> {#standalone-dataDir}
+### `dataDir` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">/var/lib/vcluster</span> <span className="config-field-enum"></span> {#standalone-dataDir}
 
 DataDir defines the data directory for the standalone mode.
 
@@ -45,7 +45,7 @@ DataDir defines the data directory for the standalone mode.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes}
+### `autoNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes}
 
 AutoNodes automatically deploys nodes for standalone mode.
 
@@ -57,7 +57,7 @@ AutoNodes automatically deploys nodes for standalone mode.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `provider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-provider}
+#### `provider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-provider}
 
 Provider is the node provider of the nodes in this pool.
 
@@ -72,7 +72,7 @@ Provider is the node provider of the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `quantity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-quantity}
+#### `quantity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-quantity}
 
 Quantity is the number of nodes to deploy for standalone mode.
 
@@ -87,7 +87,7 @@ Quantity is the number of nodes to deploy for standalone mode.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector}
+#### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -100,7 +100,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -115,7 +115,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -130,7 +130,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -145,7 +145,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -166,7 +166,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode}
+### `joinNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode}
 
 JoinNode holds configuration for the standalone control plane node.
 
@@ -178,7 +178,7 @@ JoinNode holds configuration for the standalone control plane node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#standalone-joinNode-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#standalone-joinNode-enabled}
 
 Enabled defines if the standalone node should be joined into the cluster. If false, only the control plane binaries will be executed and no node will show up in the actual cluster.
 
@@ -193,7 +193,7 @@ Enabled defines if the standalone node should be joined into the cluster. If fal
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preInstallCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-preInstallCommands}
+#### `preInstallCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-preInstallCommands}
 
 PreInstallCommands are commands that will be executed before containerd, kubelet etc. is installed.
 
@@ -208,7 +208,7 @@ PreInstallCommands are commands that will be executed before containerd, kubelet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-preJoinCommands}
+#### `preJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-preJoinCommands}
 
 PreJoinCommands are commands that will be executed before kubeadm join is executed.
 
@@ -223,7 +223,7 @@ PreJoinCommands are commands that will be executed before kubeadm join is execut
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-postJoinCommands}
+#### `postJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-postJoinCommands}
 
 PostJoinCommands are commands that will be executed after kubeadm join is executed.
 
@@ -238,7 +238,7 @@ PostJoinCommands are commands that will be executed after kubeadm join is execut
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd}
+#### `containerd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd}
 
 Containerd holds configuration for the containerd join process.
 
@@ -250,7 +250,7 @@ Containerd holds configuration for the containerd join process.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-enabled}
 
 Enabled defines if containerd should be installed and configured by vCluster.
 
@@ -265,7 +265,7 @@ Enabled defines if containerd should be installed and configured by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry}
 
 Registry holds configuration for how containerd should be configured to use a registries.
 
@@ -277,7 +277,7 @@ Registry holds configuration for how containerd should be configured to use a re
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-configPath}
+##### `configPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-configPath}
 
 ConfigPath is the path to the containerd registry config.
 
@@ -292,7 +292,7 @@ ConfigPath is the path to the containerd registry config.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors}
+##### `mirrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors}
 
 Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -304,7 +304,7 @@ Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-server}
 
 Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -319,7 +319,7 @@ Server is the fallback server to use for the containerd registry mirror. E.g. ht
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror.
 
@@ -334,7 +334,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -349,7 +349,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -364,7 +364,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -379,7 +379,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts}
+##### `hosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts}
 
 Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -391,7 +391,7 @@ Hosts holds configuration for the containerd registry mirror hosts. See https://
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-server}
 
 Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
 
@@ -406,7 +406,7 @@ Server is the server to use for the containerd registry mirror host. E.g. http:/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror host.
 
@@ -421,7 +421,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror ho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -436,7 +436,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -451,7 +451,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -472,7 +472,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth}
 
 Auth holds configuration for the containerd registry auth. See https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials for more details.
 
@@ -484,7 +484,7 @@ Auth holds configuration for the containerd registry auth. See https://github.co
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-username}
 
 Username is the username for the containerd registry.
 
@@ -499,7 +499,7 @@ Username is the username for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-password}
 
 Password is the password for the containerd registry.
 
@@ -514,7 +514,7 @@ Password is the password for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-identityToken}
+##### `identityToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-identityToken}
 
 IdentityToken is the token for the containerd registry.
 
@@ -529,7 +529,7 @@ IdentityToken is the token for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-auth}
 
 Auth is the auth config for the containerd registry.
 
@@ -550,7 +550,7 @@ Auth is the auth config for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-pauseImage}
+##### `pauseImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-pauseImage}
 
 PauseImage is the image for the pause container.
 
@@ -568,7 +568,7 @@ PauseImage is the image for the pause container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-caCertPath}
+#### `caCertPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-caCertPath}
 
 CACertPath is the path to the SSL certificate authority used to
 secure communications between node and control-plane.
@@ -585,7 +585,7 @@ Defaults to "/etc/kubernetes/pki/ca.crt".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-skipPhases}
+#### `skipPhases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-skipPhases}
 
 SkipPhases is a list of phases to skip during command execution.
 The list of phases can be obtained with the "kubeadm join --help" command.
@@ -601,7 +601,7 @@ The list of phases can be obtained with the "kubeadm join --help" command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration}
+#### `nodeRegistration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration}
 
 NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
 
@@ -613,7 +613,7 @@ NodeRegistration holds configuration for the node registration similar to the ku
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-criSocket}
+##### `criSocket` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-criSocket}
 
 CRI socket is the socket for the CRI.
 
@@ -628,7 +628,7 @@ CRI socket is the socket for the CRI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs}
+##### `kubeletExtraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs}
 
 KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
 kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
@@ -644,7 +644,7 @@ Extra arguments will override existing default arguments. Duplicate extra argume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs-name}
 
 Name is the name of the argument.
 
@@ -659,7 +659,7 @@ Name is the name of the argument.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs-value}
 
 Value is the value of the argument.
 
@@ -677,7 +677,7 @@ Value is the value of the argument.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints}
+##### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints}
 
 Taints are additional taints to set for the kubelet.
 
@@ -689,7 +689,7 @@ Taints are additional taints to set for the kubelet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -704,7 +704,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -719,7 +719,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -739,7 +739,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-ignorePreflightErrors}
+##### `ignorePreflightErrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-ignorePreflightErrors}
 
 IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
 Value 'all' ignores errors from all checks.
@@ -755,7 +755,7 @@ Value 'all' ignores errors from all checks.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-imagePullPolicy}
 
 ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
 The value of this field must be one of "Always", "IfNotPresent" or "Never".

--- a/vcluster/_partials/config/controlPlane/standalone/joinNode.mdx
+++ b/vcluster/_partials/config/controlPlane/standalone/joinNode.mdx
@@ -14,7 +14,7 @@ For production deployments, keep the control-plane node dedicated by setting
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode}
+## `joinNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode}
 
 JoinNode holds configuration for the standalone control plane node.
 
@@ -26,7 +26,7 @@ JoinNode holds configuration for the standalone control plane node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#joinNode-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#joinNode-enabled}
 
 Enabled defines if the standalone node should be joined into the cluster. If false, only the control plane binaries will be executed and no node will show up in the actual cluster.
 
@@ -41,7 +41,7 @@ Enabled defines if the standalone node should be joined into the cluster. If fal
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `preInstallCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-preInstallCommands}
+### `preInstallCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-preInstallCommands}
 
 PreInstallCommands are commands that will be executed before containerd, kubelet etc. is installed.
 
@@ -56,7 +56,7 @@ PreInstallCommands are commands that will be executed before containerd, kubelet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-preJoinCommands}
+### `preJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-preJoinCommands}
 
 PreJoinCommands are commands that will be executed before kubeadm join is executed.
 
@@ -71,7 +71,7 @@ PreJoinCommands are commands that will be executed before kubeadm join is execut
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-postJoinCommands}
+### `postJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-postJoinCommands}
 
 PostJoinCommands are commands that will be executed after kubeadm join is executed.
 
@@ -86,7 +86,7 @@ PostJoinCommands are commands that will be executed after kubeadm join is execut
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd}
+### `containerd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd}
 
 Containerd holds configuration for the containerd join process.
 
@@ -98,7 +98,7 @@ Containerd holds configuration for the containerd join process.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#joinNode-containerd-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#joinNode-containerd-enabled}
 
 Enabled defines if containerd should be installed and configured by vCluster.
 
@@ -113,7 +113,7 @@ Enabled defines if containerd should be installed and configured by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry}
+#### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry}
 
 Registry holds configuration for how containerd should be configured to use a registries.
 
@@ -125,7 +125,7 @@ Registry holds configuration for how containerd should be configured to use a re
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-configPath}
+##### `configPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-configPath}
 
 ConfigPath is the path to the containerd registry config.
 
@@ -140,7 +140,7 @@ ConfigPath is the path to the containerd registry config.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors}
+##### `mirrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors}
 
 Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -152,7 +152,7 @@ Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-server}
 
 Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -167,7 +167,7 @@ Server is the fallback server to use for the containerd registry mirror. E.g. ht
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror.
 
@@ -182,7 +182,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -197,7 +197,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -212,7 +212,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -227,7 +227,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts}
+##### `hosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts}
 
 Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -239,7 +239,7 @@ Hosts holds configuration for the containerd registry mirror hosts. See https://
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-server}
 
 Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
 
@@ -254,7 +254,7 @@ Server is the server to use for the containerd registry mirror host. E.g. http:/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror host.
 
@@ -269,7 +269,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror ho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -284,7 +284,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -299,7 +299,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -320,7 +320,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth}
 
 Auth holds configuration for the containerd registry auth. See https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials for more details.
 
@@ -332,7 +332,7 @@ Auth holds configuration for the containerd registry auth. See https://github.co
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-username}
 
 Username is the username for the containerd registry.
 
@@ -347,7 +347,7 @@ Username is the username for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-password}
 
 Password is the password for the containerd registry.
 
@@ -362,7 +362,7 @@ Password is the password for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-identityToken}
+##### `identityToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-identityToken}
 
 IdentityToken is the token for the containerd registry.
 
@@ -377,7 +377,7 @@ IdentityToken is the token for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-auth}
 
 Auth is the auth config for the containerd registry.
 
@@ -398,7 +398,7 @@ Auth is the auth config for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-pauseImage}
+#### `pauseImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-pauseImage}
 
 PauseImage is the image for the pause container.
 
@@ -416,7 +416,7 @@ PauseImage is the image for the pause container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-caCertPath}
+### `caCertPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-caCertPath}
 
 CACertPath is the path to the SSL certificate authority used to
 secure communications between node and control-plane.
@@ -433,7 +433,7 @@ Defaults to "/etc/kubernetes/pki/ca.crt".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-skipPhases}
+### `skipPhases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-skipPhases}
 
 SkipPhases is a list of phases to skip during command execution.
 The list of phases can be obtained with the "kubeadm join --help" command.
@@ -449,7 +449,7 @@ The list of phases can be obtained with the "kubeadm join --help" command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration}
+### `nodeRegistration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration}
 
 NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
 
@@ -461,7 +461,7 @@ NodeRegistration holds configuration for the node registration similar to the ku
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-criSocket}
+#### `criSocket` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-criSocket}
 
 CRI socket is the socket for the CRI.
 
@@ -476,7 +476,7 @@ CRI socket is the socket for the CRI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs}
+#### `kubeletExtraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs}
 
 KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
 kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
@@ -492,7 +492,7 @@ Extra arguments will override existing default arguments. Duplicate extra argume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs-name}
 
 Name is the name of the argument.
 
@@ -507,7 +507,7 @@ Name is the name of the argument.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs-value}
 
 Value is the value of the argument.
 
@@ -525,7 +525,7 @@ Value is the value of the argument.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints}
+#### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints}
 
 Taints are additional taints to set for the kubelet.
 
@@ -537,7 +537,7 @@ Taints are additional taints to set for the kubelet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -552,7 +552,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -567,7 +567,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -587,7 +587,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-ignorePreflightErrors}
+#### `ignorePreflightErrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-ignorePreflightErrors}
 
 IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
 Value 'all' ignores errors from all checks.
@@ -603,7 +603,7 @@ Value 'all' ignores errors from all checks.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-imagePullPolicy}
 
 ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
 The value of this field must be one of "Always", "IfNotPresent" or "Never".

--- a/vcluster/_partials/config/controlPlane/statefulSet.mdx
+++ b/vcluster/_partials/config/controlPlane/statefulSet.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet}
+## `statefulSet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet}
 
 StatefulSet defines options for vCluster statefulSet deployed by Helm.
 
@@ -14,7 +14,7 @@ StatefulSet defines options for vCluster statefulSet deployed by Helm.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-highAvailability}
+### `highAvailability` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-highAvailability}
 
 HighAvailability holds options related to high availability.
 
@@ -26,7 +26,7 @@ HighAvailability holds options related to high availability.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-replicas}
+#### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-replicas}
 
 Replicas is the amount of replicas to use for the statefulSet.
 
@@ -41,7 +41,7 @@ Replicas is the amount of replicas to use for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-leaseDuration}
+#### `leaseDuration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-leaseDuration}
 
 LeaseDuration is the time to lease for the leader.
 
@@ -56,7 +56,7 @@ LeaseDuration is the time to lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-renewDeadline}
+#### `renewDeadline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-renewDeadline}
 
 RenewDeadline is the deadline to renew a lease for the leader.
 
@@ -71,7 +71,7 @@ RenewDeadline is the deadline to renew a lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-retryPeriod}
+#### `retryPeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-retryPeriod}
 
 RetryPeriod is the time until a replica will retry to get a lease.
 
@@ -89,7 +89,7 @@ RetryPeriod is the time until a replica will retry to get a lease.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-resources}
+### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-resources}
 
 Resources are the resource requests and limits for the statefulSet container.
 
@@ -101,7 +101,7 @@ Resources are the resource requests and limits for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:10Gi memory:4Gi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-limits}
+#### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:10Gi memory:4Gi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -116,7 +116,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:1Gi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-requests}
+#### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:1Gi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -134,7 +134,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling}
+### `scheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling}
 
 Scheduling holds options related to scheduling.
 
@@ -146,7 +146,7 @@ Scheduling holds options related to scheduling.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -161,7 +161,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-affinity}
+#### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -176,7 +176,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -191,7 +191,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -206,7 +206,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-podManagementPolicy}
+#### `podManagementPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -221,7 +221,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -239,7 +239,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-security}
+### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-security}
 
 Security defines pod or container security context.
 
@@ -251,7 +251,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-security-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -266,7 +266,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#statefulSet-security-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -284,7 +284,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes}
+### `probes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes}
 
 Probes enables or disables the main container probes.
 
@@ -296,7 +296,7 @@ Probes enables or disables the main container probes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe}
+#### `livenessProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe}
 
 LivenessProbe specifies if the liveness probe for the container should be enabled
 
@@ -308,7 +308,7 @@ LivenessProbe specifies if the liveness probe for the container should be enable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -323,7 +323,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -338,7 +338,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initialDelaySeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-initialDelaySeconds}
+##### `initialDelaySeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-initialDelaySeconds}
 
 Time (in seconds) to wait before starting the liveness probe
 
@@ -353,7 +353,7 @@ Time (in seconds) to wait before starting the liveness probe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -368,7 +368,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -386,7 +386,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe}
+#### `readinessProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe}
 
 ReadinessProbe specifies if the readiness probe for the container should be enabled
 
@@ -398,7 +398,7 @@ ReadinessProbe specifies if the readiness probe for the container should be enab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -413,7 +413,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -428,7 +428,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -443,7 +443,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -461,7 +461,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe}
+#### `startupProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe}
 
 StartupProbe specifies if the startup probe for the container should be enabled
 
@@ -473,7 +473,7 @@ StartupProbe specifies if the startup probe for the container should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -488,7 +488,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-failureThreshold}
 
 Number of consecutive failures allowed before failing the pod
 
@@ -503,7 +503,7 @@ Number of consecutive failures allowed before failing the pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -518,7 +518,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -539,7 +539,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence}
+### `persistence` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence}
 
 Persistence defines options around persistence for the statefulSet.
 
@@ -551,7 +551,7 @@ Persistence defines options around persistence for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim}
+#### `volumeClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -563,7 +563,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
 based on the chosen distro and other options if this is required.
@@ -579,7 +579,7 @@ based on the chosen distro and other options if this is required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -594,7 +594,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -609,7 +609,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -624,7 +624,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -642,7 +642,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaimTemplates}
+#### `volumeClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -657,7 +657,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-dataVolume}
+#### `dataVolume` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-dataVolume}
 
 Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
 
@@ -672,7 +672,7 @@ Allows you to override the dataVolume. Only works correctly if volumeClaim.enabl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-binariesVolume}
+#### `binariesVolume` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-binariesVolume}
 
 BinariesVolume defines a binaries volume that is used to retrieve
 distro specific executables to be run by the syncer controller.
@@ -689,7 +689,7 @@ This volume doesn't need to be persistent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumes}
+#### `addVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -704,7 +704,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts}
+#### `addVolumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -716,7 +716,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -731,7 +731,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -747,7 +747,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -763,7 +763,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -779,7 +779,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -797,7 +797,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -821,7 +821,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-enableServiceLinks}
+### `enableServiceLinks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -836,7 +836,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -851,7 +851,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -866,7 +866,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-pods}
+### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-pods}
 
 Additional labels or annotations for the statefulSet pods.
 
@@ -878,7 +878,7 @@ Additional labels or annotations for the statefulSet pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -893,7 +893,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -911,7 +911,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image}
+### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image}
 
 Image is the image for the controlPlane statefulSet container
 It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
@@ -925,7 +925,7 @@ If you still want to use the pure OSS build, set the repository to 'loft-sh/vclu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#statefulSet-image-registry}
+#### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -941,7 +941,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#statefulSet-image-repository}
+#### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -956,7 +956,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image-tag}
+#### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -974,7 +974,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -989,7 +989,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-workingDir}
+### `workingDir` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-workingDir}
 
 WorkingDir specifies in what folder the main process should get started.
 
@@ -1004,7 +1004,7 @@ WorkingDir specifies in what folder the main process should get started.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-command}
+### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-command}
 
 Command allows you to override the main command.
 
@@ -1019,7 +1019,7 @@ Command allows you to override the main command.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-args}
+### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-args}
 
 Args allows you to override the main arguments.
 
@@ -1034,7 +1034,7 @@ Args allows you to override the main arguments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-env}
+### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-env}
 
 Env are additional environment variables for the statefulSet container.
 
@@ -1049,7 +1049,7 @@ Env are additional environment variables for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsPolicy}
+### `dnsPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsPolicy}
 
 Set DNS policy for the pod.
 
@@ -1064,7 +1064,7 @@ Set DNS policy for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig}
+### `dnsConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig}
 
 Specifies the DNS parameters of a pod.
 
@@ -1076,7 +1076,7 @@ Specifies the DNS parameters of a pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-nameservers}
+#### `nameservers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-nameservers}
 
 A list of DNS name server IP addresses.
 This will be appended to the base nameservers generated from DNSPolicy.
@@ -1093,7 +1093,7 @@ Duplicated nameservers will be removed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-searches}
+#### `searches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-searches}
 
 A list of DNS search domains for host-name lookup.
 This will be appended to the base search paths generated from DNSPolicy.
@@ -1110,7 +1110,7 @@ Duplicated search paths will be removed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options}
+#### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options}
 
 A list of DNS resolver options.
 This will be merged with the base options generated from DNSPolicy.
@@ -1125,7 +1125,7 @@ will override those that appear in the base DNSPolicy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-name}
 
 Required.
 
@@ -1140,7 +1140,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-value}
 
 
 
@@ -1161,7 +1161,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `initContainers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-initContainers}
+### `initContainers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-initContainers}
 
 InitContainers are additional init containers for the statefulSet.
 
@@ -1176,7 +1176,7 @@ InitContainers are additional init containers for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `sidecarContainers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-sidecarContainers}
+### `sidecarContainers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-sidecarContainers}
 
 SidecarContainers are additional sidecar containers for the statefulSet.
 
@@ -1191,7 +1191,7 @@ SidecarContainers are additional sidecar containers for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hostAliases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases}
+### `hostAliases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases}
 
 HostAliases allows you to add custom entries to the /etc/hosts file of each Pod created.
 
@@ -1203,7 +1203,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases-ip}
+#### `ip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases-ip}
 
 
 
@@ -1218,7 +1218,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostnames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases-hostnames}
+#### `hostnames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases-hostnames}
 
 
 
@@ -1236,7 +1236,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-runtimeClassName}
+### `runtimeClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for the statefulSet pods.
 

--- a/vcluster/_partials/config/deletion.mdx
+++ b/vcluster/_partials/config/deletion.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion}
+## `deletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion}
 
 Deletion holds configuration for automatic vCluster deletion.
 
@@ -14,7 +14,7 @@ Deletion holds configuration for automatic vCluster deletion.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `prevent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-prevent}
+### `prevent` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-prevent}
 
 Prevent prevents the vCluster from being deleted
 
@@ -29,7 +29,7 @@ Prevent prevents the vCluster from being deleted
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `auto` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-auto}
+### `auto` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-auto}
 
 Auto holds automatic deletion configuration
 
@@ -41,9 +41,9 @@ Auto holds automatic deletion configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-auto-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-auto-afterInactivity}
 
-AfterInactivity specifies after how long of inactivity the tenant cluster will be deleted.
+AfterInactivity specifies after how long of inactivity the virtual cluster will be deleted.
 Uses Go duration format (e.g., "720h" for 30 days).
 
 </summary>

--- a/vcluster/_partials/config/deploy.mdx
+++ b/vcluster/_partials/config/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy holds configuration for the deployment of vCluster.
 
@@ -14,7 +14,7 @@ Deploy holds configuration for the deployment of vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeProxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy}
+### `kubeProxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy}
 
 KubeProxy holds dedicated kube proxy configuration.
 
@@ -26,7 +26,7 @@ KubeProxy holds dedicated kube proxy configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-enabled}
 
 Enabled defines if the kube proxy should be enabled.
 
@@ -41,7 +41,7 @@ Enabled defines if the kube proxy should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-image}
 
 Image is the image for the kube-proxy.
 
@@ -56,7 +56,7 @@ Image is the image for the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -71,7 +71,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-nodeSelector}
 
 NodeSelector is the node selector for the kube-proxy.
 
@@ -86,7 +86,7 @@ NodeSelector is the node selector for the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-priorityClassName}
 
 PriorityClassName is the priority class name for the kube-proxy.
 
@@ -101,7 +101,7 @@ PriorityClassName is the priority class name for the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-tolerations}
 
 Tolerations is the tolerations for the kube-proxy.
 
@@ -116,7 +116,7 @@ Tolerations is the tolerations for the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-extraEnv}
+#### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-extraEnv}
 
 ExtraEnv is the extra environment variables for the kube-proxy.
 
@@ -131,7 +131,7 @@ ExtraEnv is the extra environment variables for the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-extraArgs}
 
 ExtraArgs are additional arguments to pass to the kube-proxy.
 
@@ -146,7 +146,7 @@ ExtraArgs are additional arguments to pass to the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-config}
+#### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-config}
 
 Config is the config for the kube-proxy that will be merged into the default kube-proxy config. More information can be found here:
 https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration
@@ -165,7 +165,7 @@ https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kube
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metallb` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb}
+### `metallb` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb}
 
 Metallb holds dedicated metallb configuration.
 
@@ -177,7 +177,7 @@ Metallb holds dedicated metallb configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-metallb-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-metallb-enabled}
 
 Enabled defines if metallb should be enabled.
 
@@ -192,7 +192,7 @@ Enabled defines if metallb should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `controllerImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-controllerImage}
+#### `controllerImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-controllerImage}
 
 ControllerImage is the image for metallb controller.
 
@@ -207,7 +207,7 @@ ControllerImage is the image for metallb controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `speakerImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-speakerImage}
+#### `speakerImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-speakerImage}
 
 SpeakerImage is the image for metallb speaker.
 
@@ -222,7 +222,7 @@ SpeakerImage is the image for metallb speaker.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ipAddressPool` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool}
+#### `ipAddressPool` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool}
 
 IPAddressPool is the IP address pool to use for metallb.
 
@@ -234,7 +234,7 @@ IPAddressPool is the IP address pool to use for metallb.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool-addresses}
+##### `addresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool-addresses}
 
 Addresses is a list of IP addresses to use for the IP address pool.
 
@@ -249,7 +249,7 @@ Addresses is a list of IP addresses to use for the IP address pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `l2Advertisement` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool-l2Advertisement}
+##### `l2Advertisement` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool-l2Advertisement}
 
 L2Advertisement defines if L2 advertisement should be enabled for the IP address pool.
 
@@ -270,7 +270,7 @@ L2Advertisement defines if L2 advertisement should be enabled for the IP address
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cni` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni}
+### `cni` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni}
 
 CNI holds dedicated CNI configuration.
 
@@ -282,7 +282,7 @@ CNI holds dedicated CNI configuration.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `flannel` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel}
+#### `flannel` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel}
 
 Flannel holds dedicated Flannel configuration.
 
@@ -294,7 +294,7 @@ Flannel holds dedicated Flannel configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-cni-flannel-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-cni-flannel-enabled}
 
 Enabled defines if Flannel should be enabled.
 
@@ -309,7 +309,7 @@ Enabled defines if Flannel should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-image}
 
 Image is the image for Flannel main container.
 
@@ -324,7 +324,7 @@ Image is the image for Flannel main container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-initImage}
+##### `initImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-initImage}
 
 InitImage is the image for Flannel init container.
 
@@ -339,7 +339,7 @@ InitImage is the image for Flannel init container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -360,7 +360,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `localPathProvisioner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner}
+### `localPathProvisioner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner}
 
 LocalPathProvisioner holds dedicated local path provisioner configuration.
 
@@ -372,7 +372,7 @@ LocalPathProvisioner holds dedicated local path provisioner configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-enabled}
 
 Enabled defines if LocalPathProvisioner should be enabled.
 
@@ -387,7 +387,7 @@ Enabled defines if LocalPathProvisioner should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-image}
 
 Image is the image for local path provisioner.
 
@@ -402,7 +402,7 @@ Image is the image for local path provisioner.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -417,7 +417,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-nodePath}
+#### `nodePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-nodePath}
 
 NodePath is the path on the node where to create the persistent volume directories.
 
@@ -435,7 +435,7 @@ NodePath is the path on the node where to create the persistent volume directori
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingressNginx` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-ingressNginx}
+### `ingressNginx` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-ingressNginx}
 
 IngressNginx holds dedicated ingress-nginx configuration.
 Deprecated: We do not deploy ingress nginx and the project is being deprecated.
@@ -448,7 +448,7 @@ Deprecated: We do not deploy ingress nginx and the project is being deprecated.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-ingressNginx-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-ingressNginx-enabled}
 
 Enabled defines if ingress-nginx should be enabled.
 
@@ -463,7 +463,7 @@ Enabled defines if ingress-nginx should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultIngressClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-ingressNginx-defaultIngressClass}
+#### `defaultIngressClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-ingressNginx-defaultIngressClass}
 
 DefaultIngressClass defines if the deployed ingress class should be the default ingress class.
 
@@ -481,7 +481,7 @@ DefaultIngressClass defines if the deployed ingress class should be the default 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metricsServer}
+### `metricsServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metricsServer}
 
 MetricsServer holds dedicated metrics server configuration.
 
@@ -493,7 +493,7 @@ MetricsServer holds dedicated metrics server configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-metricsServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-metricsServer-enabled}
 
 Enabled defines if metrics server should be enabled.
 
@@ -511,7 +511,7 @@ Enabled defines if metrics server should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotController` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-volumeSnapshotController}
+### `volumeSnapshotController` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-volumeSnapshotController}
 
 VolumeSnapshotController holds dedicated CSI snapshot-controller configuration.
 
@@ -523,7 +523,7 @@ VolumeSnapshotController holds dedicated CSI snapshot-controller configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-volumeSnapshotController-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-volumeSnapshotController-enabled}
 
 Enabled defines if the CSI volumes snapshot-controller should be enabled.
 
@@ -541,7 +541,7 @@ Enabled defines if the CSI volumes snapshot-controller should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `argoCD` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD}
+### `argoCD` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD}
 
 ArgoCD holds dedicated configuration for argoCD Apps to deploy
 
@@ -553,7 +553,7 @@ ArgoCD holds dedicated configuration for argoCD Apps to deploy
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `applications` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications}
+#### `applications` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications}
 
 Applications specifies the applications to deploy. This requires the argo cd integration to be enabled.
 
@@ -565,7 +565,7 @@ Applications specifies the applications to deploy. This requires the argo cd int
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-name}
 
 Name specifies the stable identifier of the argo cd application. It is used to derive generated
 ArgoCDApplication resource names and the final Argo CD application name.
@@ -581,7 +581,7 @@ ArgoCDApplication resource names and the final Argo CD application name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-displayName}
 
 DisplayName specifies the display name of the argo cd application.
 
@@ -596,7 +596,7 @@ DisplayName specifies the display name of the argo cd application.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-target}
+##### `target` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-target}
 
 Target specifies the target of the argo cd application. This can be "vCluster" or "host". Defaults to "vCluster".
 
@@ -611,7 +611,7 @@ Target specifies the target of the argo cd application. This can be "vCluster" o
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-inline}
 
 Inline specifies the inline argo cd application definition. This requires the argo cd integration to be enabled.
 
@@ -626,7 +626,7 @@ Inline specifies the inline argo cd application definition. This requires the ar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template}
+##### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template}
 
 Template specifies the argo cd application template to use. This requires the argo cd integration to be enabled.
 
@@ -638,7 +638,7 @@ Template specifies the argo cd application template to use. This requires the ar
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template-name}
 
 Name specifies the name of the argo cd application template
 
@@ -653,7 +653,7 @@ Name specifies the name of the argo cd application template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template-parameters}
 
 Parameters specifies the parameters to pass to the argo cd application template.
 

--- a/vcluster/_partials/config/experimental.mdx
+++ b/vcluster/_partials/config/experimental.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `experimental` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental}
+## `experimental` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental}
 
 Experimental features for vCluster. Configuration here might change, so be careful with this.
 
@@ -14,7 +14,7 @@ Experimental features for vCluster. Configuration here might change, so be caref
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy}
+### `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -26,7 +26,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host}
+#### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -38,7 +38,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifests}
+##### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -53,7 +53,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -71,7 +71,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster}
+#### `vcluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -83,7 +83,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifests}
+##### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -98,7 +98,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -113,7 +113,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm}
+##### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -125,7 +125,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -137,7 +137,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-name}
 
 
 
@@ -152,7 +152,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-repo}
 
 
 
@@ -167,7 +167,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -182,7 +182,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-version}
 
 
 
@@ -197,7 +197,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-username}
 
 
 
@@ -212,7 +212,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-password}
 
 
 
@@ -230,7 +230,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -242,7 +242,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -257,7 +257,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -275,7 +275,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -290,7 +290,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -305,7 +305,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 
@@ -329,7 +329,7 @@ Bundle allows to compress the Helm chart and specify this instead of an online c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings}
+### `syncSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -341,7 +341,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-syncSettings-setOwner}
+#### `setOwner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -356,7 +356,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-hostMetricsBindAddress}
+#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -371,7 +371,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-virtualMetricsBindAddress}
+#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 
@@ -389,7 +389,7 @@ VirtualMetricsBindAddress is the bind address for the virtual manager
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig}
+### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 Deprecated: Removed in 0.29.0.
@@ -402,7 +402,7 @@ Deprecated: Removed in 0.29.0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-kubeConfig}
+#### `kubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -417,7 +417,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCAKey}
+#### `serverCAKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -432,7 +432,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCACert}
+#### `serverCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCACert}
 
 ServerCACert is the server ca cert path.
 
@@ -447,7 +447,7 @@ ServerCACert is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCACert}
+#### `clientCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCACert}
 
 ClientCACert is the client ca cert path.
 
@@ -462,7 +462,7 @@ ClientCACert is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCAKey}
+#### `clientCAKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCAKey}
 
 ClientCAKey is the client ca key path.
 
@@ -477,7 +477,7 @@ ClientCAKey is the client ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
+#### `requestHeaderCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 
@@ -495,7 +495,7 @@ RequestHeaderCACert is the request header ca cert path.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests}
+### `denyProxyRequests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -507,7 +507,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-name}
 
 The name of the check.
 
@@ -522,7 +522,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -539,7 +539,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -553,7 +553,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -568,7 +568,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiVersions}
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -583,7 +583,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -598,7 +598,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-scope}
+##### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -613,7 +613,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-operations}
+##### `operations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -633,7 +633,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-excludedUsers}
+#### `excludedUsers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.
@@ -652,7 +652,7 @@ Impersonation attempts on these users will still be subjected to the checks.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy}
+### `proxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy}
 
 Proxy enables vCluster-to-vCluster proxying of resources
 
@@ -664,7 +664,7 @@ Proxy enables vCluster-to-vCluster proxying of resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources}
+#### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources}
 
 CustomResources is a map of resource keys (format: "kind.apiGroup/version") to proxy configuration
 
@@ -676,7 +676,7 @@ CustomResources is a map of resource keys (format: "kind.apiGroup/version") to p
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-enabled}
 
 Enabled defines if this resource proxy should be enabled
 
@@ -691,7 +691,7 @@ Enabled defines if this resource proxy should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `targetVirtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster}
+##### `targetVirtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster}
 
 TargetVirtualCluster is the target virtual cluster for the custom resource proxy
 
@@ -703,7 +703,7 @@ TargetVirtualCluster is the target virtual cluster for the custom resource proxy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster-name}
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster-name}
 
 Name is the name of the target virtual cluster.
 
@@ -718,7 +718,7 @@ Name is the name of the target virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster-project}
 
 Project is the project of the target virtual cluster. If empty, defaults to the same project as the source vCluster.
 
@@ -736,7 +736,7 @@ Project is the project of the target virtual cluster. If empty, defaults to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-accessResources}
+##### `accessResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-accessResources}
 
 AccessResources defines which resources should be accessible in the proxy.
 
@@ -757,7 +757,7 @@ AccessResources defines which resources should be accessible in the proxy.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `docker` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker}
+### `docker` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker}
 
 Docker allows you to configure Docker related settings when deploying a vCluster using Docker.
 
@@ -769,7 +769,7 @@ Docker allows you to configure Docker related settings when deploying a vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-image}
 
 Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container.
 
@@ -784,7 +784,7 @@ Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-ports}
+#### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-ports}
 
 Ports defines extra port mappings to be added to the container.
 
@@ -799,7 +799,7 @@ Ports defines extra port mappings to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `volumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-volumes}
+#### `volumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-volumes}
 
 Volumes defines extra volumes to be added to the container.
 
@@ -814,7 +814,7 @@ Volumes defines extra volumes to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-env}
+#### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-env}
 
 Env defines extra environment variables to be added to the container. Use key=value.
 
@@ -829,7 +829,7 @@ Env defines extra environment variables to be added to the container. Use key=va
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-args}
+#### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-args}
 
 Args defines extra arguments to be added to the docker run command of the container.
 
@@ -844,7 +844,7 @@ Args defines extra arguments to be added to the docker run command of the contai
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-enabled}
 
 Enabled defines if the vCluster was deployed using Docker. This is automatically set by vCluster and should not be set by the user.
 
@@ -859,7 +859,7 @@ Enabled defines if the vCluster was deployed using Docker. This is automatically
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `network` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-network}
+#### `network` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-network}
 
 Network defines the network to use for the vCluster. If not specified, the a network will be created for the vCluster.
 
@@ -874,7 +874,7 @@ Network defines the network to use for the vCluster. If not specified, the a net
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes}
+#### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes}
 
 Nodes defines the nodes of the vCluster.
 
@@ -886,7 +886,7 @@ Nodes defines the nodes of the vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-image}
 
 Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container.
 
@@ -901,7 +901,7 @@ Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-ports}
 
 Ports defines extra port mappings to be added to the container.
 
@@ -916,7 +916,7 @@ Ports defines extra port mappings to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-volumes}
+##### `volumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-volumes}
 
 Volumes defines extra volumes to be added to the container.
 
@@ -931,7 +931,7 @@ Volumes defines extra volumes to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-env}
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-env}
 
 Env defines extra environment variables to be added to the container. Use key=value.
 
@@ -946,7 +946,7 @@ Env defines extra environment variables to be added to the container. Use key=va
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-args}
+##### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-args}
 
 Args defines extra arguments to be added to the docker run command of the container.
 
@@ -961,7 +961,7 @@ Args defines extra arguments to be added to the docker run command of the contai
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-name}
 
 Name defines the name of the node. If not specified, a random name will be generated.
 
@@ -979,7 +979,7 @@ Name defines the name of the node. If not specified, a random name will be gener
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `registryProxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-registryProxy}
+#### `registryProxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-registryProxy}
 
 Defines if docker images should be pulled from the host docker daemon. This prevents pulling images again and allows to
 use purely local images. Only works if containerd image storage is used. For more information, see https://docs.docker.com/engine/storage/containerd
@@ -992,7 +992,7 @@ use purely local images. Only works if containerd image storage is used. For mor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-registryProxy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-registryProxy-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1010,7 +1010,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `loadBalancer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer}
+#### `loadBalancer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer}
 
 Defines if vCluster should configure load balancer services inside the vCluster. This might require
 sudo access on the host cluster for docker desktop or rancher desktop on macos.
@@ -1023,7 +1023,7 @@ sudo access on the host cluster for docker desktop or rancher desktop on macos.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1038,7 +1038,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `forwardPorts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer-forwardPorts}
+##### `forwardPorts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer-forwardPorts}
 
 ForwardPorts defines if the load balancer ips should be made available locally
 via port forwarding. This will be only done if necessary for example on macos when using docker desktop.
@@ -1060,7 +1060,7 @@ via port forwarding. This will be only done if necessary for example on macos wh
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodeMonitors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors}
+### `nodeMonitors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors}
 
 NodeMonitors allows you to create a service monitor for each node.
 
@@ -1072,7 +1072,7 @@ NodeMonitors allows you to create a service monitor for each node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-name}
 
 Name is the name of the monitor. It will be suffixed with the node name.
 
@@ -1087,7 +1087,7 @@ Name is the name of the monitor. It will be suffixed with the node name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-nodeSelector}
 
 NodeSelector defines the node selector for the service monitor.
 
@@ -1102,7 +1102,7 @@ NodeSelector defines the node selector for the service monitor.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints}
+#### `endpoints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints}
 
 Endpoints is a list of endpoints to add to the service monitor. By default, vCluster will relabel the node and instance label to the node name.
 
@@ -1114,7 +1114,7 @@ Endpoints is a list of endpoints to add to the service monitor. By default, vClu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-path}
 
 Path is the kubelet path of the endpoint. vCluster will prepend /api/v1/nodes/NODE_NAME to the path.
 
@@ -1129,7 +1129,7 @@ Path is the kubelet path of the endpoint. vCluster will prepend /api/v1/nodes/NO
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `params` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-params}
+##### `params` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-params}
 
 Params allows you to configure extra parameters to add to the endpoint.
 
@@ -1144,7 +1144,7 @@ Params allows you to configure extra parameters to add to the endpoint.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraRelabelings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-extraRelabelings}
+##### `extraRelabelings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-extraRelabelings}
 
 ExtraRelabelings allows you to configure extra relabelings to add to the endpoint. By default, vCluster will relabel the node and instance label to the node name.
 
@@ -1159,7 +1159,7 @@ ExtraRelabelings allows you to configure extra relabelings to add to the endpoin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `metricsRelabelings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-metricsRelabelings}
+##### `metricsRelabelings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-metricsRelabelings}
 
 MetricsRelabelings allows you to configure extra metrics relabelings to add to the endpoint.
 
@@ -1174,7 +1174,7 @@ MetricsRelabelings allows you to configure extra metrics relabelings to add to t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `interval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-interval}
+##### `interval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-interval}
 
 Interval is the interval at which to scrape the endpoint.
 
@@ -1189,7 +1189,7 @@ Interval is the interval at which to scrape the endpoint.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scrapeTimeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-scrapeTimeout}
+##### `scrapeTimeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-scrapeTimeout}
 
 ScrapeTimeout is the timeout for the scrape of the endpoint.
 
@@ -1207,7 +1207,7 @@ ScrapeTimeout is the timeout for the scrape of the endpoint.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-spec}
 
 Spec allows you to configure extra service monitor options that will be merged into the spec.
 
@@ -1222,7 +1222,7 @@ Spec allows you to configure extra service monitor options that will be merged i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1237,7 +1237,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/experimental/denyProxyRequests.mdx
+++ b/vcluster/_partials/config/experimental/denyProxyRequests.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests}
+## `denyProxyRequests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -14,7 +14,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-name}
 
 The name of the check.
 
@@ -29,7 +29,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -46,7 +46,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules}
+### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -60,7 +60,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiGroups}
+#### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -75,7 +75,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiVersions}
+#### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -90,7 +90,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -105,7 +105,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-scope}
+#### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -120,7 +120,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-operations}
+#### `operations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -140,7 +140,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-excludedUsers}
+### `excludedUsers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.

--- a/vcluster/_partials/config/experimental/deploy.mdx
+++ b/vcluster/_partials/config/experimental/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -14,7 +14,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host}
+### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -26,7 +26,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifests}
+#### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -41,7 +41,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -59,7 +59,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster}
+### `vcluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -71,7 +71,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifests}
+#### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -86,7 +86,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -101,7 +101,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm}
+#### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -113,7 +113,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -125,7 +125,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-name}
 
 
 
@@ -140,7 +140,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-repo}
 
 
 
@@ -155,7 +155,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -170,7 +170,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-version}
 
 
 
@@ -185,7 +185,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-username}
 
 
 
@@ -200,7 +200,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-password}
 
 
 
@@ -218,7 +218,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -230,7 +230,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -245,7 +245,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -263,7 +263,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -278,7 +278,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -293,7 +293,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 

--- a/vcluster/_partials/config/experimental/docker.mdx
+++ b/vcluster/_partials/config/experimental/docker.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `docker` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker}
+## `docker` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker}
 
 Docker allows you to configure Docker related settings when deploying a vCluster using Docker.
 
@@ -14,7 +14,7 @@ Docker allows you to configure Docker related settings when deploying a vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-image}
+### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-image}
 
 Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container.
 
@@ -29,7 +29,7 @@ Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-ports}
+### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-ports}
 
 Ports defines extra port mappings to be added to the container.
 
@@ -44,7 +44,7 @@ Ports defines extra port mappings to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `volumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-volumes}
+### `volumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-volumes}
 
 Volumes defines extra volumes to be added to the container.
 
@@ -59,7 +59,7 @@ Volumes defines extra volumes to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-env}
+### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-env}
 
 Env defines extra environment variables to be added to the container. Use key=value.
 
@@ -74,7 +74,7 @@ Env defines extra environment variables to be added to the container. Use key=va
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-args}
+### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-args}
 
 Args defines extra arguments to be added to the docker run command of the container.
 
@@ -89,7 +89,7 @@ Args defines extra arguments to be added to the docker run command of the contai
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-enabled}
 
 Enabled defines if the vCluster was deployed using Docker. This is automatically set by vCluster and should not be set by the user.
 
@@ -104,7 +104,7 @@ Enabled defines if the vCluster was deployed using Docker. This is automatically
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `network` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-network}
+### `network` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-network}
 
 Network defines the network to use for the vCluster. If not specified, the a network will be created for the vCluster.
 
@@ -119,7 +119,7 @@ Network defines the network to use for the vCluster. If not specified, the a net
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes}
+### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes}
 
 Nodes defines the nodes of the vCluster.
 
@@ -131,7 +131,7 @@ Nodes defines the nodes of the vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-image}
 
 Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container.
 
@@ -146,7 +146,7 @@ Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-ports}
+#### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-ports}
 
 Ports defines extra port mappings to be added to the container.
 
@@ -161,7 +161,7 @@ Ports defines extra port mappings to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `volumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-volumes}
+#### `volumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-volumes}
 
 Volumes defines extra volumes to be added to the container.
 
@@ -176,7 +176,7 @@ Volumes defines extra volumes to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-env}
+#### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-env}
 
 Env defines extra environment variables to be added to the container. Use key=value.
 
@@ -191,7 +191,7 @@ Env defines extra environment variables to be added to the container. Use key=va
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-args}
+#### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-args}
 
 Args defines extra arguments to be added to the docker run command of the container.
 
@@ -206,7 +206,7 @@ Args defines extra arguments to be added to the docker run command of the contai
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-name}
 
 Name defines the name of the node. If not specified, a random name will be generated.
 
@@ -224,7 +224,7 @@ Name defines the name of the node. If not specified, a random name will be gener
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `registryProxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-registryProxy}
+### `registryProxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-registryProxy}
 
 Defines if docker images should be pulled from the host docker daemon. This prevents pulling images again and allows to
 use purely local images. Only works if containerd image storage is used. For more information, see https://docs.docker.com/engine/storage/containerd
@@ -237,7 +237,7 @@ use purely local images. Only works if containerd image storage is used. For mor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-registryProxy-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-registryProxy-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -255,7 +255,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `loadBalancer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-loadBalancer}
+### `loadBalancer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-loadBalancer}
 
 Defines if vCluster should configure load balancer services inside the vCluster. This might require
 sudo access on the host cluster for docker desktop or rancher desktop on macos.
@@ -268,7 +268,7 @@ sudo access on the host cluster for docker desktop or rancher desktop on macos.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-loadBalancer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-loadBalancer-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -283,7 +283,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `forwardPorts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-loadBalancer-forwardPorts}
+#### `forwardPorts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-loadBalancer-forwardPorts}
 
 ForwardPorts defines if the load balancer ips should be made available locally
 via port forwarding. This will be only done if necessary for example on macos when using docker desktop.

--- a/vcluster/_partials/config/experimental/proxy.mdx
+++ b/vcluster/_partials/config/experimental/proxy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
+## `proxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
 
 Proxy enables vCluster-to-vCluster proxying of resources
 
@@ -14,7 +14,7 @@ Proxy enables vCluster-to-vCluster proxying of resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources}
+### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources}
 
 CustomResources is a map of resource keys (format: "kind.apiGroup/version") to proxy configuration
 
@@ -26,7 +26,7 @@ CustomResources is a map of resource keys (format: "kind.apiGroup/version") to p
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-enabled}
 
 Enabled defines if this resource proxy should be enabled
 
@@ -41,7 +41,7 @@ Enabled defines if this resource proxy should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `targetVirtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster}
+#### `targetVirtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster}
 
 TargetVirtualCluster is the target virtual cluster for the custom resource proxy
 
@@ -53,7 +53,7 @@ TargetVirtualCluster is the target virtual cluster for the custom resource proxy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster-name}
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster-name}
 
 Name is the name of the target virtual cluster.
 
@@ -68,7 +68,7 @@ Name is the name of the target virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster-project}
 
 Project is the project of the target virtual cluster. If empty, defaults to the same project as the source vCluster.
 
@@ -86,7 +86,7 @@ Project is the project of the target virtual cluster. If empty, defaults to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `accessResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-accessResources}
+#### `accessResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-accessResources}
 
 AccessResources defines which resources should be accessible in the proxy.
 

--- a/vcluster/_partials/config/experimental/syncSettings.mdx
+++ b/vcluster/_partials/config/experimental/syncSettings.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings}
+## `syncSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -14,7 +14,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#syncSettings-setOwner}
+### `setOwner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -29,7 +29,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-hostMetricsBindAddress}
+### `hostMetricsBindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -44,7 +44,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-virtualMetricsBindAddress}
+### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 

--- a/vcluster/_partials/config/experimental/virtualClusterKubeConfig.mdx
+++ b/vcluster/_partials/config/experimental/virtualClusterKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig}
+## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 Deprecated: Removed in 0.29.0.
@@ -15,7 +15,7 @@ Deprecated: Removed in 0.29.0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -30,7 +30,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCAKey}
+### `serverCAKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -45,7 +45,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCACert}
+### `serverCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCACert}
 
 ServerCACert is the server ca cert path.
 
@@ -60,7 +60,7 @@ ServerCACert is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCACert}
+### `clientCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCACert}
 
 ClientCACert is the client ca cert path.
 
@@ -75,7 +75,7 @@ ClientCACert is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clientCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCAKey}
+### `clientCAKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCAKey}
 
 ClientCAKey is the client ca key path.
 
@@ -90,7 +90,7 @@ ClientCAKey is the client ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-requestHeaderCACert}
+### `requestHeaderCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 

--- a/vcluster/_partials/config/exportKubeConfig.mdx
+++ b/vcluster/_partials/config/exportKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `exportKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig}
+## `exportKubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig}
 
 ExportKubeConfig describes how vCluster should export the vCluster kubeConfig file.
 
@@ -14,7 +14,7 @@ ExportKubeConfig describes how vCluster should export the vCluster kubeConfig fi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-context}
+### `context` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -29,7 +29,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-server}
+### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -44,7 +44,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#exportKubeConfig-insecure}
+### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#exportKubeConfig-insecure}
 
 If tls should get skipped for the server
 
@@ -59,7 +59,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -71,7 +71,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -86,7 +86,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -102,7 +102,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -120,7 +120,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret}
+### `secret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret}
 
 Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
 If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
@@ -136,7 +136,7 @@ Deprecated: Use AdditionalSecrets instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-name}
 
 Name is the name of the secret where the kubeconfig should get stored.
 
@@ -151,7 +151,7 @@ Name is the name of the secret where the kubeconfig should get stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-namespace}
 
 Namespace where vCluster should store the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.
@@ -170,7 +170,7 @@ where you deployed vCluster, you need to make sure vCluster has access to this o
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `additionalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets}
+### `additionalSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets}
 
 AdditionalSecrets specifies the additional host cluster secrets in which vCluster will store the
 generated virtual cluster kubeconfigs.
@@ -183,7 +183,7 @@ generated virtual cluster kubeconfigs.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-context}
+#### `context` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -198,7 +198,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-server}
+#### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -213,7 +213,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-insecure}
+#### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-insecure}
 
 If tls should get skipped for the server
 
@@ -228,7 +228,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount}
+#### `serviceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -240,7 +240,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -255,7 +255,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -271,7 +271,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -289,7 +289,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-name}
 
 Name is the name of the secret where the kubeconfig is stored.
 
@@ -304,7 +304,7 @@ Name is the name of the secret where the kubeconfig is stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-namespace}
 
 Namespace where vCluster stores the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.

--- a/vcluster/_partials/config/integrations.mdx
+++ b/vcluster/_partials/config/integrations.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `integrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations}
+## `integrations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations}
 
 Integrations holds config for vCluster integrations with other operators or tools running on the host cluster
 
@@ -14,7 +14,7 @@ Integrations holds config for vCluster integrations with other operators or tool
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer}
+### `metricsServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -26,7 +26,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-metricsServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -41,7 +41,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService}
+#### `apiService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -53,7 +53,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -65,7 +65,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -80,7 +80,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -95,7 +95,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -116,7 +116,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-nodes}
+#### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -131,7 +131,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-pods}
+#### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 
@@ -149,7 +149,7 @@ Pods defines if metrics-server pods api should get proxied from host to virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt}
+### `kubeVirt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -161,7 +161,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -176,7 +176,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService}
+#### `apiService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -188,7 +188,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -200,7 +200,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -215,7 +215,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -230,7 +230,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -251,7 +251,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook}
+#### `webhook` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -263,7 +263,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -281,7 +281,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync}
+#### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -293,7 +293,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes}
+##### `dataVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -305,7 +305,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -323,7 +323,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
+##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -335,7 +335,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -353,7 +353,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances}
+##### `virtualMachineInstances` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -365,7 +365,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -383,7 +383,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines}
+##### `virtualMachines` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -395,7 +395,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -413,7 +413,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones}
+##### `virtualMachineClones` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -425,7 +425,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -443,7 +443,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools}
+##### `virtualMachinePools` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -455,7 +455,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -479,7 +479,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets}
+### `externalSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
 - ExternalSecrets will be synced from the virtual cluster to the host cluster.
@@ -494,7 +494,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -509,7 +509,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-version}
 
 Version defines the version of the external secrets operator to use. If empty, the storage version will be used.
 
@@ -524,7 +524,7 @@ Version defines the version of the external secrets operator to use. If empty, t
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook}
+#### `webhook` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -536,7 +536,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -554,7 +554,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync}
+#### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -566,7 +566,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost}
 
 ToHost defines what resources are synced from the virtual cluster to the host
 
@@ -578,7 +578,7 @@ ToHost defines what resources are synced from the virtual cluster to the host
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets}
+##### `externalSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets}
 
 ExternalSecrets allows to configure if only a subset of ExternalSecrets matching a label selector should get synced from the virtual cluster to the host cluster.
 
@@ -590,7 +590,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector}
 
 
 
@@ -602,7 +602,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
 
 
 
@@ -617,7 +617,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
 
 
 
@@ -629,22 +629,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
 
 
 
@@ -659,7 +644,22 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
 
 
 
@@ -683,7 +683,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores}
+##### `stores` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 
@@ -695,7 +695,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector}
 
 
 
@@ -707,7 +707,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchLabels}
 
 
 
@@ -722,7 +722,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions}
 
 
 
@@ -734,22 +734,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
 
 
 
@@ -764,7 +749,22 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
 
 
 
@@ -785,7 +785,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -806,7 +806,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost}
+##### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost}
 
 FromHost defines what resources are synced from the host cluster to the virtual cluster
 
@@ -818,7 +818,7 @@ FromHost defines what resources are synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores}
+##### `clusterStores` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
@@ -830,7 +830,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector}
 
 
 
@@ -842,7 +842,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
 
 
 
@@ -857,7 +857,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
 
 
 
@@ -869,22 +869,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
 
 
 
@@ -899,7 +884,22 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
 
 
 
@@ -920,7 +920,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -947,7 +947,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager}
+### `certManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -961,7 +961,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-certManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -976,7 +976,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync}
+#### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -988,7 +988,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost}
 
 
 
@@ -1000,7 +1000,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -1012,7 +1012,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1030,7 +1030,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -1042,7 +1042,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1063,7 +1063,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost}
+##### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost}
 
 
 
@@ -1075,7 +1075,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -1087,7 +1087,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1102,7 +1102,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -1114,7 +1114,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -1144,7 +1144,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio}
+### `istio` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio}
 
 Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
 
@@ -1156,7 +1156,7 @@ Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-istio-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-istio-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1171,7 +1171,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync}
+#### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync}
 
 
 
@@ -1183,7 +1183,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost}
 
 
 
@@ -1195,7 +1195,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules}
+##### `destinationRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules}
 
 
 
@@ -1207,7 +1207,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1225,7 +1225,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways}
+##### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways}
 
 
 
@@ -1237,7 +1237,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1255,7 +1255,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices}
+##### `virtualServices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices}
 
 
 
@@ -1267,7 +1267,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1294,7 +1294,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `netris` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris}
+### `netris` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris}
 
 Netris integration helps configuring netris networking for vCluster.
 
@@ -1306,7 +1306,7 @@ Netris integration helps configuring netris networking for vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-enabled}
 
 Enabled defines if netris integration is enabled
 
@@ -1321,7 +1321,7 @@ Enabled defines if netris integration is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-connector}
+#### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-connector}
 
 Connector specifies the netris connector name
 
@@ -1336,7 +1336,7 @@ Connector specifies the netris connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `kubeVip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip}
+#### `kubeVip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip}
 
 KubeVip holds kube-vip configuration for netris
 
@@ -1348,7 +1348,7 @@ KubeVip holds kube-vip configuration for netris
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `serverCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-serverCluster}
+##### `serverCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-serverCluster}
 
 ServerCluster specifies the server cluster name
 
@@ -1363,7 +1363,7 @@ ServerCluster specifies the server cluster name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bridge` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-bridge}
+##### `bridge` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-bridge}
 
 Bridge specifies the bridge interface name
 
@@ -1378,7 +1378,7 @@ Bridge specifies the bridge interface name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ipRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-ipRange}
+##### `ipRange` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-ipRange}
 
 IPRange specifies the IP range for kube-vip
 
@@ -1399,7 +1399,7 @@ IPRange specifies the IP range for kube-vip
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `argoCD` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD}
+### `argoCD` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD}
 
 ArgoCD integration helps configuring ArgoCD for vCluster.
 
@@ -1411,7 +1411,7 @@ ArgoCD integration helps configuring ArgoCD for vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD-enabled}
 
 Enabled defines if argo cd integration is enabled
 
@@ -1426,7 +1426,7 @@ Enabled defines if argo cd integration is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD-connector}
+#### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD-connector}
 
 Connector specifies the argo cd connector name
 

--- a/vcluster/_partials/config/integrations/certManager.mdx
+++ b/vcluster/_partials/config/integrations/certManager.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager}
+## `certManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -16,7 +16,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#certManager-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -31,7 +31,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync}
+### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -43,7 +43,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost}
 
 
 
@@ -55,7 +55,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -67,7 +67,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -85,7 +85,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -97,7 +97,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -118,7 +118,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost}
 
 
 
@@ -130,7 +130,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -142,7 +142,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -157,7 +157,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -169,7 +169,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 

--- a/vcluster/_partials/config/integrations/externalSecrets.mdx
+++ b/vcluster/_partials/config/integrations/externalSecrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets}
+## `externalSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
 - ExternalSecrets will be synced from the virtual cluster to the host cluster.
@@ -17,7 +17,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -32,7 +32,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-version}
+### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-version}
 
 Version defines the version of the external secrets operator to use. If empty, the storage version will be used.
 
@@ -47,7 +47,7 @@ Version defines the version of the external secrets operator to use. If empty, t
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-webhook}
+### `webhook` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -59,7 +59,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -77,7 +77,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync}
+### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -89,7 +89,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost}
 
 ToHost defines what resources are synced from the virtual cluster to the host
 
@@ -101,7 +101,7 @@ ToHost defines what resources are synced from the virtual cluster to the host
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets}
+##### `externalSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets}
 
 ExternalSecrets allows to configure if only a subset of ExternalSecrets matching a label selector should get synced from the virtual cluster to the host cluster.
 
@@ -113,7 +113,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector}
 
 
 
@@ -125,7 +125,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
 
 
 
@@ -140,7 +140,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
 
 
 
@@ -152,22 +152,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
 
 
 
@@ -182,7 +167,22 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
 
 
 
@@ -206,7 +206,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores}
+##### `stores` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 
@@ -218,7 +218,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector}
 
 
 
@@ -230,7 +230,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchLabels}
 
 
 
@@ -245,7 +245,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions}
 
 
 
@@ -257,22 +257,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
 
 
 
@@ -287,7 +272,22 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
 
 
 
@@ -308,7 +308,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -329,7 +329,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost}
 
 FromHost defines what resources are synced from the host cluster to the virtual cluster
 
@@ -341,7 +341,7 @@ FromHost defines what resources are synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores}
+##### `clusterStores` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
@@ -353,7 +353,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector}
 
 
 
@@ -365,7 +365,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
 
 
 
@@ -380,7 +380,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
 
 
 
@@ -392,22 +392,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
 
 
 
@@ -422,7 +407,22 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
 
 
 
@@ -443,7 +443,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster/_partials/config/integrations/istio.mdx
+++ b/vcluster/_partials/config/integrations/istio.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio}
+## `istio` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio}
 
 Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
 
@@ -14,7 +14,7 @@ Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#istio-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#istio-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync}
+### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync}
 
 
 
@@ -41,7 +41,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost}
 
 
 
@@ -53,7 +53,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules}
+##### `destinationRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules}
 
 
 
@@ -65,37 +65,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules-enabled}
-
-Enabled defines if this option should be enabled.
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -113,7 +83,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices}
+##### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways}
 
 
 
@@ -125,7 +95,37 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualServices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster/_partials/config/integrations/kubeVirt.mdx
+++ b/vcluster/_partials/config/integrations/kubeVirt.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt}
+## `kubeVirt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -14,7 +14,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -29,7 +29,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService}
+### `apiService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service}
+#### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-webhook}
+### `webhook` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -116,7 +116,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -134,7 +134,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync}
+### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -146,7 +146,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes}
+#### `dataVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -158,7 +158,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -176,7 +176,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
+#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -188,7 +188,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -206,7 +206,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances}
+#### `virtualMachineInstances` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -218,7 +218,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -236,7 +236,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines}
+#### `virtualMachines` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -248,7 +248,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -266,7 +266,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones}
+#### `virtualMachineClones` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -278,7 +278,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -296,7 +296,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools}
+#### `virtualMachinePools` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -308,7 +308,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster/_partials/config/integrations/metricsServer.mdx
+++ b/vcluster/_partials/config/integrations/metricsServer.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer}
+## `metricsServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -14,7 +14,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#metricsServer-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -29,7 +29,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService}
+### `apiService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service}
+#### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-nodes}
+### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -119,7 +119,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-pods}
+### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 

--- a/vcluster/_partials/config/integrations/netris.mdx
+++ b/vcluster/_partials/config/integrations/netris.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `netris` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris}
+## `netris` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris}
 
 Netris integration helps configuring netris networking for vCluster.
 
@@ -14,7 +14,7 @@ Netris integration helps configuring netris networking for vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-enabled}
 
 Enabled defines if netris integration is enabled
 
@@ -29,7 +29,7 @@ Enabled defines if netris integration is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-connector}
+### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-connector}
 
 Connector specifies the netris connector name
 
@@ -44,7 +44,7 @@ Connector specifies the netris connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip}
+### `kubeVip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip}
 
 KubeVip holds kube-vip configuration for netris
 
@@ -56,7 +56,7 @@ KubeVip holds kube-vip configuration for netris
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-serverCluster}
+#### `serverCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-serverCluster}
 
 ServerCluster specifies the server cluster name
 
@@ -71,7 +71,7 @@ ServerCluster specifies the server cluster name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `bridge` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-bridge}
+#### `bridge` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-bridge}
 
 Bridge specifies the bridge interface name
 
@@ -86,7 +86,7 @@ Bridge specifies the bridge interface name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ipRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-ipRange}
+#### `ipRange` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-ipRange}
 
 IPRange specifies the IP range for kube-vip
 

--- a/vcluster/_partials/config/logging.mdx
+++ b/vcluster/_partials/config/logging.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `logging` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#logging}
+## `logging` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#logging}
 
 Logging provides structured logging options
 
@@ -14,7 +14,7 @@ Logging provides structured logging options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `encoding` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">console</span> <span className="config-field-enum"></span> {#logging-encoding}
+### `encoding` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">console</span> <span className="config-field-enum"></span> {#logging-encoding}
 
 Encoding specifies the format of vCluster logs, it can either be json or console.
 

--- a/vcluster/_partials/config/networking.mdx
+++ b/vcluster/_partials/config/networking.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networking` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking}
+## `networking` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking}
 
 Networking options related to the virtual cluster.
 
@@ -14,7 +14,7 @@ Networking options related to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serviceCIDR` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-serviceCIDR}
+### `serviceCIDR` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-serviceCIDR}
 
 ServiceCIDR holds the service cidr for the virtual cluster. This should only be set if privateNodes.enabled is true or vCluster cannot detect the host service cidr.
 
@@ -29,7 +29,7 @@ ServiceCIDR holds the service cidr for the virtual cluster. This should only be 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `podCIDR` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">10.244.0.0/16</span> <span className="config-field-enum"></span> {#networking-podCIDR}
+### `podCIDR` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">10.244.0.0/16</span> <span className="config-field-enum"></span> {#networking-podCIDR}
 
 PodCIDR holds the pod cidr for the virtual cluster. This should only be set if privateNodes.enabled is true.
 
@@ -44,7 +44,7 @@ PodCIDR holds the pod cidr for the virtual cluster. This should only be set if p
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices}
+### `replicateServices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -56,7 +56,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost}
+#### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -70,7 +70,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -85,7 +85,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -103,7 +103,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -115,7 +115,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -130,7 +130,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -151,7 +151,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS}
+### `resolveDNS` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -163,7 +163,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-hostname}
+#### `hostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -178,7 +178,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-service}
+#### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -193,7 +193,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -208,7 +208,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target}
+#### `target` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -220,7 +220,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostname}
+##### `hostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -235,7 +235,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-ip}
+##### `ip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -250,7 +250,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostService}
+##### `hostService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -265,7 +265,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostNamespace}
+##### `hostNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -280,7 +280,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-vClusterService}
+##### `vClusterService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 
@@ -301,7 +301,7 @@ VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterS
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced}
+### `advanced` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced}
 
 Advanced holds advanced network options.
 
@@ -313,7 +313,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#networking-advanced-clusterDomain}
+#### `clusterDomain` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#networking-advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -328,7 +328,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networking-advanced-fallbackHostCluster}
+#### `fallbackHostCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networking-advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -344,7 +344,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets}
+#### `proxyKubelets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -357,7 +357,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byHostname}
+##### `byHostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -373,7 +373,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byIP}
+##### `byIP` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster/_partials/config/networking/advanced.mdx
+++ b/vcluster/_partials/config/networking/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds advanced network options.
 
@@ -14,7 +14,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#advanced-clusterDomain}
+### `clusterDomain` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -29,7 +29,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-fallbackHostCluster}
+### `fallbackHostCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -45,7 +45,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-proxyKubelets}
+### `proxyKubelets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -58,7 +58,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byHostname}
+#### `byHostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -74,7 +74,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byIP}
+#### `byIP` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster/_partials/config/networking/replicateServices.mdx
+++ b/vcluster/_partials/config/networking/replicateServices.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices}
+## `replicateServices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -14,7 +14,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost}
+### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -28,7 +28,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-from}
+#### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -43,7 +43,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-to}
+#### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -61,7 +61,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -73,7 +73,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-from}
+#### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -88,7 +88,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-to}
+#### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 

--- a/vcluster/_partials/config/networking/resolveDNS.mdx
+++ b/vcluster/_partials/config/networking/resolveDNS.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS}
+## `resolveDNS` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -14,7 +14,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-hostname}
+### `hostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -29,7 +29,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-service}
+### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -44,7 +44,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-namespace}
+### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -59,7 +59,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target}
+### `target` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -71,7 +71,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostname}
+#### `hostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -86,7 +86,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-ip}
+#### `ip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -101,7 +101,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostService}
+#### `hostService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -116,7 +116,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostNamespace}
+#### `hostNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -131,7 +131,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-vClusterService}
+#### `vClusterService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 

--- a/vcluster/_partials/config/platform.mdx
+++ b/vcluster/_partials/config/platform.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform}
+## `platform` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform}
 
 Platform holds vCluster Platform specific configuration.
 
@@ -14,7 +14,7 @@ Platform holds vCluster Platform specific configuration.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey}
+### `apiKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey}
 
 APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
 * environment variable called LICENSE
@@ -29,7 +29,7 @@ APIKey defines where to find the platform access key and host. By default, vClus
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-secretName}
 
 SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.
 
@@ -44,7 +44,7 @@ SecretName is the name of the secret where the platform access key is stored. Th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-namespace}
 
 Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace
 where the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.
@@ -60,7 +60,7 @@ where the vCluster instance is deployed, you need to make sure vCluster has acce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-createRBAC}
+#### `createRBAC` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-createRBAC}
 
 CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified
 in the above namespace, if specified.
@@ -80,7 +80,7 @@ This defaults to true.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-project}
+### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-project}
 
 Project specifies which platform project the vcluster should be imported to
 

--- a/vcluster/_partials/config/plugins.mdx
+++ b/vcluster/_partials/config/plugins.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `plugins` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins}
+## `plugins` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins}
 
 Define which vCluster plugins to load.
 
@@ -14,7 +14,7 @@ Define which vCluster plugins to load.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-name}
 
 Name is the name of the init-container and NOT the plugin name
 
@@ -29,7 +29,7 @@ Name is the name of the init-container and NOT the plugin name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-image}
+### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-image}
 
 Image is the container image that should be used for the plugin
 
@@ -44,7 +44,7 @@ Image is the container image that should be used for the plugin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-imagePullPolicy}
 
 ImagePullPolicy is the pull policy to use for the container image
 
@@ -59,7 +59,7 @@ ImagePullPolicy is the pull policy to use for the container image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-config}
+### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-config}
 
 Config is the plugin config to use. This can be arbitrary config used for the plugin.
 
@@ -74,7 +74,7 @@ Config is the plugin config to use. This can be arbitrary config used for the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac}
+### `rbac` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac}
 
 RBAC holds additional rbac configuration for the plugin
 
@@ -86,7 +86,7 @@ RBAC holds additional rbac configuration for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role}
+#### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role}
 
 Role holds extra virtual cluster role permissions for the plugin
 
@@ -98,7 +98,7 @@ Role holds extra virtual cluster role permissions for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -110,7 +110,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -125,7 +125,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -141,7 +141,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -156,7 +156,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -171,7 +171,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -194,7 +194,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole}
 
 ClusterRole holds extra virtual cluster cluster role permissions required for the plugin
 
@@ -206,7 +206,7 @@ ClusterRole holds extra virtual cluster cluster role permissions required for th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -218,7 +218,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -233,7 +233,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -249,7 +249,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -264,7 +264,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -279,7 +279,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -305,7 +305,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-command}
+### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-command}
 
 Command is the command that should be used for the init container
 
@@ -320,7 +320,7 @@ Command is the command that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-args}
+### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-args}
 
 Args are the arguments that should be used for the init container
 
@@ -335,7 +335,7 @@ Args are the arguments that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-securityContext}
 
 SecurityContext is the container security context used for the init container
 
@@ -350,7 +350,7 @@ SecurityContext is the container security context used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-resources}
+### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-resources}
 
 Resources are the container resources used for the init container
 
@@ -365,7 +365,7 @@ Resources are the container resources used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `volumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-volumeMounts}
+### `volumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-volumeMounts}
 
 VolumeMounts are extra volume mounts for the init container
 

--- a/vcluster/_partials/config/policies.mdx
+++ b/vcluster/_partials/config/policies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `policies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies}
+## `policies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies}
 
 Policies to enforce for the virtual cluster deployment as well as within the virtual cluster.
 
@@ -14,7 +14,7 @@ Policies to enforce for the virtual cluster deployment as well as within the vir
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy}
+### `networkPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -26,7 +26,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#policies-networkPolicy-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#policies-networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -41,7 +41,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -56,7 +56,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-labels}
 
 Labels are extra labels for this resource.
 
@@ -71,7 +71,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#policies-networkPolicy-fallbackDns}
+#### `fallbackDns` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#policies-networkPolicy-fallbackDns}
 
 FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server.
 
@@ -86,7 +86,7 @@ FallbackDNS is the fallback DNS server to use if the virtual cluster does not ha
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane}
+#### `controlPlane` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane}
 
 ControlPlane network policy rules
 
@@ -98,7 +98,7 @@ ControlPlane network policy rules
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress}
 
 Ingress rules for the vCluster control plane.
 
@@ -110,7 +110,7 @@ Ingress rules for the vCluster control plane.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports}
 
 ports is a list of ports which should be made accessible on the pods selected for
 this rule. Each item in this list is combined using a logical OR. If this field is
@@ -126,7 +126,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -142,7 +142,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -160,7 +160,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -181,7 +181,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from}
 
 from is a list of sources which should be able to access the pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -197,7 +197,7 @@ allows traffic only if the traffic matches at least one item in the from list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -214,7 +214,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchLabels}
 
 
 
@@ -229,7 +229,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions}
 
 
 
@@ -241,22 +241,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-key}
 
 
 
@@ -271,7 +256,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-values}
 
 
 
@@ -292,7 +292,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -309,7 +309,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchLabels}
 
 
 
@@ -324,7 +324,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions}
 
 
 
@@ -336,22 +336,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-key}
 
 
 
@@ -366,7 +351,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-values}
 
 
 
@@ -387,7 +387,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -400,7 +400,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -416,7 +416,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -441,7 +441,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `egress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress}
+##### `egress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress}
 
 Egress rules for the vCluster control plane.
 
@@ -453,7 +453,7 @@ Egress rules for the vCluster control plane.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports}
 
 ports is a list of destination ports for outgoing traffic.
 Each item in this list is combined using a logical OR. If this field is
@@ -469,7 +469,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -485,7 +485,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -503,7 +503,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -524,7 +524,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to}
 
 to is a list of destinations for outgoing traffic of pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -540,7 +540,7 @@ allows traffic only if the traffic matches at least one item in the to list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -557,7 +557,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchLabels}
 
 
 
@@ -572,7 +572,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions}
 
 
 
@@ -584,22 +584,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-key}
 
 
 
@@ -614,7 +599,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-values}
 
 
 
@@ -635,7 +635,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -652,7 +652,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchLabels}
 
 
 
@@ -667,7 +667,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions}
 
 
 
@@ -679,22 +679,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-key}
 
 
 
@@ -709,7 +694,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-values}
 
 
 
@@ -730,7 +730,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -743,7 +743,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -759,7 +759,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -787,7 +787,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `workload` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload}
+#### `workload` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload}
 
 Workload network policy rules
 
@@ -799,7 +799,7 @@ Workload network policy rules
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `publicEgress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress}
+##### `publicEgress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress}
 
 PublicEgress holds the public outgoing connections options for the vCluster workloads.
 
@@ -811,7 +811,7 @@ PublicEgress holds the public outgoing connections options for the vCluster work
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-enabled}
 
 Enabled defines if the workload public egress should be enabled or disabled.
 
@@ -826,7 +826,7 @@ Enabled defines if the workload public egress should be enabled or disabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -842,7 +842,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -861,7 +861,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress}
 
 Ingress rules for the vCluster workloads.
 
@@ -873,7 +873,7 @@ Ingress rules for the vCluster workloads.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports}
 
 ports is a list of ports which should be made accessible on the pods selected for
 this rule. Each item in this list is combined using a logical OR. If this field is
@@ -889,7 +889,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -905,7 +905,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -923,7 +923,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -944,7 +944,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from}
 
 from is a list of sources which should be able to access the pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -960,7 +960,7 @@ allows traffic only if the traffic matches at least one item in the from list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -977,7 +977,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchLabels}
 
 
 
@@ -992,7 +992,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions}
 
 
 
@@ -1004,22 +1004,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-key}
 
 
 
@@ -1034,7 +1019,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-values}
 
 
 
@@ -1055,7 +1055,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -1072,7 +1072,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchLabels}
 
 
 
@@ -1087,7 +1087,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions}
 
 
 
@@ -1099,22 +1099,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-key}
 
 
 
@@ -1129,7 +1114,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-values}
 
 
 
@@ -1150,7 +1150,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -1163,7 +1163,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -1179,7 +1179,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -1204,7 +1204,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `egress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress}
+##### `egress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress}
 
 Egress rules for the vCluster workloads.
 
@@ -1216,7 +1216,7 @@ Egress rules for the vCluster workloads.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports}
 
 ports is a list of destination ports for outgoing traffic.
 Each item in this list is combined using a logical OR. If this field is
@@ -1232,7 +1232,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -1248,7 +1248,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -1266,7 +1266,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -1287,7 +1287,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to}
 
 to is a list of destinations for outgoing traffic of pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -1303,7 +1303,7 @@ allows traffic only if the traffic matches at least one item in the to list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -1320,7 +1320,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchLabels}
 
 
 
@@ -1335,7 +1335,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions}
 
 
 
@@ -1347,22 +1347,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-key}
 
 
 
@@ -1377,7 +1362,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-values}
 
 
 
@@ -1398,7 +1398,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -1415,7 +1415,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchLabels}
 
 
 
@@ -1430,7 +1430,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions}
 
 
 
@@ -1442,22 +1442,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-key}
 
 
 
@@ -1472,7 +1457,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-values}
 
 
 
@@ -1493,7 +1493,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -1506,7 +1506,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -1522,7 +1522,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -1553,7 +1553,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-podSecurityStandard}
+### `podSecurityStandard` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 
@@ -1568,7 +1568,7 @@ PodSecurityStandard that can be enforced can be one of: empty (""), baseline, re
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-resourceQuota}
+### `resourceQuota` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -1580,7 +1580,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-resourceQuota-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -1596,7 +1596,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-quota}
+#### `quota` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-quota}
 
 Quota are the quota options
 
@@ -1611,7 +1611,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopeSelector}
+#### `scopeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -1626,7 +1626,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopes}
+#### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -1641,7 +1641,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1656,7 +1656,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-labels}
 
 Labels are extra labels for this resource.
 
@@ -1674,7 +1674,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-limitRange}
+### `limitRange` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-limitRange}
 
 LimitRange specifies limit range options.
 
@@ -1686,7 +1686,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-limitRange-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -1702,7 +1702,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-default}
+#### `default` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -1717,7 +1717,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-defaultRequest}
+#### `defaultRequest` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -1732,7 +1732,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-max}
+#### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -1747,7 +1747,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-min}
+#### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -1762,7 +1762,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1777,7 +1777,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-labels}
 
 Labels are extra labels for this resource.
 
@@ -1795,7 +1795,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission}
+### `centralAdmission` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -1807,7 +1807,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks}
+#### `validatingWebhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -1819,7 +1819,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -1835,7 +1835,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -1852,7 +1852,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -1864,7 +1864,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -1882,7 +1882,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -1899,7 +1899,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -1918,7 +1918,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -1930,7 +1930,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -1948,7 +1948,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -1960,7 +1960,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -1977,7 +1977,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -1992,7 +1992,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -2007,7 +2007,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -2022,7 +2022,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -2038,7 +2038,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -2058,7 +2058,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -2077,7 +2077,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -2093,7 +2093,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -2109,7 +2109,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -2125,7 +2125,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -2144,7 +2144,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -2162,7 +2162,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -2177,7 +2177,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -2192,7 +2192,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -2208,7 +2208,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -2232,7 +2232,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks}
+#### `mutatingWebhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -2244,7 +2244,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -2260,7 +2260,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -2277,7 +2277,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -2289,7 +2289,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -2307,7 +2307,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -2324,7 +2324,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -2343,7 +2343,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -2355,7 +2355,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -2371,7 +2371,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -2389,7 +2389,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -2401,7 +2401,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -2418,7 +2418,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -2433,7 +2433,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -2448,7 +2448,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -2463,7 +2463,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -2479,7 +2479,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -2499,7 +2499,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -2518,7 +2518,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -2534,7 +2534,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -2550,7 +2550,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -2566,7 +2566,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -2585,7 +2585,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -2603,7 +2603,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -2618,7 +2618,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -2633,7 +2633,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -2649,7 +2649,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster/_partials/config/policies/centralAdmission.mdx
+++ b/vcluster/_partials/config/policies/centralAdmission.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission}
+## `centralAdmission` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -14,7 +14,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks}
+### `validatingWebhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -26,7 +26,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -42,7 +42,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -59,7 +59,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -71,7 +71,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -89,7 +89,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -106,7 +106,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -125,7 +125,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -137,7 +137,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -155,7 +155,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -167,7 +167,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -184,7 +184,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -199,7 +199,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -214,7 +214,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -229,7 +229,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -245,7 +245,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -265,7 +265,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -284,7 +284,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -300,7 +300,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -316,7 +316,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -332,7 +332,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -351,7 +351,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -369,7 +369,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -384,7 +384,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -399,7 +399,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -415,7 +415,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -439,7 +439,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks}
+### `mutatingWebhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -451,7 +451,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -467,7 +467,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -484,7 +484,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -496,7 +496,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -514,7 +514,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -531,7 +531,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -550,7 +550,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -562,7 +562,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -578,7 +578,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -596,7 +596,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -608,7 +608,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -625,7 +625,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -640,7 +640,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -655,7 +655,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -670,7 +670,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -686,7 +686,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -706,7 +706,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -725,7 +725,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -741,7 +741,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -757,7 +757,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -773,7 +773,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -792,7 +792,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -810,7 +810,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -825,7 +825,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -840,7 +840,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -856,7 +856,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster/_partials/config/policies/limitRange.mdx
+++ b/vcluster/_partials/config/policies/limitRange.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#limitRange}
+## `limitRange` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#limitRange}
 
 LimitRange specifies limit range options.
 
@@ -14,7 +14,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#limitRange-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -30,7 +30,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-default}
+### `default` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -45,7 +45,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-defaultRequest}
+### `defaultRequest` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -60,7 +60,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-max}
+### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -75,7 +75,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-min}
+### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -90,7 +90,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -105,7 +105,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/policies/networkPolicy.mdx
+++ b/vcluster/_partials/config/policies/networkPolicy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy}
+## `networkPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -14,7 +14,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicy-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -29,7 +29,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -44,7 +44,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-labels}
 
 Labels are extra labels for this resource.
 
@@ -59,7 +59,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#networkPolicy-fallbackDns}
+### `fallbackDns` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#networkPolicy-fallbackDns}
 
 FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server.
 
@@ -74,7 +74,7 @@ FallbackDNS is the fallback DNS server to use if the virtual cluster does not ha
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane}
+### `controlPlane` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane}
 
 ControlPlane network policy rules
 
@@ -86,7 +86,7 @@ ControlPlane network policy rules
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress}
+#### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress}
 
 Ingress rules for the vCluster control plane.
 
@@ -98,7 +98,7 @@ Ingress rules for the vCluster control plane.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports}
 
 ports is a list of ports which should be made accessible on the pods selected for
 this rule. Each item in this list is combined using a logical OR. If this field is
@@ -114,7 +114,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -130,7 +130,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -148,7 +148,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -169,7 +169,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from}
 
 from is a list of sources which should be able to access the pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -185,7 +185,7 @@ allows traffic only if the traffic matches at least one item in the from list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -202,7 +202,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchLabels}
 
 
 
@@ -217,7 +217,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions}
 
 
 
@@ -229,22 +229,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-key}
 
 
 
@@ -259,7 +244,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-values}
 
 
 
@@ -280,7 +280,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -297,7 +297,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchLabels}
 
 
 
@@ -312,7 +312,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions}
 
 
 
@@ -324,22 +324,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-key}
 
 
 
@@ -354,7 +339,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-values}
 
 
 
@@ -375,7 +375,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -388,7 +388,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -404,7 +404,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -429,7 +429,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `egress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress}
+#### `egress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress}
 
 Egress rules for the vCluster control plane.
 
@@ -441,7 +441,7 @@ Egress rules for the vCluster control plane.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports}
 
 ports is a list of destination ports for outgoing traffic.
 Each item in this list is combined using a logical OR. If this field is
@@ -457,7 +457,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -473,7 +473,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -491,7 +491,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -512,7 +512,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to}
 
 to is a list of destinations for outgoing traffic of pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -528,7 +528,7 @@ allows traffic only if the traffic matches at least one item in the to list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -545,7 +545,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchLabels}
 
 
 
@@ -560,7 +560,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions}
 
 
 
@@ -572,22 +572,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-key}
 
 
 
@@ -602,7 +587,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-values}
 
 
 
@@ -623,7 +623,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -640,7 +640,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchLabels}
 
 
 
@@ -655,7 +655,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions}
 
 
 
@@ -667,22 +667,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-key}
 
 
 
@@ -697,7 +682,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-values}
 
 
 
@@ -718,7 +718,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -731,7 +731,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -747,7 +747,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -775,7 +775,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `workload` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload}
+### `workload` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload}
 
 Workload network policy rules
 
@@ -787,7 +787,7 @@ Workload network policy rules
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `publicEgress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress}
+#### `publicEgress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress}
 
 PublicEgress holds the public outgoing connections options for the vCluster workloads.
 
@@ -799,7 +799,7 @@ PublicEgress holds the public outgoing connections options for the vCluster work
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-enabled}
 
 Enabled defines if the workload public egress should be enabled or disabled.
 
@@ -814,7 +814,7 @@ Enabled defines if the workload public egress should be enabled or disabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -830,7 +830,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -849,7 +849,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress}
+#### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress}
 
 Ingress rules for the vCluster workloads.
 
@@ -861,7 +861,7 @@ Ingress rules for the vCluster workloads.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports}
 
 ports is a list of ports which should be made accessible on the pods selected for
 this rule. Each item in this list is combined using a logical OR. If this field is
@@ -877,7 +877,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -893,7 +893,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -911,7 +911,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -932,7 +932,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from}
 
 from is a list of sources which should be able to access the pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -948,7 +948,7 @@ allows traffic only if the traffic matches at least one item in the from list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -965,7 +965,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchLabels}
 
 
 
@@ -980,7 +980,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions}
 
 
 
@@ -992,22 +992,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-key}
 
 
 
@@ -1022,7 +1007,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-values}
 
 
 
@@ -1043,7 +1043,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -1060,7 +1060,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchLabels}
 
 
 
@@ -1075,7 +1075,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions}
 
 
 
@@ -1087,22 +1087,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-key}
 
 
 
@@ -1117,7 +1102,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-values}
 
 
 
@@ -1138,7 +1138,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -1151,7 +1151,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -1167,7 +1167,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -1192,7 +1192,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `egress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress}
+#### `egress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress}
 
 Egress rules for the vCluster workloads.
 
@@ -1204,7 +1204,7 @@ Egress rules for the vCluster workloads.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports}
 
 ports is a list of destination ports for outgoing traffic.
 Each item in this list is combined using a logical OR. If this field is
@@ -1220,7 +1220,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -1236,7 +1236,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -1254,7 +1254,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -1275,7 +1275,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to}
 
 to is a list of destinations for outgoing traffic of pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -1291,7 +1291,7 @@ allows traffic only if the traffic matches at least one item in the to list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -1308,7 +1308,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchLabels}
 
 
 
@@ -1323,7 +1323,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions}
 
 
 
@@ -1335,22 +1335,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-key}
 
 
 
@@ -1365,7 +1350,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-values}
 
 
 
@@ -1386,7 +1386,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -1403,7 +1403,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchLabels}
 
 
 
@@ -1418,7 +1418,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions}
 
 
 
@@ -1430,22 +1430,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-key}
 
 
 
@@ -1460,7 +1445,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-values}
 
 
 
@@ -1481,7 +1481,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -1494,7 +1494,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -1510,7 +1510,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".

--- a/vcluster/_partials/config/policies/podSecurityStandard.mdx
+++ b/vcluster/_partials/config/policies/podSecurityStandard.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podSecurityStandard}
+## `podSecurityStandard` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 

--- a/vcluster/_partials/config/policies/resourceQuota.mdx
+++ b/vcluster/_partials/config/policies/resourceQuota.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resourceQuota}
+## `resourceQuota` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -14,7 +14,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#resourceQuota-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -30,7 +30,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-quota}
+### `quota` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-quota}
 
 Quota are the quota options
 
@@ -45,7 +45,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopeSelector}
+### `scopeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -60,7 +60,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopes}
+### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -75,7 +75,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -90,7 +90,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/privateNodes.mdx
+++ b/vcluster/_partials/config/privateNodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `privateNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes}
+## `privateNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes}
 
 PrivateNodes holds configuration for vCluster private nodes mode.
 
@@ -14,7 +14,7 @@ PrivateNodes holds configuration for vCluster private nodes mode.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-enabled}
 
 Enabled defines if dedicated nodes should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if dedicated nodes should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubelet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-kubelet}
+### `kubelet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-kubelet}
 
 Kubelet holds kubelet configuration that is used for all nodes.
 
@@ -41,7 +41,7 @@ Kubelet holds kubelet configuration that is used for all nodes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-kubelet-config}
+#### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-kubelet-config}
 
 Config is the config for the kubelet that will be merged into the default kubelet config. More information can be found here:
 https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
@@ -60,7 +60,7 @@ https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoUpgrade` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade}
+### `autoUpgrade` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade}
 
 AutoUpgrade holds configuration for auto upgrade.
 
@@ -72,7 +72,7 @@ AutoUpgrade holds configuration for auto upgrade.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-enabled}
 
 Enabled defines if auto upgrade should be enabled.
 
@@ -87,7 +87,7 @@ Enabled defines if auto upgrade should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-image}
 
 Image is the image for the auto upgrade pod started by vCluster. If empty defaults to the controlPlane.statefulSet.image.
 
@@ -102,7 +102,7 @@ Image is the image for the auto upgrade pod started by vCluster. If empty defaul
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -117,7 +117,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-nodeSelector}
 
 NodeSelector is the node selector for the auto upgrade. If empty will select all worker nodes.
 
@@ -132,7 +132,7 @@ NodeSelector is the node selector for the auto upgrade. If empty will select all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `binariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-binariesPath}
+#### `binariesPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-binariesPath}
 
 BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/bin
 
@@ -147,7 +147,7 @@ BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `cniBinariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-cniBinariesPath}
+#### `cniBinariesPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-cniBinariesPath}
 
 CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 
@@ -162,7 +162,7 @@ CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `concurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-concurrency}
+#### `concurrency` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-concurrency}
 
 Concurrency is the number of nodes that can be upgraded at the same time.
 
@@ -177,7 +177,7 @@ Concurrency is the number of nodes that can be upgraded at the same time.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level for the upgrade pod.
 
@@ -192,7 +192,7 @@ PodSecurityContext specifies security context options on the pod level for the u
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level for the upgrade container.
 
@@ -210,7 +210,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode}
+### `joinNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode}
 
 JoinNode holds configuration specifically used during joining the node (see "kubeadm join").
 
@@ -222,7 +222,7 @@ JoinNode holds configuration specifically used during joining the node (see "kub
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preInstallCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-preInstallCommands}
+#### `preInstallCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-preInstallCommands}
 
 PreInstallCommands are commands that will be executed before containerd, kubelet etc. is installed.
 
@@ -237,7 +237,7 @@ PreInstallCommands are commands that will be executed before containerd, kubelet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-preJoinCommands}
+#### `preJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-preJoinCommands}
 
 PreJoinCommands are commands that will be executed before kubeadm join is executed.
 
@@ -252,7 +252,7 @@ PreJoinCommands are commands that will be executed before kubeadm join is execut
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-postJoinCommands}
+#### `postJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-postJoinCommands}
 
 PostJoinCommands are commands that will be executed after kubeadm join is executed.
 
@@ -267,7 +267,7 @@ PostJoinCommands are commands that will be executed after kubeadm join is execut
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd}
+#### `containerd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd}
 
 Containerd holds configuration for the containerd join process.
 
@@ -279,7 +279,7 @@ Containerd holds configuration for the containerd join process.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-enabled}
 
 Enabled defines if containerd should be installed and configured by vCluster.
 
@@ -294,7 +294,7 @@ Enabled defines if containerd should be installed and configured by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry}
 
 Registry holds configuration for how containerd should be configured to use a registries.
 
@@ -306,7 +306,7 @@ Registry holds configuration for how containerd should be configured to use a re
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-configPath}
+##### `configPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-configPath}
 
 ConfigPath is the path to the containerd registry config.
 
@@ -321,7 +321,7 @@ ConfigPath is the path to the containerd registry config.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors}
+##### `mirrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors}
 
 Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -333,7 +333,7 @@ Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-server}
 
 Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -348,7 +348,7 @@ Server is the fallback server to use for the containerd registry mirror. E.g. ht
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror.
 
@@ -363,7 +363,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -378,7 +378,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -393,7 +393,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -408,7 +408,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts}
+##### `hosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts}
 
 Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -420,7 +420,7 @@ Hosts holds configuration for the containerd registry mirror hosts. See https://
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-server}
 
 Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
 
@@ -435,7 +435,7 @@ Server is the server to use for the containerd registry mirror host. E.g. http:/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror host.
 
@@ -450,7 +450,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror ho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -465,7 +465,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -480,7 +480,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -501,7 +501,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth}
 
 Auth holds configuration for the containerd registry auth. See https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials for more details.
 
@@ -513,7 +513,7 @@ Auth holds configuration for the containerd registry auth. See https://github.co
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-username}
 
 Username is the username for the containerd registry.
 
@@ -528,7 +528,7 @@ Username is the username for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-password}
 
 Password is the password for the containerd registry.
 
@@ -543,7 +543,7 @@ Password is the password for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-identityToken}
+##### `identityToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-identityToken}
 
 IdentityToken is the token for the containerd registry.
 
@@ -558,7 +558,7 @@ IdentityToken is the token for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-auth}
 
 Auth is the auth config for the containerd registry.
 
@@ -579,7 +579,7 @@ Auth is the auth config for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-pauseImage}
+##### `pauseImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-pauseImage}
 
 PauseImage is the image for the pause container.
 
@@ -597,7 +597,7 @@ PauseImage is the image for the pause container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-caCertPath}
+#### `caCertPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-caCertPath}
 
 CACertPath is the path to the SSL certificate authority used to
 secure communications between node and control-plane.
@@ -614,7 +614,7 @@ Defaults to "/etc/kubernetes/pki/ca.crt".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-skipPhases}
+#### `skipPhases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-skipPhases}
 
 SkipPhases is a list of phases to skip during command execution.
 The list of phases can be obtained with the "kubeadm join --help" command.
@@ -630,7 +630,7 @@ The list of phases can be obtained with the "kubeadm join --help" command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration}
+#### `nodeRegistration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration}
 
 NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
 
@@ -642,7 +642,7 @@ NodeRegistration holds configuration for the node registration similar to the ku
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-criSocket}
+##### `criSocket` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-criSocket}
 
 CRI socket is the socket for the CRI.
 
@@ -657,7 +657,7 @@ CRI socket is the socket for the CRI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs}
+##### `kubeletExtraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs}
 
 KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
 kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
@@ -673,7 +673,7 @@ Extra arguments will override existing default arguments. Duplicate extra argume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-name}
 
 Name is the name of the argument.
 
@@ -688,7 +688,7 @@ Name is the name of the argument.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-value}
 
 Value is the value of the argument.
 
@@ -706,7 +706,7 @@ Value is the value of the argument.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints}
+##### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints}
 
 Taints are additional taints to set for the kubelet.
 
@@ -718,7 +718,7 @@ Taints are additional taints to set for the kubelet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -733,7 +733,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -748,7 +748,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -768,7 +768,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-ignorePreflightErrors}
+##### `ignorePreflightErrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-ignorePreflightErrors}
 
 IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
 Value 'all' ignores errors from all checks.
@@ -784,7 +784,7 @@ Value 'all' ignores errors from all checks.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-imagePullPolicy}
 
 ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
 The value of this field must be one of "Always", "IfNotPresent" or "Never".
@@ -807,7 +807,7 @@ If this field is unset kubeadm will default it to "IfNotPresent", or pull the re
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes}
+### `autoNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes}
 
 AutoNodes stores auto nodes configuration.
 
@@ -819,7 +819,7 @@ AutoNodes stores auto nodes configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `provider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-provider}
+#### `provider` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-provider}
 
 Provider is the node provider of the nodes in this pool.
 
@@ -834,7 +834,7 @@ Provider is the node provider of the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-properties}
+#### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-properties}
 
 Properties are the node provider properties. This is a simple key value map and can contain things
 like region, subscription, etc. that is then used by the node provider to create the nodes and node environment.
@@ -850,7 +850,7 @@ like region, subscription, etc. that is then used by the node provider to create
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `static` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static}
+#### `static` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static}
 
 Static defines static node pools. Static node pools have a fixed size and are not scaled automatically.
 
@@ -862,7 +862,7 @@ Static defines static node pools. Static node pools have a fixed size and are no
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-name}
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-name}
 
 Name is the name of this static nodePool
 
@@ -877,7 +877,7 @@ Name is the name of this static nodePool
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector}
+##### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -890,7 +890,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -905,7 +905,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -920,7 +920,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -935,7 +935,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -953,7 +953,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints}
+##### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints}
 
 Taints are the taints to apply to the nodes in this pool.
 
@@ -965,7 +965,7 @@ Taints are the taints to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -980,7 +980,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -995,7 +995,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -1015,7 +1015,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeLabels}
+##### `nodeLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeLabels}
 
 NodeLabels are the labels to apply to the nodes in this pool.
 
@@ -1030,7 +1030,7 @@ NodeLabels are the labels to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `terminationGracePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-terminationGracePeriod}
+##### `terminationGracePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-terminationGracePeriod}
 
 TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
@@ -1057,7 +1057,7 @@ Defaults to 30s. Set to Never to wait indefinitely for pods to be drained.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `quantity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-quantity}
+##### `quantity` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-quantity}
 
 Quantity is the number of desired nodes in this pool.
 
@@ -1075,7 +1075,7 @@ Quantity is the number of desired nodes in this pool.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dynamic` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic}
+#### `dynamic` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic}
 
 Dynamic defines dynamic node pools. Dynamic node pools are scaled automatically based on the requirements within the cluster.
 Karpenter is used under the hood to handle the scheduling of the nodes.
@@ -1088,7 +1088,7 @@ Karpenter is used under the hood to handle the scheduling of the nodes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-name}
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-name}
 
 Name is the name of this NodePool
 
@@ -1103,7 +1103,7 @@ Name is the name of this NodePool
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector}
+##### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -1116,7 +1116,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -1131,7 +1131,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -1146,7 +1146,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -1161,7 +1161,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -1179,7 +1179,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints}
+##### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints}
 
 Taints are the taints to apply to the nodes in this pool.
 
@@ -1191,7 +1191,7 @@ Taints are the taints to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -1206,7 +1206,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -1221,7 +1221,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -1241,7 +1241,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeLabels}
+##### `nodeLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeLabels}
 
 NodeLabels are the labels to apply to the nodes in this pool.
 
@@ -1256,7 +1256,7 @@ NodeLabels are the labels to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-limits}
 
 Limits specify the maximum resources that can be provisioned by this node pool,
 mapping to the 'limits' field in Karpenter's NodePool API.
@@ -1272,7 +1272,7 @@ mapping to the 'limits' field in Karpenter's NodePool API.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `disruption` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption}
+##### `disruption` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption}
 
 Disruption contains the parameters that relate to Karpenter's disruption logic
 
@@ -1284,7 +1284,7 @@ Disruption contains the parameters that relate to Karpenter's disruption logic
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `consolidateAfter` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-consolidateAfter}
+##### `consolidateAfter` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-consolidateAfter}
 
 ConsolidateAfter is the duration the controller will wait
 before attempting to terminate nodes that are underutilized.
@@ -1301,7 +1301,7 @@ Refer to ConsolidationPolicy for how underutilization is considered.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `consolidationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-consolidationPolicy}
+##### `consolidationPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-consolidationPolicy}
 
 ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
 algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
@@ -1317,7 +1317,7 @@ algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `budgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets}
+##### `budgets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets}
 
 Budgets is a list of Budgets.
 If there are multiple active budgets, Karpenter uses
@@ -1332,7 +1332,7 @@ this will default to one budget with a value to 10%.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-nodes}
+##### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-nodes}
 
 Nodes dictates the maximum number of NodeClaims owned by this NodePool
 that can be terminating at once. This is calculated by counting nodes that
@@ -1350,7 +1350,7 @@ This field is required when specifying a budget.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-schedule}
+##### `schedule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-schedule}
 
 Schedule specifies when a budget begins being active, following
 the upstream cronjob syntax. If omitted, the budget is always active.
@@ -1367,7 +1367,7 @@ Timezones are not supported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `duration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-duration}
+##### `duration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-duration}
 
 Duration determines how long a Budget is active since each Schedule hit.
 Only minutes and hours are accepted, as cron does not work in seconds.
@@ -1391,7 +1391,7 @@ This is required if Schedule is set.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `terminationGracePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-terminationGracePeriod}
+##### `terminationGracePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-terminationGracePeriod}
 
 TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
@@ -1418,7 +1418,7 @@ Defaults to 30s. Set to Never to wait indefinitely for pods to be drained.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expireAfter` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-expireAfter}
+##### `expireAfter` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-expireAfter}
 
 The amount of time a Node can live on the cluster before being removed
 
@@ -1433,7 +1433,7 @@ The amount of time a Node can live on the cluster before being removed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `weight` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-weight}
+##### `weight` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-weight}
 
 Weight is the weight of this node pool.
 
@@ -1454,7 +1454,7 @@ Weight is the weight of this node pool.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vpn` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-vpn}
+### `vpn` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-vpn}
 
 VPN holds configuration for the private nodes vpn. This can be used to connect the private nodes to the control plane or
 connect the private nodes to each other if they are not running in the same network. Platform connection is required for the vpn to work.
@@ -1467,7 +1467,7 @@ connect the private nodes to each other if they are not running in the same netw
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-vpn-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-vpn-enabled}
 
 Enabled defines if the private nodes vpn should be enabled.
 
@@ -1482,7 +1482,7 @@ Enabled defines if the private nodes vpn should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeToNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-vpn-nodeToNode}
+#### `nodeToNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-vpn-nodeToNode}
 
 NodeToNode holds configuration for the node to node vpn. This can be used to connect the private nodes to each other if they are not running in the same network.
 
@@ -1494,7 +1494,7 @@ NodeToNode holds configuration for the node to node vpn. This can be used to con
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-vpn-nodeToNode-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-vpn-nodeToNode-enabled}
 
 Enabled defines if the node to node vpn should be enabled.
 
@@ -1515,7 +1515,7 @@ Enabled defines if the node to node vpn should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `daemon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon}
+### `daemon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon}
 
 Daemon holds configuration for the private nodes daemon that is deployed on the nodes.
 
@@ -1527,7 +1527,7 @@ Daemon holds configuration for the private nodes daemon that is deployed on the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-enabled}
 
 Enabled defines if the private nodes daemon should be enabled.
 
@@ -1542,7 +1542,7 @@ Enabled defines if the private nodes daemon should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controlPlaneLoadBalancer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer}
+#### `controlPlaneLoadBalancer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer}
 
 ControlPlaneLoadBalancer holds configuration for the control plane load balancer. This is used to load balance the control plane traffic on the node to the control plane nodes.
 This is useful to achieve true high availability for the control plane without having to deploy a separate load balancer.
@@ -1555,7 +1555,7 @@ This is useful to achieve true high availability for the control plane without h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-enabled}
 
 Enabled defines if the control plane load balancer should be enabled. The control plane load balancer is used to load balance the control plane traffic on the node to the control plane nodes.
 
@@ -1570,7 +1570,7 @@ Enabled defines if the control plane load balancer should be enabled. The contro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kubeProxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-kubeProxy}
+##### `kubeProxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-kubeProxy}
 
 KubeProxy defines if the kube proxy should be proxied through the control plane load balancer as well.
 
@@ -1585,7 +1585,7 @@ KubeProxy defines if the kube proxy should be proxied through the control plane 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">11343</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">11343</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-port}
 
 Port defines the port for the control plane load balancer.
 

--- a/vcluster/_partials/config/privateNodes/autoNodes.mdx
+++ b/vcluster/_partials/config/privateNodes/autoNodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes}
+## `autoNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes}
 
 AutoNodes stores auto nodes configuration.
 
@@ -14,7 +14,7 @@ AutoNodes stores auto nodes configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `provider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-provider}
+### `provider` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-provider}
 
 Provider is the node provider of the nodes in this pool.
 
@@ -29,7 +29,7 @@ Provider is the node provider of the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-properties}
+### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-properties}
 
 Properties are the node provider properties. This is a simple key value map and can contain things
 like region, subscription, etc. that is then used by the node provider to create the nodes and node environment.
@@ -45,7 +45,7 @@ like region, subscription, etc. that is then used by the node provider to create
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `static` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static}
+### `static` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static}
 
 Static defines static node pools. Static node pools have a fixed size and are not scaled automatically.
 
@@ -57,7 +57,7 @@ Static defines static node pools. Static node pools have a fixed size and are no
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-name}
+#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-name}
 
 Name is the name of this static nodePool
 
@@ -72,7 +72,7 @@ Name is the name of this static nodePool
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector}
+#### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -85,7 +85,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -100,7 +100,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -115,7 +115,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -130,7 +130,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -148,7 +148,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints}
+#### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints}
 
 Taints are the taints to apply to the nodes in this pool.
 
@@ -160,7 +160,7 @@ Taints are the taints to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -175,7 +175,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -190,7 +190,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -210,7 +210,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeLabels}
+#### `nodeLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeLabels}
 
 NodeLabels are the labels to apply to the nodes in this pool.
 
@@ -225,7 +225,7 @@ NodeLabels are the labels to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `terminationGracePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-terminationGracePeriod}
+#### `terminationGracePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-terminationGracePeriod}
 
 TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
@@ -252,7 +252,7 @@ Defaults to 30s. Set to Never to wait indefinitely for pods to be drained.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `quantity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-quantity}
+#### `quantity` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-quantity}
 
 Quantity is the number of desired nodes in this pool.
 
@@ -270,7 +270,7 @@ Quantity is the number of desired nodes in this pool.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `dynamic` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic}
+### `dynamic` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic}
 
 Dynamic defines dynamic node pools. Dynamic node pools are scaled automatically based on the requirements within the cluster.
 Karpenter is used under the hood to handle the scheduling of the nodes.
@@ -283,7 +283,7 @@ Karpenter is used under the hood to handle the scheduling of the nodes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-name}
+#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-name}
 
 Name is the name of this NodePool
 
@@ -298,7 +298,7 @@ Name is the name of this NodePool
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector}
+#### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -311,7 +311,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -326,7 +326,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -341,7 +341,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -356,7 +356,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -374,7 +374,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints}
+#### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints}
 
 Taints are the taints to apply to the nodes in this pool.
 
@@ -386,7 +386,7 @@ Taints are the taints to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -401,7 +401,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -416,7 +416,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -436,7 +436,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeLabels}
+#### `nodeLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeLabels}
 
 NodeLabels are the labels to apply to the nodes in this pool.
 
@@ -451,7 +451,7 @@ NodeLabels are the labels to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-limits}
+#### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-limits}
 
 Limits specify the maximum resources that can be provisioned by this node pool,
 mapping to the 'limits' field in Karpenter's NodePool API.
@@ -467,7 +467,7 @@ mapping to the 'limits' field in Karpenter's NodePool API.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `disruption` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption}
+#### `disruption` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption}
 
 Disruption contains the parameters that relate to Karpenter's disruption logic
 
@@ -479,7 +479,7 @@ Disruption contains the parameters that relate to Karpenter's disruption logic
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `consolidateAfter` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-consolidateAfter}
+##### `consolidateAfter` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-consolidateAfter}
 
 ConsolidateAfter is the duration the controller will wait
 before attempting to terminate nodes that are underutilized.
@@ -496,7 +496,7 @@ Refer to ConsolidationPolicy for how underutilization is considered.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `consolidationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-consolidationPolicy}
+##### `consolidationPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-consolidationPolicy}
 
 ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
 algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
@@ -512,7 +512,7 @@ algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `budgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets}
+##### `budgets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets}
 
 Budgets is a list of Budgets.
 If there are multiple active budgets, Karpenter uses
@@ -527,7 +527,7 @@ this will default to one budget with a value to 10%.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-nodes}
+##### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-nodes}
 
 Nodes dictates the maximum number of NodeClaims owned by this NodePool
 that can be terminating at once. This is calculated by counting nodes that
@@ -545,7 +545,7 @@ This field is required when specifying a budget.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-schedule}
+##### `schedule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-schedule}
 
 Schedule specifies when a budget begins being active, following
 the upstream cronjob syntax. If omitted, the budget is always active.
@@ -562,7 +562,7 @@ Timezones are not supported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `duration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-duration}
+##### `duration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-duration}
 
 Duration determines how long a Budget is active since each Schedule hit.
 Only minutes and hours are accepted, as cron does not work in seconds.
@@ -586,7 +586,7 @@ This is required if Schedule is set.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `terminationGracePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-terminationGracePeriod}
+#### `terminationGracePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-terminationGracePeriod}
 
 TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
@@ -613,7 +613,7 @@ Defaults to 30s. Set to Never to wait indefinitely for pods to be drained.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expireAfter` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-expireAfter}
+#### `expireAfter` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-expireAfter}
 
 The amount of time a Node can live on the cluster before being removed
 
@@ -628,7 +628,7 @@ The amount of time a Node can live on the cluster before being removed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `weight` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-weight}
+#### `weight` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-weight}
 
 Weight is the weight of this node pool.
 

--- a/vcluster/_partials/config/privateNodes/autoUpgrade.mdx
+++ b/vcluster/_partials/config/privateNodes/autoUpgrade.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoUpgrade` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade}
+## `autoUpgrade` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade}
 
 AutoUpgrade holds configuration for auto upgrade.
 
@@ -14,7 +14,7 @@ AutoUpgrade holds configuration for auto upgrade.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#autoUpgrade-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#autoUpgrade-enabled}
 
 Enabled defines if auto upgrade should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if auto upgrade should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-image}
+### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-image}
 
 Image is the image for the auto upgrade pod started by vCluster. If empty defaults to the controlPlane.statefulSet.image.
 
@@ -44,7 +44,7 @@ Image is the image for the auto upgrade pod started by vCluster. If empty defaul
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -59,7 +59,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-nodeSelector}
+### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-nodeSelector}
 
 NodeSelector is the node selector for the auto upgrade. If empty will select all worker nodes.
 
@@ -74,7 +74,7 @@ NodeSelector is the node selector for the auto upgrade. If empty will select all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `binariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-binariesPath}
+### `binariesPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-binariesPath}
 
 BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/bin
 
@@ -89,7 +89,7 @@ BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `cniBinariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-cniBinariesPath}
+### `cniBinariesPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-cniBinariesPath}
 
 CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 
@@ -104,7 +104,7 @@ CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `concurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#autoUpgrade-concurrency}
+### `concurrency` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#autoUpgrade-concurrency}
 
 Concurrency is the number of nodes that can be upgraded at the same time.
 
@@ -119,7 +119,7 @@ Concurrency is the number of nodes that can be upgraded at the same time.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-podSecurityContext}
+### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level for the upgrade pod.
 
@@ -134,7 +134,7 @@ PodSecurityContext specifies security context options on the pod level for the u
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-containerSecurityContext}
+### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level for the upgrade container.
 

--- a/vcluster/_partials/config/privateNodes/vpn.mdx
+++ b/vcluster/_partials/config/privateNodes/vpn.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `vpn` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vpn}
+## `vpn` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vpn}
 
 VPN holds configuration for the private nodes vpn. This can be used to connect the private nodes to the control plane or
 connect the private nodes to each other if they are not running in the same network. Platform connection is required for the vpn to work.
@@ -15,7 +15,7 @@ connect the private nodes to each other if they are not running in the same netw
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#vpn-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#vpn-enabled}
 
 Enabled defines if the private nodes vpn should be enabled.
 
@@ -30,7 +30,7 @@ Enabled defines if the private nodes vpn should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodeToNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vpn-nodeToNode}
+### `nodeToNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vpn-nodeToNode}
 
 NodeToNode holds configuration for the node to node vpn. This can be used to connect the private nodes to each other if they are not running in the same network.
 
@@ -42,7 +42,7 @@ NodeToNode holds configuration for the node to node vpn. This can be used to con
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#vpn-nodeToNode-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#vpn-nodeToNode-enabled}
 
 Enabled defines if the node to node vpn should be enabled.
 

--- a/vcluster/_partials/config/rbac.mdx
+++ b/vcluster/_partials/config/rbac.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac}
+## `rbac` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac}
 
 RBAC options for the virtual cluster.
 
@@ -14,7 +14,7 @@ RBAC options for the virtual cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-role}
+### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-role}
 
 Role holds virtual cluster role configuration
 
@@ -26,7 +26,7 @@ Role holds virtual cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#rbac-role-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#rbac-role-enabled}
 
 Enabled defines if the role should be enabled or disabled.
 
@@ -41,7 +41,7 @@ Enabled defines if the role should be enabled or disabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-extraRules}
 
 ExtraRules will add rules to the role.
 
@@ -56,7 +56,7 @@ ExtraRules will add rules to the role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-overwriteRules}
 
 OverwriteRules will overwrite the role rules completely.
 
@@ -74,7 +74,7 @@ OverwriteRules will overwrite the role rules completely.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-clusterRole}
+### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-clusterRole}
 
 ClusterRole holds virtual cluster cluster role configuration
 
@@ -86,7 +86,7 @@ ClusterRole holds virtual cluster cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-clusterRole-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-clusterRole-enabled}
 
 Enabled defines if the cluster role should be enabled or disabled. If auto, vCluster automatically determines whether the virtual cluster requires a cluster role.
 
@@ -101,7 +101,7 @@ Enabled defines if the cluster role should be enabled or disabled. If auto, vClu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-extraRules}
 
 ExtraRules will add rules to the cluster role.
 
@@ -116,7 +116,7 @@ ExtraRules will add rules to the cluster role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-overwriteRules}
 
 OverwriteRules will overwrite the cluster role rules completely.
 
@@ -134,7 +134,7 @@ OverwriteRules will overwrite the cluster role rules completely.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `enableVolumeSnapshotRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-enableVolumeSnapshotRules}
+### `enableVolumeSnapshotRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-enableVolumeSnapshotRules}
 
 EnableVolumeSnapshotRules enables all required volume snapshot rules in the Role and
 ClusterRole.
@@ -147,7 +147,7 @@ ClusterRole.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-enableVolumeSnapshotRules-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-enableVolumeSnapshotRules-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster/_partials/config/sleep.mdx
+++ b/vcluster/_partials/config/sleep.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep}
+## `sleep` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep}
 
 Sleep holds configuration for automatically putting the virtual cluster to sleep.
 
@@ -14,7 +14,7 @@ Sleep holds configuration for automatically putting the virtual cluster to sleep
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `auto` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto}
+### `auto` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto}
 
 Auto holds automatic sleep configuration
 
@@ -26,7 +26,7 @@ Auto holds automatic sleep configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-afterInactivity}
 
 AfterInactivity represents how long a vCluster can be idle before workloads are automatically put to sleep
 
@@ -41,7 +41,7 @@ AfterInactivity represents how long a vCluster can be idle before workloads are 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-schedule}
+#### `schedule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-schedule}
 
 Schedule represents a cron schedule for when to sleep workloads
 
@@ -56,7 +56,7 @@ Schedule represents a cron schedule for when to sleep workloads
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `exclude` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude}
+#### `exclude` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude}
 
 Exclude holds configuration for labels that, if present, will prevent a workload from going to sleep
 
@@ -68,7 +68,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude-selector}
 
 
 
@@ -80,7 +80,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -101,7 +101,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `wakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-wakeup}
+#### `wakeup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-wakeup}
 
 Wakeup holds configuration for waking the vCluster on a schedule
 
@@ -113,7 +113,7 @@ Wakeup holds configuration for waking the vCluster on a schedule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-wakeup-schedule}
+##### `schedule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-wakeup-schedule}
 
 
 
@@ -131,7 +131,7 @@ Wakeup holds configuration for waking the vCluster on a schedule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-timezone}
+#### `timezone` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-timezone}
 
 Timezone specifies time zone used for scheduled sleep operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).

--- a/vcluster/_partials/config/snapshots.mdx
+++ b/vcluster/_partials/config/snapshots.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `snapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots}
+## `snapshots` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots}
 
 Snapshots holds configuration for automatic vCluster snapshots.
 
@@ -14,7 +14,7 @@ Snapshots holds configuration for automatic vCluster snapshots.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `auto` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto}
+### `auto` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto}
 
 Auto holds automatic snapshot configuration
 
@@ -26,9 +26,9 @@ Auto holds automatic snapshot configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-schedule}
+#### `schedule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-schedule}
 
-Schedule specifies a scheduled time in Cron format, see https://en.wikipedia.org/wiki/Cron for a tenant cluster snapshot to be taken
+Schedule specifies a scheduled time in Cron format, see https://en.wikipedia.org/wiki/Cron for a virtual cluster snapshot to be taken
 
 </summary>
 
@@ -41,7 +41,7 @@ Schedule specifies a scheduled time in Cron format, see https://en.wikipedia.org
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-timezone}
+#### `timezone` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-timezone}
 
 Timezone specifies time zone used for scheduled snapshot operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).
@@ -58,7 +58,7 @@ The value should be a location name corresponding to a file in the IANA Time Zon
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention}
+#### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention}
 
 Retention specifies how long snapshots will be kept
 
@@ -70,7 +70,7 @@ Retention specifies how long snapshots will be kept
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `period` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention-period}
+##### `period` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention-period}
 
 Period defines the number of days a snapshot will be kept
 
@@ -85,7 +85,7 @@ Period defines the number of days a snapshot will be kept
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention-maxSnapshots}
+##### `maxSnapshots` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention-maxSnapshots}
 
 MaxSnapshots defines the number of snapshots that can be taken
 
@@ -103,7 +103,7 @@ MaxSnapshots defines the number of snapshots that can be taken
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage}
+#### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage}
 
 Storage specifies where the snapshot will be stored
 
@@ -115,7 +115,7 @@ Storage specifies where the snapshot will be stored
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-type}
 
 Type specifies supported type of storage services for a snapshot S3/OCI/Container, see https://www.vcluster.com/docs/vcluster/manage/backup-restore#store-snapshots-in-s3-buckets
 
@@ -130,7 +130,7 @@ Type specifies supported type of storage services for a snapshot S3/OCI/Containe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `s3` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3}
+##### `s3` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3}
 
 S3 holds configuration for storing snapshots in S3-compatible bucket
 
@@ -142,7 +142,7 @@ S3 holds configuration for storing snapshots in S3-compatible bucket
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-url}
 
 Url specifies url to the storage service
 
@@ -157,7 +157,7 @@ Url specifies url to the storage service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credential` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential}
+##### `credential` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential}
 
 Credential secret with the S3 Credentials, it should contain AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN
 
@@ -169,7 +169,7 @@ Credential secret with the S3 Credentials, it should contain AWS_ACCESS_KEY_ID, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential-secretName}
 
 SecretName is the secret name with credential
 
@@ -184,7 +184,7 @@ SecretName is the secret name with credential
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential-secretNamespace}
 
 SecretNamespace is the secret namespace with credential
 
@@ -205,7 +205,7 @@ SecretNamespace is the secret namespace with credential
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `oci` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci}
+##### `oci` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci}
 
 OCI holds configuration for storing snapshots in OCI image registries
 
@@ -217,7 +217,7 @@ OCI holds configuration for storing snapshots in OCI image registries
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-repository}
 
 Repository OCI repository to store the snapshot
 
@@ -232,7 +232,7 @@ Repository OCI repository to store the snapshot
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credential` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential}
+##### `credential` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential}
 
 Credential secret with the OCI Credentials
 
@@ -244,7 +244,7 @@ Credential secret with the OCI Credentials
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential-secretName}
 
 SecretName is the secret name with credential
 
@@ -259,7 +259,7 @@ SecretName is the secret name with credential
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential-secretNamespace}
 
 SecretNamespace is the secret namespace with credential
 
@@ -277,7 +277,7 @@ SecretNamespace is the secret namespace with credential
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-username}
 
 Username to authenticate with the OCI registry
 
@@ -292,7 +292,7 @@ Username to authenticate with the OCI registry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-password}
 
 Password to authenticate with the OCI registry
 
@@ -310,7 +310,7 @@ Password to authenticate with the OCI registry
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `container` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container}
+##### `container` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container}
 
 Container holds configuration for storing snapshots as local files inside a vCluster container
 
@@ -322,7 +322,7 @@ Container holds configuration for storing snapshots as local files inside a vClu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-path}
 
 Path specifies directory to store the snapshot
 
@@ -337,7 +337,7 @@ Path specifies directory to store the snapshot
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume}
+##### `volume` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume}
 
 Volume specifies which volume needs to be mounted into the container to store the snapshot
 
@@ -349,7 +349,7 @@ Volume specifies which volume needs to be mounted into the container to store th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume-name}
 
 Name to be used to mount the volume
 
@@ -364,7 +364,7 @@ Name to be used to mount the volume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume-path}
 
 Path to the volume mount
 
@@ -385,7 +385,7 @@ Path to the volume mount
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `azure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure}
+##### `azure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure}
 
 Azure holds configuration for storing snapshots in Azure Blob Storage
 
@@ -397,7 +397,7 @@ Azure holds configuration for storing snapshots in Azure Blob Storage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blobUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-blobUrl}
+##### `blobUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-blobUrl}
 
 BlobURL specifies the Azure Blob Storage URL in the format https://&#123;account&#125;.blob.core.windows.net/&#123;container&#125;/&#123;path&#125;
 
@@ -412,7 +412,7 @@ BlobURL specifies the Azure Blob Storage URL in the format https://&#123;account
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credential` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential}
+##### `credential` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential}
 
 Credential secret with the Azure credentials. The secret should contain either:
 AZURE_STORAGE_KEY (storage account access key), or
@@ -426,7 +426,7 @@ AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID, AZ
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretName}
 
 SecretName is the secret name with credential
 
@@ -441,7 +441,7 @@ SecretName is the secret name with credential
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretNamespace}
 
 SecretNamespace is the secret namespace with credential
 
@@ -465,7 +465,7 @@ SecretNamespace is the secret namespace with credential
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-volumes}
+#### `volumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-volumes}
 
 Volumes specifies configuration for volume snapshots
 
@@ -477,7 +477,7 @@ Volumes specifies configuration for volume snapshots
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-volumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-volumes-enabled}
 
 Enabled specifies whether a snapshot should also include volumes in the snapshot
 

--- a/vcluster/_partials/config/sync.mdx
+++ b/vcluster/_partials/config/sync.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync}
+## `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync}
 
 Sync describes how to sync resources from the virtual cluster to host cluster and back.
 
@@ -14,7 +14,7 @@ Sync describes how to sync resources from the virtual cluster to host cluster an
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost}
+### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -26,7 +26,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods}
+#### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -38,7 +38,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -53,7 +53,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-translateImage}
+##### `translateImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -69,7 +69,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enforceTolerations}
+##### `enforceTolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -84,7 +84,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-useSecretsForSATokens}
+##### `useSecretsForSATokens` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -100,7 +100,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-runtimeClassName}
+##### `runtimeClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -115,7 +115,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -130,7 +130,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts}
+##### `rewriteHosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -144,7 +144,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -159,7 +159,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -171,7 +171,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -183,7 +183,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -199,7 +199,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -214,7 +214,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -232,7 +232,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -244,7 +244,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -259,7 +259,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -283,7 +283,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -295,7 +295,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -310,7 +310,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -325,7 +325,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -340,7 +340,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -354,7 +354,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -369,7 +369,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -384,7 +384,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -399,7 +399,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -414,7 +414,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -429,7 +429,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -448,7 +448,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -466,7 +466,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling}
+##### `hybridScheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -478,7 +478,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -493,7 +493,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-hostSchedulers}
+##### `hostSchedulers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 
@@ -514,7 +514,7 @@ HostSchedulers is a list of schedulers that are deployed on the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -526,7 +526,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -541,7 +541,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-all}
+##### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -556,7 +556,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -568,7 +568,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -583,7 +583,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -598,7 +598,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -613,7 +613,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -627,7 +627,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -642,7 +642,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -657,7 +657,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -672,7 +672,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -687,7 +687,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -702,7 +702,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -721,7 +721,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -742,7 +742,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -754,7 +754,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -769,7 +769,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-all}
+##### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -784,7 +784,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -796,7 +796,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -811,7 +811,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -826,7 +826,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -841,7 +841,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -855,7 +855,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -870,7 +870,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -885,7 +885,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -900,7 +900,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -915,7 +915,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -930,7 +930,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -949,7 +949,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -970,7 +970,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses}
+#### `ingresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -982,7 +982,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -997,7 +997,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1009,7 +1009,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1024,7 +1024,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1039,7 +1039,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1054,7 +1054,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1068,7 +1068,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1083,7 +1083,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1098,7 +1098,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1113,7 +1113,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1128,7 +1128,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1143,7 +1143,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1162,7 +1162,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1183,7 +1183,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gatewayApi` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi}
+#### `gatewayApi` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi}
 
 GatewayAPI defines Gateway API resources created within the tenant cluster that should get synced to the control plane cluster.
 
@@ -1195,7 +1195,7 @@ GatewayAPI defines Gateway API resources created within the tenant cluster that 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1210,7 +1210,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1222,7 +1222,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1237,7 +1237,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1252,7 +1252,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1267,7 +1267,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1281,7 +1281,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1296,7 +1296,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1311,7 +1311,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1326,7 +1326,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1341,7 +1341,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1356,7 +1356,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1375,7 +1375,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1393,7 +1393,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `httpRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes}
+##### `httpRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes}
 
 HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 
@@ -1405,7 +1405,7 @@ HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1420,7 +1420,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1432,7 +1432,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1447,7 +1447,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1462,7 +1462,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1477,7 +1477,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1491,7 +1491,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1506,7 +1506,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1521,7 +1521,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1536,7 +1536,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1551,7 +1551,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1566,7 +1566,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1585,7 +1585,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1606,7 +1606,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways}
+##### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways}
 
 Gateways configures tenant-created Gateway sync to the control plane cluster.
 
@@ -1618,7 +1618,7 @@ Gateways configures tenant-created Gateway sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1633,7 +1633,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1645,7 +1645,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1660,7 +1660,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1675,7 +1675,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1690,7 +1690,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1704,7 +1704,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1719,7 +1719,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1734,7 +1734,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1749,7 +1749,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1764,7 +1764,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1779,7 +1779,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1798,7 +1798,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1819,7 +1819,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tlsRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes}
+##### `tlsRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes}
 
 TLSRoutes configures TLSRoute sync to the control plane cluster.
 
@@ -1831,7 +1831,7 @@ TLSRoutes configures TLSRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1846,7 +1846,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1858,7 +1858,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1873,7 +1873,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1888,7 +1888,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1903,7 +1903,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1917,7 +1917,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1932,7 +1932,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1947,7 +1947,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1962,7 +1962,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1977,7 +1977,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1992,7 +1992,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2011,7 +2011,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2032,7 +2032,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `backendTLSPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies}
+##### `backendTLSPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies}
 
 BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster.
 
@@ -2044,7 +2044,7 @@ BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2059,7 +2059,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2071,7 +2071,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2086,7 +2086,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2101,7 +2101,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2116,7 +2116,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2130,7 +2130,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2145,7 +2145,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2160,7 +2160,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2175,7 +2175,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2190,7 +2190,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2205,7 +2205,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2224,7 +2224,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2245,7 +2245,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `referenceGrants` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants}
+##### `referenceGrants` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants}
 
 ReferenceGrants configures ReferenceGrant sync to the control plane cluster. Enabled may be "auto", "true", or "false".
 
@@ -2257,7 +2257,7 @@ ReferenceGrants configures ReferenceGrant sync to the control plane cluster. Ena
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2272,7 +2272,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2284,7 +2284,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2299,7 +2299,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2314,7 +2314,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2329,7 +2329,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2343,7 +2343,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2358,7 +2358,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2373,7 +2373,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2388,7 +2388,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2403,7 +2403,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2418,7 +2418,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2437,7 +2437,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2461,7 +2461,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services}
+#### `services` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -2473,7 +2473,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-services-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2488,7 +2488,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2500,7 +2500,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2515,7 +2515,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2530,7 +2530,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2545,7 +2545,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2559,7 +2559,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2574,7 +2574,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2589,7 +2589,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2604,7 +2604,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2619,7 +2619,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2634,7 +2634,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2653,7 +2653,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2674,7 +2674,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints}
+#### `endpoints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -2686,7 +2686,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2701,7 +2701,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2713,7 +2713,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2728,7 +2728,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2743,7 +2743,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2758,7 +2758,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2772,7 +2772,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2787,7 +2787,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2802,7 +2802,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2817,7 +2817,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2832,7 +2832,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2847,7 +2847,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2866,7 +2866,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2887,7 +2887,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `endpointSlices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices}
+#### `endpointSlices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices}
 
 EndpointSlices defines if endpointslices created within the virtual cluster should get synced to the host cluster.
 
@@ -2899,7 +2899,7 @@ EndpointSlices defines if endpointslices created within the virtual cluster shou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2914,7 +2914,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2926,7 +2926,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2941,7 +2941,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2956,7 +2956,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2971,7 +2971,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2985,7 +2985,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3000,7 +3000,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3015,7 +3015,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3030,7 +3030,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3045,7 +3045,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3060,7 +3060,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3079,7 +3079,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3100,7 +3100,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies}
+#### `networkPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -3112,7 +3112,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3127,7 +3127,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3139,7 +3139,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3154,7 +3154,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3169,7 +3169,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3184,7 +3184,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3198,7 +3198,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3213,7 +3213,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3228,7 +3228,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3243,7 +3243,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3258,7 +3258,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3273,7 +3273,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3292,7 +3292,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3313,7 +3313,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims}
+#### `persistentVolumeClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -3325,7 +3325,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3340,7 +3340,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3352,7 +3352,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3367,7 +3367,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3382,7 +3382,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3397,7 +3397,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3411,7 +3411,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3426,7 +3426,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3441,7 +3441,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3456,7 +3456,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3471,7 +3471,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3486,7 +3486,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3505,7 +3505,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3526,7 +3526,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes}
+#### `persistentVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -3538,7 +3538,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3553,7 +3553,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3565,7 +3565,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3580,7 +3580,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3595,7 +3595,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3610,7 +3610,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3624,7 +3624,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3639,7 +3639,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3654,7 +3654,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3669,7 +3669,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3684,7 +3684,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3699,7 +3699,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3718,7 +3718,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3739,7 +3739,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots}
+#### `volumeSnapshots` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -3751,7 +3751,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3766,7 +3766,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3778,7 +3778,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3793,7 +3793,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3808,7 +3808,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3823,7 +3823,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3837,7 +3837,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3852,7 +3852,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3867,7 +3867,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3882,7 +3882,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3897,7 +3897,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3912,7 +3912,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3931,7 +3931,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3952,7 +3952,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents}
+#### `volumeSnapshotContents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -3964,7 +3964,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3979,7 +3979,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3991,7 +3991,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4006,7 +4006,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4021,7 +4021,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4036,7 +4036,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4050,7 +4050,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4065,7 +4065,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4080,7 +4080,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4095,7 +4095,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4110,7 +4110,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4125,7 +4125,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4144,7 +4144,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4165,7 +4165,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -4177,7 +4177,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4192,7 +4192,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4204,7 +4204,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4219,7 +4219,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4234,7 +4234,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4249,7 +4249,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4263,7 +4263,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4278,7 +4278,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4293,7 +4293,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4308,7 +4308,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4323,7 +4323,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4338,7 +4338,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4357,7 +4357,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4378,7 +4378,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts}
+#### `serviceAccounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -4390,7 +4390,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4405,7 +4405,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4417,7 +4417,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4432,7 +4432,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4447,7 +4447,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4462,7 +4462,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4476,7 +4476,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4491,7 +4491,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4506,7 +4506,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4521,7 +4521,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4536,7 +4536,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4551,7 +4551,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4570,7 +4570,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4591,7 +4591,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets}
+#### `podDisruptionBudgets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -4603,7 +4603,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4618,7 +4618,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4630,7 +4630,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4645,7 +4645,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4660,7 +4660,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4675,7 +4675,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4689,7 +4689,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4704,7 +4704,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4719,7 +4719,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4734,7 +4734,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4749,7 +4749,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4764,7 +4764,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4783,7 +4783,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4804,7 +4804,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -4816,7 +4816,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4831,7 +4831,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4843,7 +4843,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4858,7 +4858,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4873,7 +4873,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4888,7 +4888,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4902,7 +4902,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4917,7 +4917,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4932,7 +4932,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4947,7 +4947,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4962,7 +4962,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4977,7 +4977,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4996,7 +4996,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5017,7 +5017,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -5030,7 +5030,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5045,7 +5045,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -5060,7 +5060,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5072,7 +5072,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5087,7 +5087,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5102,7 +5102,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5117,7 +5117,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5131,7 +5131,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5146,7 +5146,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5161,7 +5161,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5176,7 +5176,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5191,7 +5191,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5206,7 +5206,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5225,7 +5225,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5246,7 +5246,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces}
 
 Namespaces defines if namespaces created within the virtual cluster should get synced to the host cluster.
 
@@ -5258,7 +5258,7 @@ Namespaces defines if namespaces created within the virtual cluster should get s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-enabled}
+##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5273,7 +5273,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5285,7 +5285,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5300,7 +5300,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5315,7 +5315,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5330,7 +5330,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5344,7 +5344,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5359,7 +5359,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5374,7 +5374,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5389,7 +5389,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5404,7 +5404,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5419,7 +5419,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5438,7 +5438,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5456,7 +5456,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings}
+##### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings}
 
 Mappings for Namespace and Object
 
@@ -5468,7 +5468,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -5502,7 +5502,7 @@ byName:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappingsOnly}
+##### `mappingsOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappingsOnly}
 
 MappingsOnly defines if creation of namespaces not matched by mappings should be allowed.
 
@@ -5517,7 +5517,7 @@ MappingsOnly defines if creation of namespaces not matched by mappings should be
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-extraLabels}
+##### `extraLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-extraLabels}
 
 ExtraLabels are additional labels to add to the namespace in the host cluster.
 
@@ -5535,7 +5535,7 @@ ExtraLabels are additional labels to add to the namespace in the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resourceClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims}
+#### `resourceClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims}
 
 ResourceClaim defines if resource claims created within the virtual cluster should get synced to the host cluster.
 
@@ -5547,7 +5547,7 @@ ResourceClaim defines if resource claims created within the virtual cluster shou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5562,7 +5562,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5574,7 +5574,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5589,7 +5589,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5604,7 +5604,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5619,7 +5619,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5633,7 +5633,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5648,7 +5648,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5663,7 +5663,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5678,7 +5678,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5693,7 +5693,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5708,7 +5708,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5727,7 +5727,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5748,7 +5748,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resourceClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates}
+#### `resourceClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates}
 
 ResourceClaimTemplates defines if resourceClaimTemplates created within the virtual cluster should get synced to the host cluster.
 
@@ -5760,7 +5760,7 @@ ResourceClaimTemplates defines if resourceClaimTemplates created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5775,7 +5775,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5787,7 +5787,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5802,7 +5802,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5817,7 +5817,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5832,7 +5832,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5846,7 +5846,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5861,7 +5861,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5876,7 +5876,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5891,7 +5891,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5906,7 +5906,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5921,7 +5921,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5940,7 +5940,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5964,7 +5964,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -5976,7 +5976,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes}
+#### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -5988,7 +5988,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -6003,7 +6003,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-syncBackChanges}
+##### `syncBackChanges` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -6018,7 +6018,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-clearImageStatus}
+##### `clearImageStatus` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -6033,7 +6033,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -6045,7 +6045,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -6060,7 +6060,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -6078,7 +6078,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6090,7 +6090,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6105,7 +6105,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6120,7 +6120,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6135,7 +6135,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6149,7 +6149,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6164,7 +6164,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6179,7 +6179,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6194,7 +6194,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6209,7 +6209,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6224,7 +6224,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6243,7 +6243,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6264,7 +6264,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events}
+#### `events` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -6276,7 +6276,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-events-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6291,7 +6291,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6303,7 +6303,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6318,7 +6318,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6333,7 +6333,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6348,7 +6348,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6362,7 +6362,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6377,7 +6377,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6392,7 +6392,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6407,7 +6407,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6422,7 +6422,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6437,7 +6437,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6456,7 +6456,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6477,7 +6477,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses}
+#### `ingressClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -6489,7 +6489,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6504,7 +6504,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6516,7 +6516,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6531,7 +6531,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6546,7 +6546,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6561,7 +6561,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6575,7 +6575,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6590,7 +6590,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6605,7 +6605,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6620,7 +6620,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6635,7 +6635,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6650,7 +6650,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6669,7 +6669,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6687,7 +6687,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -6699,7 +6699,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchLabels}
 
 
 
@@ -6714,7 +6714,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions}
 
 
 
@@ -6726,22 +6726,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -6756,7 +6741,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-values}
 
 
 
@@ -6780,7 +6780,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gatewayClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses}
+#### `gatewayClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses}
 
 GatewayClasses defines if gateway classes should get synced from the control plane cluster to the tenant cluster, but not back.
 
@@ -6792,7 +6792,7 @@ GatewayClasses defines if gateway classes should get synced from the control pla
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6807,7 +6807,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6819,7 +6819,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6834,7 +6834,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6849,7 +6849,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6864,7 +6864,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6878,7 +6878,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6893,7 +6893,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6908,7 +6908,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6923,7 +6923,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6938,7 +6938,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6953,7 +6953,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6972,7 +6972,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6990,7 +6990,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -7002,7 +7002,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchLabels}
 
 
 
@@ -7017,7 +7017,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions}
 
 
 
@@ -7029,22 +7029,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-key}
 
 
 
@@ -7059,7 +7044,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-values}
 
 
 
@@ -7083,7 +7083,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways}
+#### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways}
 
 Gateways defines if selected control plane Gateways should get synced from the control plane cluster to the tenant cluster, but not back.
 
@@ -7095,7 +7095,7 @@ Gateways defines if selected control plane Gateways should get synced from the c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -7110,7 +7110,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -7122,7 +7122,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -7137,7 +7137,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -7152,7 +7152,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -7167,7 +7167,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -7181,7 +7181,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -7196,7 +7196,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -7211,7 +7211,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -7226,7 +7226,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -7241,7 +7241,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -7256,7 +7256,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -7275,7 +7275,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -7293,7 +7293,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -7305,7 +7305,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchLabels}
 
 
 
@@ -7320,7 +7320,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions}
 
 
 
@@ -7332,22 +7332,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-key}
 
 
 
@@ -7362,7 +7347,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-values}
 
 
 
@@ -7383,7 +7383,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-mappings}
+##### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-mappings}
 
 Mappings define control plane Gateway namespace/name to tenant-facing namespace/name placement.
 
@@ -7395,7 +7395,7 @@ Mappings define control plane Gateway namespace/name to tenant-facing namespace/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -7429,7 +7429,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `allowedRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes}
+##### `allowedRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes}
 
 AllowedRoutes configures the tenant-facing allowedRoutes policy shown on imported Gateways and enforced for Routes.
 
@@ -7441,7 +7441,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `defaultVirtualNamespacePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy}
+##### `defaultVirtualNamespacePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy}
 
 
 
@@ -7453,7 +7453,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-from}
 
 
 
@@ -7468,7 +7468,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector}
 
 
 
@@ -7480,7 +7480,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchLabels}
 
 
 
@@ -7495,7 +7495,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions}
 
 
 
@@ -7507,22 +7507,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-key}
 
 
 
@@ -7537,43 +7522,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-values}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `overrides` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-hostNamespace}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-operator}
 
 
 
@@ -7588,7 +7537,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-name}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-values}
 
 
 
@@ -7597,138 +7546,6 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 
 
 </details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `virtualNamespacePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-from}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchLabels}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-operator}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-values}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `allowedHostnames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-allowedHostnames}
-
-
-
-</summary>
-
 
 
 </details>
@@ -7744,7 +7561,190 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-status}
+##### `overrides` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `hostNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-hostNamespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualNamespacePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-from}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-key}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `allowedHostnames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-allowedHostnames}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-status}
 
 Status configures how Gateway status is mirrored.
 
@@ -7756,7 +7756,7 @@ Status configures how Gateway status is mirrored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `exposeAddresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-status-exposeAddresses}
+##### `exposeAddresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-status-exposeAddresses}
 
 
 
@@ -7774,7 +7774,7 @@ Status configures how Gateway status is mirrored.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-metadata}
 
 Metadata configures imported Gateway metadata visibility.
 
@@ -7786,7 +7786,7 @@ Metadata configures imported Gateway metadata visibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `exposeSourceGateway` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-metadata-exposeSourceGateway}
+##### `exposeSourceGateway` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-metadata-exposeSourceGateway}
 
 
 
@@ -7804,7 +7804,7 @@ Metadata configures imported Gateway metadata visibility.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sanitize` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize}
+##### `sanitize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize}
 
 Sanitize configures sensitive control plane field sanitization.
 
@@ -7816,7 +7816,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certificateRefs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize-certificateRefs}
+##### `certificateRefs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize-certificateRefs}
 
 
 
@@ -7831,7 +7831,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `infrastructure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize-infrastructure}
+##### `infrastructure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize-infrastructure}
 
 
 
@@ -7852,7 +7852,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses}
+#### `runtimeClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -7864,7 +7864,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -7879,7 +7879,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -7891,7 +7891,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -7906,7 +7906,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -7921,7 +7921,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -7936,7 +7936,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -7950,7 +7950,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -7965,7 +7965,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -7980,7 +7980,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -7995,7 +7995,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -8010,7 +8010,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -8025,7 +8025,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -8044,7 +8044,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -8062,7 +8062,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -8074,7 +8074,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchLabels}
 
 
 
@@ -8089,7 +8089,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions}
 
 
 
@@ -8101,22 +8101,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -8131,7 +8116,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-values}
 
 
 
@@ -8155,7 +8155,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -8167,7 +8167,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -8182,7 +8182,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -8194,7 +8194,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -8209,7 +8209,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -8224,7 +8224,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -8239,7 +8239,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -8253,7 +8253,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -8268,7 +8268,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -8283,7 +8283,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -8298,7 +8298,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -8313,7 +8313,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -8328,7 +8328,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -8347,7 +8347,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -8365,7 +8365,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -8377,7 +8377,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchLabels}
 
 
 
@@ -8392,7 +8392,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions}
 
 
 
@@ -8404,22 +8404,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -8434,7 +8419,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-values}
 
 
 
@@ -8458,7 +8458,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -8470,7 +8470,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -8485,7 +8485,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -8497,7 +8497,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -8512,7 +8512,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -8527,7 +8527,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -8542,7 +8542,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -8556,7 +8556,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -8571,7 +8571,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -8586,7 +8586,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -8601,7 +8601,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -8616,7 +8616,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -8631,7 +8631,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -8650,7 +8650,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -8668,7 +8668,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -8680,7 +8680,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchLabels}
 
 
 
@@ -8695,7 +8695,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions}
 
 
 
@@ -8707,22 +8707,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-key}
 
 
 
@@ -8737,7 +8722,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-values}
 
 
 
@@ -8761,7 +8761,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes}
+#### `csiNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -8773,7 +8773,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -8788,7 +8788,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -8800,7 +8800,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -8815,7 +8815,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -8830,7 +8830,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -8845,7 +8845,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -8859,7 +8859,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -8874,7 +8874,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -8889,7 +8889,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -8904,7 +8904,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -8919,7 +8919,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -8934,7 +8934,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -8953,7 +8953,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -8974,7 +8974,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers}
+#### `csiDrivers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -8986,7 +8986,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -9001,7 +9001,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -9013,7 +9013,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -9028,7 +9028,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -9043,7 +9043,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -9058,7 +9058,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -9072,7 +9072,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -9087,7 +9087,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -9102,7 +9102,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -9117,7 +9117,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -9132,7 +9132,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -9147,7 +9147,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -9166,7 +9166,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -9187,7 +9187,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities}
+#### `csiStorageCapacities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -9199,7 +9199,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -9214,7 +9214,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -9226,7 +9226,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -9241,7 +9241,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -9256,7 +9256,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -9271,7 +9271,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -9285,7 +9285,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -9300,7 +9300,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -9315,7 +9315,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -9330,7 +9330,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -9345,7 +9345,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -9360,7 +9360,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -9379,7 +9379,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -9400,7 +9400,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -9412,7 +9412,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -9427,7 +9427,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -9442,7 +9442,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -9454,7 +9454,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -9469,7 +9469,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -9484,7 +9484,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -9499,7 +9499,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -9513,7 +9513,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -9528,7 +9528,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -9543,7 +9543,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -9558,7 +9558,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -9573,7 +9573,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -9588,7 +9588,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -9607,7 +9607,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -9625,7 +9625,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings}
+##### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -9637,7 +9637,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -9674,7 +9674,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses}
+#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -9686,7 +9686,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -9701,7 +9701,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -9713,7 +9713,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -9728,7 +9728,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -9743,7 +9743,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -9758,7 +9758,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -9772,7 +9772,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -9787,7 +9787,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -9802,7 +9802,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -9817,7 +9817,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -9832,7 +9832,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -9847,7 +9847,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -9866,7 +9866,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -9887,7 +9887,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -9899,7 +9899,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -9914,7 +9914,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -9926,7 +9926,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -9941,7 +9941,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -9956,7 +9956,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -9971,7 +9971,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -9985,7 +9985,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -10000,7 +10000,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -10015,7 +10015,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -10030,7 +10030,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -10045,7 +10045,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -10060,7 +10060,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -10079,7 +10079,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -10097,7 +10097,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings}
+##### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -10109,7 +10109,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -10146,7 +10146,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -10158,7 +10158,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -10173,7 +10173,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -10185,7 +10185,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -10200,7 +10200,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -10215,7 +10215,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -10230,7 +10230,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -10244,7 +10244,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -10259,7 +10259,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -10274,7 +10274,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -10289,7 +10289,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -10304,7 +10304,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -10319,7 +10319,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -10338,7 +10338,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -10356,7 +10356,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings}
+##### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -10368,7 +10368,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -10405,7 +10405,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deviceClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses}
+#### `deviceClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses}
 
 DeviceClasses defines if device classes in the host should get synced to the virtual cluster
 
@@ -10417,7 +10417,7 @@ DeviceClasses defines if device classes in the host should get synced to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -10432,7 +10432,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -10444,7 +10444,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -10459,7 +10459,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -10474,7 +10474,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -10489,7 +10489,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -10503,7 +10503,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -10518,7 +10518,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -10533,7 +10533,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -10548,7 +10548,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -10563,7 +10563,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -10578,7 +10578,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -10597,7 +10597,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -10615,7 +10615,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -10627,7 +10627,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchLabels}
 
 
 
@@ -10642,7 +10642,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions}
 
 
 
@@ -10654,22 +10654,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-key}
 
 
 
@@ -10684,7 +10669,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster/_partials/config/sync/fromHost.mdx
+++ b/vcluster/_partials/config/sync/fromHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost}
+## `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -14,7 +14,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes}
+### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -26,7 +26,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -41,7 +41,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-syncBackChanges}
+#### `syncBackChanges` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -56,7 +56,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-clearImageStatus}
+#### `clearImageStatus` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -71,7 +71,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -83,7 +83,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -98,7 +98,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -116,7 +116,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -128,7 +128,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -143,7 +143,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -158,7 +158,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -173,7 +173,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -187,7 +187,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -202,7 +202,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -217,7 +217,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -232,7 +232,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -247,7 +247,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -262,7 +262,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -281,7 +281,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -302,7 +302,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events}
+### `events` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -314,7 +314,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-events-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -329,7 +329,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -341,7 +341,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -356,7 +356,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -371,7 +371,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -386,7 +386,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -400,7 +400,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -415,7 +415,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -430,7 +430,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -445,7 +445,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -460,7 +460,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -475,7 +475,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -494,7 +494,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -515,7 +515,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses}
+### `ingressClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -527,7 +527,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -542,7 +542,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -554,7 +554,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -569,7 +569,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -584,7 +584,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -599,7 +599,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -613,7 +613,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -628,7 +628,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -643,7 +643,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -658,7 +658,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -673,7 +673,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -688,7 +688,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -707,7 +707,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -725,7 +725,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -737,7 +737,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchLabels}
 
 
 
@@ -752,7 +752,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions}
 
 
 
@@ -764,22 +764,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -794,7 +779,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-values}
 
 
 
@@ -818,7 +818,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `gatewayClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses}
+### `gatewayClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses}
 
 GatewayClasses defines if gateway classes should get synced from the control plane cluster to the tenant cluster, but not back.
 
@@ -830,7 +830,7 @@ GatewayClasses defines if gateway classes should get synced from the control pla
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -845,7 +845,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -857,7 +857,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -872,7 +872,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -887,7 +887,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -902,7 +902,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -916,7 +916,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -931,7 +931,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -946,7 +946,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -961,7 +961,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -976,7 +976,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -991,7 +991,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1010,7 +1010,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1028,7 +1028,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -1040,7 +1040,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchLabels}
 
 
 
@@ -1055,7 +1055,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions}
 
 
 
@@ -1067,22 +1067,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-key}
 
 
 
@@ -1097,7 +1082,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-values}
 
 
 
@@ -1121,7 +1121,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways}
+### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways}
 
 Gateways defines if selected control plane Gateways should get synced from the control plane cluster to the tenant cluster, but not back.
 
@@ -1133,7 +1133,7 @@ Gateways defines if selected control plane Gateways should get synced from the c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1148,7 +1148,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1160,7 +1160,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1175,7 +1175,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1190,7 +1190,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1205,7 +1205,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1219,7 +1219,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1234,7 +1234,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1249,7 +1249,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1264,7 +1264,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1279,7 +1279,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1294,7 +1294,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1313,7 +1313,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1331,7 +1331,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -1343,7 +1343,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchLabels}
 
 
 
@@ -1358,7 +1358,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions}
 
 
 
@@ -1370,22 +1370,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-key}
 
 
 
@@ -1400,7 +1385,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-values}
 
 
 
@@ -1421,7 +1421,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-mappings}
+#### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-mappings}
 
 Mappings define control plane Gateway namespace/name to tenant-facing namespace/name placement.
 
@@ -1433,7 +1433,7 @@ Mappings define control plane Gateway namespace/name to tenant-facing namespace/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-gateways-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-gateways-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -1467,7 +1467,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `allowedRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes}
+#### `allowedRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes}
 
 AllowedRoutes configures the tenant-facing allowedRoutes policy shown on imported Gateways and enforced for Routes.
 
@@ -1479,7 +1479,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `defaultVirtualNamespacePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy}
+##### `defaultVirtualNamespacePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy}
 
 
 
@@ -1491,7 +1491,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-from}
 
 
 
@@ -1506,7 +1506,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector}
 
 
 
@@ -1518,7 +1518,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchLabels}
 
 
 
@@ -1533,7 +1533,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions}
 
 
 
@@ -1545,22 +1545,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-key}
 
 
 
@@ -1575,43 +1560,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-values}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `overrides` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-hostNamespace}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-operator}
 
 
 
@@ -1626,7 +1575,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-name}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-values}
 
 
 
@@ -1635,138 +1584,6 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 
 
 </details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `virtualNamespacePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-from}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchLabels}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-operator}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-values}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `allowedHostnames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-allowedHostnames}
-
-
-
-</summary>
-
 
 
 </details>
@@ -1782,7 +1599,190 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-status}
+##### `overrides` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `hostNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-hostNamespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualNamespacePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-from}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-key}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `allowedHostnames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-allowedHostnames}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-status}
 
 Status configures how Gateway status is mirrored.
 
@@ -1794,7 +1794,7 @@ Status configures how Gateway status is mirrored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `exposeAddresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-status-exposeAddresses}
+##### `exposeAddresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-status-exposeAddresses}
 
 
 
@@ -1812,7 +1812,7 @@ Status configures how Gateway status is mirrored.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-metadata}
 
 Metadata configures imported Gateway metadata visibility.
 
@@ -1824,7 +1824,7 @@ Metadata configures imported Gateway metadata visibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `exposeSourceGateway` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-metadata-exposeSourceGateway}
+##### `exposeSourceGateway` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-metadata-exposeSourceGateway}
 
 
 
@@ -1842,7 +1842,7 @@ Metadata configures imported Gateway metadata visibility.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sanitize` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize}
+#### `sanitize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize}
 
 Sanitize configures sensitive control plane field sanitization.
 
@@ -1854,7 +1854,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certificateRefs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize-certificateRefs}
+##### `certificateRefs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize-certificateRefs}
 
 
 
@@ -1869,7 +1869,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `infrastructure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize-infrastructure}
+##### `infrastructure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize-infrastructure}
 
 
 
@@ -1890,7 +1890,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses}
+### `runtimeClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -1902,7 +1902,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1917,7 +1917,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1929,7 +1929,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1944,7 +1944,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1959,7 +1959,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1974,7 +1974,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1988,7 +1988,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2003,7 +2003,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2018,7 +2018,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2033,7 +2033,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2048,7 +2048,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2063,7 +2063,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2082,7 +2082,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2100,7 +2100,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -2112,7 +2112,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchLabels}
 
 
 
@@ -2127,7 +2127,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions}
 
 
 
@@ -2139,22 +2139,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -2169,7 +2154,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-values}
 
 
 
@@ -2193,7 +2193,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -2205,7 +2205,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2220,7 +2220,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2232,7 +2232,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2247,7 +2247,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2262,7 +2262,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2277,7 +2277,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2291,7 +2291,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2306,7 +2306,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2321,7 +2321,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2336,7 +2336,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2351,7 +2351,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2366,7 +2366,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2385,7 +2385,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2403,7 +2403,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -2415,7 +2415,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchLabels}
 
 
 
@@ -2430,7 +2430,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions}
 
 
 
@@ -2442,22 +2442,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -2472,7 +2457,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-values}
 
 
 
@@ -2496,7 +2496,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -2508,7 +2508,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2523,7 +2523,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2535,7 +2535,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2550,7 +2550,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2565,7 +2565,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2580,7 +2580,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2594,7 +2594,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2609,7 +2609,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2624,7 +2624,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2639,7 +2639,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2654,7 +2654,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2669,7 +2669,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2688,7 +2688,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2706,7 +2706,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -2718,7 +2718,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchLabels}
 
 
 
@@ -2733,7 +2733,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions}
 
 
 
@@ -2745,22 +2745,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-key}
 
 
 
@@ -2775,7 +2760,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-values}
 
 
 
@@ -2799,7 +2799,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes}
+### `csiNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -2811,7 +2811,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiNodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2826,7 +2826,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2838,7 +2838,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2853,7 +2853,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2868,7 +2868,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2883,7 +2883,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2897,7 +2897,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2912,7 +2912,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2927,7 +2927,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2942,7 +2942,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2957,7 +2957,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2972,7 +2972,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2991,7 +2991,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3012,7 +3012,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers}
+### `csiDrivers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -3024,7 +3024,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3039,7 +3039,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3051,7 +3051,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3066,7 +3066,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3081,7 +3081,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3096,7 +3096,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3110,7 +3110,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3125,7 +3125,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3140,7 +3140,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3155,7 +3155,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3170,7 +3170,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3185,7 +3185,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3204,7 +3204,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3225,7 +3225,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities}
+### `csiStorageCapacities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -3237,7 +3237,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3252,7 +3252,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3264,7 +3264,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3279,7 +3279,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3294,7 +3294,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3309,7 +3309,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3323,7 +3323,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3338,7 +3338,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3353,7 +3353,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3368,7 +3368,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3383,7 +3383,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3398,7 +3398,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3417,7 +3417,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3438,7 +3438,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -3450,7 +3450,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3465,7 +3465,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -3480,7 +3480,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3492,7 +3492,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3507,7 +3507,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3522,7 +3522,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3537,7 +3537,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3551,7 +3551,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3566,7 +3566,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3581,7 +3581,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3596,7 +3596,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3611,7 +3611,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3626,7 +3626,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3645,7 +3645,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3663,7 +3663,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings}
+#### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -3675,7 +3675,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -3712,7 +3712,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses}
+### `volumeSnapshotClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -3724,7 +3724,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3739,7 +3739,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3751,7 +3751,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3766,7 +3766,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3781,7 +3781,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3796,7 +3796,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3810,7 +3810,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3825,7 +3825,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3840,7 +3840,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3855,7 +3855,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3870,7 +3870,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3885,7 +3885,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3904,7 +3904,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3925,7 +3925,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -3937,7 +3937,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3952,7 +3952,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3964,7 +3964,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3979,7 +3979,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3994,7 +3994,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4009,7 +4009,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4023,7 +4023,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4038,7 +4038,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4053,7 +4053,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4068,7 +4068,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4083,7 +4083,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4098,7 +4098,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4117,7 +4117,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4135,7 +4135,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings}
+#### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -4147,7 +4147,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -4184,7 +4184,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -4196,7 +4196,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4211,7 +4211,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4223,7 +4223,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4238,7 +4238,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4253,7 +4253,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4268,7 +4268,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4282,7 +4282,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4297,7 +4297,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4312,7 +4312,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4327,7 +4327,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4342,7 +4342,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4357,7 +4357,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4376,7 +4376,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4394,7 +4394,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings}
+#### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -4406,7 +4406,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -4443,7 +4443,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deviceClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses}
+### `deviceClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses}
 
 DeviceClasses defines if device classes in the host should get synced to the virtual cluster
 
@@ -4455,7 +4455,7 @@ DeviceClasses defines if device classes in the host should get synced to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4470,7 +4470,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4482,7 +4482,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4497,7 +4497,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4512,7 +4512,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4527,7 +4527,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4541,7 +4541,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4556,7 +4556,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4571,7 +4571,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4586,7 +4586,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4601,7 +4601,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4616,7 +4616,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4635,7 +4635,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4653,7 +4653,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -4665,7 +4665,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchLabels}
 
 
 
@@ -4680,7 +4680,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions}
 
 
 
@@ -4692,22 +4692,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-key}
 
 
 
@@ -4722,7 +4707,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster/_partials/config/sync/fromHost/configMaps.mdx
+++ b/vcluster/_partials/config/sync/fromHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-mappings}
+### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#configMaps-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#configMaps-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:

--- a/vcluster/_partials/config/sync/fromHost/csiDrivers.mdx
+++ b/vcluster/_partials/config/sync/fromHost/csiDrivers.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers}
+## `csiDrivers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiDrivers-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/fromHost/csiNodes.mdx
+++ b/vcluster/_partials/config/sync/fromHost/csiNodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes}
+## `csiNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiNodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/fromHost/csiStorageCapacities.mdx
+++ b/vcluster/_partials/config/sync/fromHost/csiStorageCapacities.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities}
+## `csiStorageCapacities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiStorageCapacities-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/fromHost/customResources.mdx
+++ b/vcluster/_partials/config/sync/fromHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -14,7 +14,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -44,7 +44,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -227,7 +227,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings}
+### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -239,7 +239,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:

--- a/vcluster/_partials/config/sync/fromHost/events.mdx
+++ b/vcluster/_partials/config/sync/fromHost/events.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events}
+## `events` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#events-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/fromHost/gatewayClasses.mdx
+++ b/vcluster/_partials/config/sync/fromHost/gatewayClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `gatewayClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses}
+## `gatewayClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses}
 
 GatewayClasses defines if gateway classes should get synced from the control plane cluster to the tenant cluster, but not back.
 
@@ -14,7 +14,7 @@ GatewayClasses defines if gateway classes should get synced from the control pla
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster/_partials/config/sync/fromHost/ingressClasses.mdx
+++ b/vcluster/_partials/config/sync/fromHost/ingressClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses}
+## `ingressClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingressClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster/_partials/config/sync/fromHost/nodes.mdx
+++ b/vcluster/_partials/config/sync/fromHost/nodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes}
+## `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -29,7 +29,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-syncBackChanges}
+### `syncBackChanges` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -44,7 +44,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-clearImageStatus}
+### `clearImageStatus` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -59,7 +59,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -71,7 +71,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-selector-all}
+#### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -86,7 +86,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#nodes-selector-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -104,7 +104,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -116,7 +116,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -131,7 +131,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -146,7 +146,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -161,7 +161,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -175,7 +175,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -190,7 +190,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -205,7 +205,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -220,7 +220,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -235,7 +235,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -250,7 +250,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -269,7 +269,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/fromHost/priorityClasses.mdx
+++ b/vcluster/_partials/config/sync/fromHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster/_partials/config/sync/fromHost/runtimeClasses.mdx
+++ b/vcluster/_partials/config/sync/fromHost/runtimeClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses}
+## `runtimeClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#runtimeClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster/_partials/config/sync/fromHost/secrets.mdx
+++ b/vcluster/_partials/config/sync/fromHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-mappings}
+### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#secrets-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#secrets-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:

--- a/vcluster/_partials/config/sync/fromHost/storageClasses.mdx
+++ b/vcluster/_partials/config/sync/fromHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster/_partials/config/sync/toHost.mdx
+++ b/vcluster/_partials/config/sync/toHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost}
+## `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -14,7 +14,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods}
+### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -26,7 +26,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -41,7 +41,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#toHost-pods-translateImage}
+#### `translateImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -57,7 +57,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-enforceTolerations}
+#### `enforceTolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -72,7 +72,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-useSecretsForSATokens}
+#### `useSecretsForSATokens` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -88,7 +88,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-runtimeClassName}
+#### `runtimeClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -103,7 +103,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -118,7 +118,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts}
+#### `rewriteHosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -132,7 +132,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -147,7 +147,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -159,7 +159,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -171,7 +171,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -187,7 +187,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -202,7 +202,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -220,7 +220,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -232,7 +232,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -247,7 +247,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -271,7 +271,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -283,7 +283,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -298,7 +298,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -313,7 +313,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -328,7 +328,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -342,7 +342,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -357,7 +357,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -372,7 +372,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -387,7 +387,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -402,7 +402,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -417,7 +417,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -436,7 +436,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -454,7 +454,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling}
+#### `hybridScheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -466,7 +466,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -481,7 +481,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-hostSchedulers}
+##### `hostSchedulers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 
@@ -502,7 +502,7 @@ HostSchedulers is a list of schedulers that are deployed on the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -514,7 +514,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -529,7 +529,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-secrets-all}
+#### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -544,7 +544,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -556,7 +556,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -571,7 +571,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -586,7 +586,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -601,7 +601,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -615,7 +615,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -630,7 +630,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -645,7 +645,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -660,7 +660,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -675,7 +675,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -690,7 +690,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -709,7 +709,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -730,7 +730,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -742,7 +742,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -757,7 +757,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-configMaps-all}
+#### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -772,7 +772,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -784,7 +784,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -799,7 +799,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -814,7 +814,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -829,7 +829,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -843,7 +843,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -858,7 +858,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -873,7 +873,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -888,7 +888,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -903,7 +903,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -918,7 +918,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -937,7 +937,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -958,7 +958,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses}
+### `ingresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -970,7 +970,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-ingresses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -985,7 +985,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -997,7 +997,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1012,7 +1012,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1027,7 +1027,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1042,7 +1042,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1056,7 +1056,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1071,7 +1071,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1086,7 +1086,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1101,7 +1101,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1116,7 +1116,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1131,7 +1131,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1150,7 +1150,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1171,7 +1171,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `gatewayApi` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi}
+### `gatewayApi` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi}
 
 GatewayAPI defines Gateway API resources created within the tenant cluster that should get synced to the control plane cluster.
 
@@ -1183,7 +1183,7 @@ GatewayAPI defines Gateway API resources created within the tenant cluster that 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1198,7 +1198,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1210,7 +1210,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1225,7 +1225,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1240,7 +1240,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1255,7 +1255,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1269,7 +1269,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1284,7 +1284,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1299,7 +1299,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1314,7 +1314,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1329,7 +1329,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1344,7 +1344,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1363,7 +1363,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1381,7 +1381,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `httpRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes}
+#### `httpRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes}
 
 HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 
@@ -1393,7 +1393,7 @@ HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1408,7 +1408,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1420,7 +1420,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1435,7 +1435,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1450,7 +1450,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1465,7 +1465,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1479,7 +1479,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1494,7 +1494,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1509,7 +1509,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1524,7 +1524,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1539,7 +1539,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1554,7 +1554,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1573,7 +1573,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1594,7 +1594,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways}
+#### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways}
 
 Gateways configures tenant-created Gateway sync to the control plane cluster.
 
@@ -1606,7 +1606,7 @@ Gateways configures tenant-created Gateway sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1621,7 +1621,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1633,7 +1633,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1648,7 +1648,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1663,7 +1663,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1678,7 +1678,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1692,7 +1692,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1707,7 +1707,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1722,7 +1722,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1737,7 +1737,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1752,7 +1752,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1767,7 +1767,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1786,7 +1786,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1807,7 +1807,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `tlsRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes}
+#### `tlsRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes}
 
 TLSRoutes configures TLSRoute sync to the control plane cluster.
 
@@ -1819,7 +1819,7 @@ TLSRoutes configures TLSRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1834,7 +1834,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1846,7 +1846,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1861,7 +1861,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1876,7 +1876,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1891,7 +1891,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1905,7 +1905,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1920,7 +1920,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1935,7 +1935,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1950,7 +1950,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1965,7 +1965,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1980,7 +1980,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1999,7 +1999,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2020,7 +2020,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `backendTLSPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies}
+#### `backendTLSPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies}
 
 BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster.
 
@@ -2032,7 +2032,7 @@ BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2047,7 +2047,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2059,7 +2059,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2074,7 +2074,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2089,7 +2089,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2104,7 +2104,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2118,7 +2118,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2133,7 +2133,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2148,7 +2148,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2163,7 +2163,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2178,7 +2178,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2193,7 +2193,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2212,7 +2212,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2233,7 +2233,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `referenceGrants` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants}
+#### `referenceGrants` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants}
 
 ReferenceGrants configures ReferenceGrant sync to the control plane cluster. Enabled may be "auto", "true", or "false".
 
@@ -2245,7 +2245,7 @@ ReferenceGrants configures ReferenceGrant sync to the control plane cluster. Ena
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2260,7 +2260,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2272,7 +2272,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2287,7 +2287,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2302,7 +2302,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2317,7 +2317,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2331,7 +2331,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2346,7 +2346,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2361,7 +2361,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2376,7 +2376,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2391,7 +2391,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2406,7 +2406,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2425,7 +2425,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2449,7 +2449,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services}
+### `services` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -2461,7 +2461,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-services-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2476,7 +2476,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2488,7 +2488,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2503,7 +2503,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2518,7 +2518,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2533,7 +2533,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2547,7 +2547,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2562,7 +2562,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2577,7 +2577,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2592,7 +2592,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2607,7 +2607,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2622,7 +2622,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2641,7 +2641,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2662,7 +2662,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints}
+### `endpoints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -2674,7 +2674,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpoints-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2689,7 +2689,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2701,7 +2701,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2716,7 +2716,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2731,7 +2731,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2746,7 +2746,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2760,7 +2760,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2775,7 +2775,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2790,7 +2790,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2805,7 +2805,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2820,7 +2820,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2835,7 +2835,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2854,7 +2854,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2875,7 +2875,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `endpointSlices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices}
+### `endpointSlices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices}
 
 EndpointSlices defines if endpointslices created within the virtual cluster should get synced to the host cluster.
 
@@ -2887,7 +2887,7 @@ EndpointSlices defines if endpointslices created within the virtual cluster shou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpointSlices-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpointSlices-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2902,7 +2902,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2914,7 +2914,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2929,7 +2929,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2944,7 +2944,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2959,7 +2959,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2973,7 +2973,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2988,7 +2988,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3003,7 +3003,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3018,7 +3018,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3033,7 +3033,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3048,7 +3048,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3067,7 +3067,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3088,7 +3088,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies}
+### `networkPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -3100,7 +3100,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-networkPolicies-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3115,7 +3115,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3127,7 +3127,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3142,7 +3142,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3157,7 +3157,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3172,7 +3172,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3186,7 +3186,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3201,7 +3201,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3216,7 +3216,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3231,7 +3231,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3246,7 +3246,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3261,7 +3261,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3280,7 +3280,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3301,7 +3301,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims}
+### `persistentVolumeClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -3313,7 +3313,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3328,7 +3328,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3340,7 +3340,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3355,7 +3355,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3370,7 +3370,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3385,7 +3385,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3399,7 +3399,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3414,7 +3414,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3429,7 +3429,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3444,7 +3444,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3459,7 +3459,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3474,7 +3474,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3493,7 +3493,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3514,7 +3514,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes}
+### `persistentVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -3526,7 +3526,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3541,7 +3541,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3553,7 +3553,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3568,7 +3568,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3583,7 +3583,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3598,7 +3598,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3612,7 +3612,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3627,7 +3627,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3642,7 +3642,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3657,7 +3657,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3672,7 +3672,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3687,7 +3687,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3706,7 +3706,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3727,7 +3727,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots}
+### `volumeSnapshots` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -3739,7 +3739,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3754,7 +3754,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3766,7 +3766,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3781,7 +3781,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3796,7 +3796,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3811,7 +3811,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3825,7 +3825,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3840,7 +3840,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3855,7 +3855,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3870,7 +3870,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3885,7 +3885,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3900,7 +3900,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3919,7 +3919,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3940,7 +3940,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents}
+### `volumeSnapshotContents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -3952,7 +3952,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3967,7 +3967,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3979,7 +3979,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3994,7 +3994,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4009,7 +4009,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4024,7 +4024,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4038,7 +4038,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4053,7 +4053,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4068,7 +4068,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4083,7 +4083,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4098,7 +4098,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4113,7 +4113,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4132,7 +4132,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4153,7 +4153,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -4165,7 +4165,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4180,7 +4180,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4192,7 +4192,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4207,7 +4207,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4222,7 +4222,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4237,7 +4237,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4251,7 +4251,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4266,7 +4266,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4281,7 +4281,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4296,7 +4296,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4311,7 +4311,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4326,7 +4326,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4345,7 +4345,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4366,7 +4366,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts}
+### `serviceAccounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -4378,7 +4378,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4393,7 +4393,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4405,7 +4405,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4420,7 +4420,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4435,7 +4435,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4450,7 +4450,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4464,7 +4464,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4479,7 +4479,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4494,7 +4494,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4509,7 +4509,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4524,7 +4524,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4539,7 +4539,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4558,7 +4558,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4579,7 +4579,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets}
+### `podDisruptionBudgets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -4591,7 +4591,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4606,7 +4606,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4618,7 +4618,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4633,7 +4633,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4648,7 +4648,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4663,7 +4663,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4677,7 +4677,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4692,7 +4692,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4707,7 +4707,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4722,7 +4722,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4737,7 +4737,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4752,7 +4752,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4771,7 +4771,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4792,7 +4792,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -4804,7 +4804,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4819,7 +4819,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4831,7 +4831,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4846,7 +4846,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4861,7 +4861,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4876,7 +4876,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4890,7 +4890,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4905,7 +4905,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4920,7 +4920,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4935,7 +4935,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4950,7 +4950,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4965,7 +4965,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4984,7 +4984,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5005,7 +5005,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -5018,7 +5018,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5033,7 +5033,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -5048,7 +5048,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5060,7 +5060,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5075,7 +5075,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5090,7 +5090,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5105,7 +5105,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5119,7 +5119,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5134,7 +5134,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5149,7 +5149,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5164,7 +5164,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5179,7 +5179,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5194,7 +5194,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5213,7 +5213,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5234,7 +5234,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces}
 
 Namespaces defines if namespaces created within the virtual cluster should get synced to the host cluster.
 
@@ -5246,7 +5246,7 @@ Namespaces defines if namespaces created within the virtual cluster should get s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-enabled}
+#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5261,7 +5261,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5273,7 +5273,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5288,7 +5288,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5303,7 +5303,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5318,7 +5318,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5332,7 +5332,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5347,7 +5347,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5362,7 +5362,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5377,7 +5377,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5392,7 +5392,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5407,7 +5407,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5426,7 +5426,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5444,7 +5444,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings}
+#### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings}
 
 Mappings for Namespace and Object
 
@@ -5456,7 +5456,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -5490,7 +5490,7 @@ byName:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-mappingsOnly}
+#### `mappingsOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-mappingsOnly}
 
 MappingsOnly defines if creation of namespaces not matched by mappings should be allowed.
 
@@ -5505,7 +5505,7 @@ MappingsOnly defines if creation of namespaces not matched by mappings should be
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-extraLabels}
+#### `extraLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-extraLabels}
 
 ExtraLabels are additional labels to add to the namespace in the host cluster.
 
@@ -5523,7 +5523,7 @@ ExtraLabels are additional labels to add to the namespace in the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resourceClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims}
+### `resourceClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims}
 
 ResourceClaim defines if resource claims created within the virtual cluster should get synced to the host cluster.
 
@@ -5535,7 +5535,7 @@ ResourceClaim defines if resource claims created within the virtual cluster shou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-resourceClaims-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-resourceClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5550,7 +5550,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5562,7 +5562,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5577,7 +5577,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5592,7 +5592,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5607,7 +5607,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5621,7 +5621,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5636,7 +5636,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5651,7 +5651,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5666,7 +5666,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5681,7 +5681,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5696,7 +5696,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5715,7 +5715,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5736,7 +5736,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resourceClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates}
+### `resourceClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates}
 
 ResourceClaimTemplates defines if resourceClaimTemplates created within the virtual cluster should get synced to the host cluster.
 
@@ -5748,7 +5748,7 @@ ResourceClaimTemplates defines if resourceClaimTemplates created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5763,7 +5763,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5775,7 +5775,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5790,7 +5790,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5805,7 +5805,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5820,7 +5820,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5834,7 +5834,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5849,7 +5849,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5864,7 +5864,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5879,7 +5879,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5894,7 +5894,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5909,7 +5909,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5928,7 +5928,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/configMaps.mdx
+++ b/vcluster/_partials/config/sync/toHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-all}
+### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/customResources.mdx
+++ b/vcluster/_partials/config/sync/toHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -15,7 +15,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -30,7 +30,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -45,7 +45,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -57,7 +57,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -72,7 +72,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -87,7 +87,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -102,7 +102,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -116,7 +116,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -131,7 +131,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -146,7 +146,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -161,7 +161,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -176,7 +176,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -191,7 +191,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -210,7 +210,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/endpointSlices.mdx
+++ b/vcluster/_partials/config/sync/toHost/endpointSlices.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `endpointSlices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices}
+## `endpointSlices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices}
 
 EndpointSlices defines if endpointslices created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ EndpointSlices defines if endpointslices created within the virtual cluster shou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpointSlices-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpointSlices-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/endpoints.mdx
+++ b/vcluster/_partials/config/sync/toHost/endpoints.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints}
+## `endpoints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpoints-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/gatewayApi.mdx
+++ b/vcluster/_partials/config/sync/toHost/gatewayApi.mdx
@@ -1,6 +1,8 @@
 
 Setting `enabled: true` turns on Gateway and HTTPRoute sync, imports control plane cluster GatewayClasses so tenant Gateways can resolve them, and serves tenant ReferenceGrants for validation; TLSRoutes and BackendTLSPolicies must be enabled individually.
 
+In auto mode grants follow route sync and are validated within the tenant cluster; they sync to the control plane cluster only when namespace sync is also enabled.
+
 
 <details className="config-field" data-expandable="true">
 <summary>

--- a/vcluster/_partials/config/sync/toHost/gatewayApi.mdx
+++ b/vcluster/_partials/config/sync/toHost/gatewayApi.mdx
@@ -1,8 +1,11 @@
 
+Setting `enabled: true` turns on Gateway and HTTPRoute sync, imports control plane cluster GatewayClasses so tenant Gateways can resolve them, and serves tenant ReferenceGrants for validation; TLSRoutes and BackendTLSPolicies must be enabled individually.
+
+
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `gatewayApi` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi}
+## `gatewayApi` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi}
 
 GatewayAPI defines Gateway API resources created within the tenant cluster that should get synced to the control plane cluster.
 
@@ -14,7 +17,7 @@ GatewayAPI defines Gateway API resources created within the tenant cluster that 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +32,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +44,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +59,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +74,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +89,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +103,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +118,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +133,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +148,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +163,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +178,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +197,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +215,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `httpRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes}
+### `httpRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes}
 
 HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 
@@ -224,7 +227,7 @@ HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -239,7 +242,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -251,7 +254,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -266,7 +269,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -281,7 +284,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -296,7 +299,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -310,7 +313,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -325,7 +328,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -340,7 +343,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -355,7 +358,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -370,7 +373,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -385,7 +388,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -404,7 +407,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -425,7 +428,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways}
+### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways}
 
 Gateways configures tenant-created Gateway sync to the control plane cluster.
 
@@ -437,7 +440,7 @@ Gateways configures tenant-created Gateway sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-gateways-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -452,7 +455,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -464,7 +467,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -479,7 +482,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -494,7 +497,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -509,7 +512,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -523,7 +526,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -538,7 +541,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -553,7 +556,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -568,7 +571,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -583,7 +586,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -598,7 +601,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -617,7 +620,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -638,7 +641,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `tlsRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes}
+### `tlsRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes}
 
 TLSRoutes configures TLSRoute sync to the control plane cluster.
 
@@ -650,7 +653,7 @@ TLSRoutes configures TLSRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -665,7 +668,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -677,7 +680,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -692,7 +695,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -707,7 +710,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -722,7 +725,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -736,7 +739,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -751,7 +754,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -766,7 +769,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -781,7 +784,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -796,7 +799,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -811,7 +814,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -830,7 +833,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -851,7 +854,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `backendTLSPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies}
+### `backendTLSPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies}
 
 BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster.
 
@@ -863,7 +866,7 @@ BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -878,7 +881,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -890,7 +893,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -905,7 +908,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -920,7 +923,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -935,7 +938,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -949,7 +952,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -964,7 +967,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -979,7 +982,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -994,7 +997,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1009,7 +1012,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1024,7 +1027,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1043,7 +1046,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1064,7 +1067,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `referenceGrants` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants}
+### `referenceGrants` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants}
 
 ReferenceGrants configures ReferenceGrant sync to the control plane cluster. Enabled may be "auto", "true", or "false".
 
@@ -1076,7 +1079,7 @@ ReferenceGrants configures ReferenceGrant sync to the control plane cluster. Ena
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1091,7 +1094,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1103,7 +1106,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1118,7 +1121,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1133,7 +1136,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1148,7 +1151,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1162,7 +1165,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1177,7 +1180,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1192,7 +1195,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1207,7 +1210,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1222,7 +1225,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1237,7 +1240,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1256,7 +1259,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/ingresses.mdx
+++ b/vcluster/_partials/config/sync/toHost/ingresses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses}
+## `ingresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingresses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/networkPolicies.mdx
+++ b/vcluster/_partials/config/sync/toHost/networkPolicies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies}
+## `networkPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicies-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/persistentVolumeClaims.mdx
+++ b/vcluster/_partials/config/sync/toHost/persistentVolumeClaims.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims}
+## `persistentVolumeClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#persistentVolumeClaims-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/persistentVolumes.mdx
+++ b/vcluster/_partials/config/sync/toHost/persistentVolumes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes}
+## `persistentVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#persistentVolumes-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/podDisruptionBudgets.mdx
+++ b/vcluster/_partials/config/sync/toHost/podDisruptionBudgets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets}
+## `podDisruptionBudgets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#podDisruptionBudgets-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/pods.mdx
+++ b/vcluster/_partials/config/sync/toHost/pods.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods}
+## `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#pods-translateImage}
+### `translateImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -45,7 +45,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-enforceTolerations}
+### `enforceTolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -60,7 +60,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-useSecretsForSATokens}
+### `useSecretsForSATokens` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -76,7 +76,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-runtimeClassName}
+### `runtimeClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -91,7 +91,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -106,7 +106,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts}
+### `rewriteHosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -120,7 +120,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -135,7 +135,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer}
+#### `initContainer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -147,7 +147,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -159,7 +159,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -175,7 +175,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -190,7 +190,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -208,7 +208,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -220,7 +220,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -235,7 +235,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -259,7 +259,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -271,7 +271,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -286,7 +286,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -301,7 +301,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -316,7 +316,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -330,7 +330,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -345,7 +345,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -360,7 +360,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -375,7 +375,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -390,7 +390,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -405,7 +405,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -424,7 +424,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -442,7 +442,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-hybridScheduling}
+### `hybridScheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -454,7 +454,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -469,7 +469,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-hostSchedulers}
+#### `hostSchedulers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 

--- a/vcluster/_partials/config/sync/toHost/priorityClasses.mdx
+++ b/vcluster/_partials/config/sync/toHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/secrets.mdx
+++ b/vcluster/_partials/config/sync/toHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-all}
+### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/serviceAccounts.mdx
+++ b/vcluster/_partials/config/sync/toHost/serviceAccounts.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts}
+## `serviceAccounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceAccounts-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/services.mdx
+++ b/vcluster/_partials/config/sync/toHost/services.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services}
+## `services` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#services-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/storageClasses.mdx
+++ b/vcluster/_partials/config/sync/toHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/volumeSnapshots.mdx
+++ b/vcluster/_partials/config/sync/toHost/volumeSnapshots.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots}
+## `volumeSnapshots` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#volumeSnapshots-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/telemetry.mdx
+++ b/vcluster/_partials/config/telemetry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `telemetry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry}
+## `telemetry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry}
 
 Configuration related to telemetry gathered about vCluster usage.
 
@@ -14,7 +14,7 @@ Configuration related to telemetry gathered about vCluster usage.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#telemetry-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#telemetry-enabled}
 
 Enabled specifies that the telemetry for the vCluster control plane should be enabled.
 
@@ -29,7 +29,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `instanceCreator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-instanceCreator}
+### `instanceCreator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-instanceCreator}
 
 
 
@@ -44,7 +44,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `machineID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-machineID}
+### `machineID` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-machineID}
 
 
 
@@ -59,7 +59,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformUserID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformUserID}
+### `platformUserID` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformUserID}
 
 
 
@@ -74,7 +74,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformInstanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformInstanceID}
+### `platformInstanceID` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformInstanceID}
 
 
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane}
+## `controlPlane` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane}
 
 Configure vCluster's control plane components and deployment.
 
@@ -14,7 +14,7 @@ Configure vCluster's control plane components and deployment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-endpoint}
+### `endpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-endpoint}
 
 Endpoint is the endpoint of the virtual cluster. This is used to connect to the virtual cluster.
 
@@ -29,7 +29,7 @@ Endpoint is the endpoint of the virtual cluster. This is used to connect to the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
+### `distro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -41,7 +41,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s}
+#### `k8s` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -53,7 +53,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -68,7 +68,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-version}
 
 Version is the Kubernetes version to use.
 
@@ -83,7 +83,7 @@ Version is the Kubernetes version to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer}
+##### `apiServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -95,7 +95,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -110,7 +110,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -125,7 +125,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -143,7 +143,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager}
+##### `controllerManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -155,7 +155,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -170,7 +170,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -185,7 +185,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -203,7 +203,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler}
+##### `scheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler.
 
@@ -215,7 +215,7 @@ Scheduler holds configuration specific to starting the scheduler.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -230,7 +230,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -245,7 +245,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -263,7 +263,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image}
 
 Image is the distro image
 
@@ -275,7 +275,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -291,7 +291,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -306,7 +306,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -324,7 +324,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -339,7 +339,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-env}
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -354,7 +354,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -369,7 +369,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -390,7 +390,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `standalone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone}
+### `standalone` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone}
 
 Standalone holds configuration for standalone mode. Standalone mode is set automatically when no container is detected and
 also implies privateNodes.enabled.
@@ -403,7 +403,7 @@ also implies privateNodes.enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-enabled}
 
 Enabled defines if standalone mode should be enabled.
 
@@ -418,7 +418,7 @@ Enabled defines if standalone mode should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">/var/lib/vcluster</span> <span className="config-field-enum"></span> {#controlPlane-standalone-dataDir}
+#### `dataDir` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">/var/lib/vcluster</span> <span className="config-field-enum"></span> {#controlPlane-standalone-dataDir}
 
 DataDir defines the data directory for the standalone mode.
 
@@ -433,7 +433,7 @@ DataDir defines the data directory for the standalone mode.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `autoNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes}
+#### `autoNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes}
 
 AutoNodes automatically deploys nodes for standalone mode.
 
@@ -445,7 +445,7 @@ AutoNodes automatically deploys nodes for standalone mode.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `provider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-provider}
+##### `provider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-provider}
 
 Provider is the node provider of the nodes in this pool.
 
@@ -460,7 +460,7 @@ Provider is the node provider of the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `quantity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-quantity}
+##### `quantity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-quantity}
 
 Quantity is the number of nodes to deploy for standalone mode.
 
@@ -475,7 +475,7 @@ Quantity is the number of nodes to deploy for standalone mode.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector}
+##### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -488,7 +488,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -503,7 +503,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -518,7 +518,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -533,7 +533,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-autoNodes-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -554,7 +554,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode}
+#### `joinNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode}
 
 JoinNode holds configuration for the standalone control plane node.
 
@@ -566,7 +566,7 @@ JoinNode holds configuration for the standalone control plane node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-enabled}
 
 Enabled defines if the standalone node should be joined into the cluster. If false, only the control plane binaries will be executed and no node will show up in the actual cluster.
 
@@ -581,7 +581,7 @@ Enabled defines if the standalone node should be joined into the cluster. If fal
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `preInstallCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-preInstallCommands}
+##### `preInstallCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-preInstallCommands}
 
 PreInstallCommands are commands that will be executed before containerd, kubelet etc. is installed.
 
@@ -596,7 +596,7 @@ PreInstallCommands are commands that will be executed before containerd, kubelet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-preJoinCommands}
+##### `preJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-preJoinCommands}
 
 PreJoinCommands are commands that will be executed before kubeadm join is executed.
 
@@ -611,7 +611,7 @@ PreJoinCommands are commands that will be executed before kubeadm join is execut
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-postJoinCommands}
+##### `postJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-postJoinCommands}
 
 PostJoinCommands are commands that will be executed after kubeadm join is executed.
 
@@ -626,7 +626,7 @@ PostJoinCommands are commands that will be executed after kubeadm join is execut
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd}
+##### `containerd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd}
 
 Containerd holds configuration for the containerd join process.
 
@@ -638,7 +638,7 @@ Containerd holds configuration for the containerd join process.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-enabled}
 
 Enabled defines if containerd should be installed and configured by vCluster.
 
@@ -653,7 +653,7 @@ Enabled defines if containerd should be installed and configured by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry}
 
 Registry holds configuration for how containerd should be configured to use a registries.
 
@@ -665,7 +665,7 @@ Registry holds configuration for how containerd should be configured to use a re
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-configPath}
+##### `configPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-configPath}
 
 ConfigPath is the path to the containerd registry config.
 
@@ -680,7 +680,7 @@ ConfigPath is the path to the containerd registry config.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors}
+##### `mirrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors}
 
 Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -692,7 +692,7 @@ Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-server}
 
 Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -707,7 +707,7 @@ Server is the fallback server to use for the containerd registry mirror. E.g. ht
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror.
 
@@ -722,7 +722,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -737,7 +737,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -752,7 +752,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -767,7 +767,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts}
+##### `hosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts}
 
 Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -779,7 +779,7 @@ Hosts holds configuration for the containerd registry mirror hosts. See https://
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-server}
 
 Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
 
@@ -794,7 +794,7 @@ Server is the server to use for the containerd registry mirror host. E.g. http:/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror host.
 
@@ -809,7 +809,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror ho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -824,7 +824,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -839,7 +839,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -860,7 +860,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth}
 
 Auth holds configuration for the containerd registry auth. See https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials for more details.
 
@@ -872,7 +872,7 @@ Auth holds configuration for the containerd registry auth. See https://github.co
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-username}
 
 Username is the username for the containerd registry.
 
@@ -887,7 +887,7 @@ Username is the username for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-password}
 
 Password is the password for the containerd registry.
 
@@ -902,7 +902,7 @@ Password is the password for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-identityToken}
+##### `identityToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-identityToken}
 
 IdentityToken is the token for the containerd registry.
 
@@ -917,7 +917,7 @@ IdentityToken is the token for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-auth-auth}
 
 Auth is the auth config for the containerd registry.
 
@@ -938,7 +938,7 @@ Auth is the auth config for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-pauseImage}
+##### `pauseImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-pauseImage}
 
 PauseImage is the image for the pause container.
 
@@ -956,7 +956,7 @@ PauseImage is the image for the pause container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-caCertPath}
+##### `caCertPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-caCertPath}
 
 CACertPath is the path to the SSL certificate authority used to
 secure communications between node and control-plane.
@@ -973,7 +973,7 @@ Defaults to "/etc/kubernetes/pki/ca.crt".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-skipPhases}
+##### `skipPhases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-skipPhases}
 
 SkipPhases is a list of phases to skip during command execution.
 The list of phases can be obtained with the "kubeadm join --help" command.
@@ -989,7 +989,7 @@ The list of phases can be obtained with the "kubeadm join --help" command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration}
+##### `nodeRegistration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration}
 
 NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
 
@@ -1001,7 +1001,7 @@ NodeRegistration holds configuration for the node registration similar to the ku
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-criSocket}
+##### `criSocket` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-criSocket}
 
 CRI socket is the socket for the CRI.
 
@@ -1016,7 +1016,7 @@ CRI socket is the socket for the CRI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs}
+##### `kubeletExtraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs}
 
 KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
 kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
@@ -1032,7 +1032,7 @@ Extra arguments will override existing default arguments. Duplicate extra argume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-name}
 
 Name is the name of the argument.
 
@@ -1047,7 +1047,7 @@ Name is the name of the argument.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-value}
 
 Value is the value of the argument.
 
@@ -1065,7 +1065,7 @@ Value is the value of the argument.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints}
+##### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints}
 
 Taints are additional taints to set for the kubelet.
 
@@ -1077,7 +1077,7 @@ Taints are additional taints to set for the kubelet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -1092,7 +1092,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -1107,7 +1107,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -1127,7 +1127,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-ignorePreflightErrors}
+##### `ignorePreflightErrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-ignorePreflightErrors}
 
 IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
 Value 'all' ignores errors from all checks.
@@ -1143,7 +1143,7 @@ Value 'all' ignores errors from all checks.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-imagePullPolicy}
 
 ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
 The value of this field must be one of "Always", "IfNotPresent" or "Never".
@@ -1169,7 +1169,7 @@ If this field is unset kubeadm will default it to "IfNotPresent", or pull the re
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore}
+### `backingStore` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore}
 
 BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
 
@@ -1181,7 +1181,7 @@ BackingStore defines which backing store to use for virtual cluster. If not defi
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd}
+#### `etcd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd}
 
 Etcd defines that etcd should be used as the backend for the virtual cluster
 
@@ -1193,7 +1193,7 @@ Etcd defines that etcd should be used as the backend for the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded}
+##### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -1205,7 +1205,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -1220,7 +1220,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-migrateFromDeployedEtcd}
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -1235,7 +1235,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-snapshotCount}
+##### `snapshotCount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -1250,7 +1250,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to the embedded etcd.
 
@@ -1268,7 +1268,7 @@ ExtraArgs are additional arguments to pass to the embedded etcd.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy}
+##### `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -1280,7 +1280,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -1295,7 +1295,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet}
+##### `statefulSet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -1307,7 +1307,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -1322,7 +1322,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+##### `enableServiceLinks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -1337,7 +1337,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -1349,7 +1349,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -1365,7 +1365,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -1380,7 +1380,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -1398,7 +1398,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -1413,7 +1413,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-env}
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -1428,7 +1428,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -1443,7 +1443,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -1455,7 +1455,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -1470,7 +1470,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -1488,7 +1488,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods}
+##### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -1500,7 +1500,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1515,7 +1515,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -1533,7 +1533,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability}
+##### `highAvailability` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -1545,7 +1545,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -1563,7 +1563,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling}
+##### `scheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -1575,7 +1575,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -1590,7 +1590,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -1605,7 +1605,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -1620,7 +1620,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -1635,7 +1635,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -1650,7 +1650,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -1668,7 +1668,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security}
+##### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -1680,7 +1680,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -1695,7 +1695,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -1713,7 +1713,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence}
+##### `persistence` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -1725,7 +1725,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -1737,7 +1737,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -1752,7 +1752,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -1767,7 +1767,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -1782,7 +1782,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -1797,7 +1797,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -1815,7 +1815,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -1830,7 +1830,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -1845,7 +1845,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -1857,7 +1857,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -1872,7 +1872,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -1888,7 +1888,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -1904,7 +1904,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -1920,7 +1920,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -1938,7 +1938,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -1962,7 +1962,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1977,7 +1977,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -1995,7 +1995,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -2007,7 +2007,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -2022,7 +2022,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -2040,7 +2040,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService}
+##### `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -2052,7 +2052,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 
@@ -2073,7 +2073,7 @@ Annotations are extra annotations for the external etcd headless service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external}
+##### `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external}
 
 External defines to use a self-hosted external etcd that is not deployed by the helm chart
 
@@ -2085,7 +2085,7 @@ External defines to use a self-hosted external etcd that is not deployed by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-enabled}
 
 Enabled defines if the external etcd should be used.
 
@@ -2100,7 +2100,7 @@ Enabled defines if the external etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-endpoint}
+##### `endpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-endpoint}
 
 Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379
 
@@ -2115,7 +2115,7 @@ Endpoint holds the endpoint of the external etcd server, e.g. my-example-service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls}
+##### `tls` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls}
 
 TLS defines the tls configuration for the external etcd server
 
@@ -2127,7 +2127,7 @@ TLS defines the tls configuration for the external etcd server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-caFile}
 
 CaFile is the path to the ca file
 
@@ -2142,7 +2142,7 @@ CaFile is the path to the ca file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-certFile}
 
 CertFile is the path to the cert file
 
@@ -2157,7 +2157,7 @@ CertFile is the path to the cert file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-keyFile}
 
 KeyFile is the path to the key file
 
@@ -2181,7 +2181,7 @@ KeyFile is the path to the key file
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database}
+#### `database` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database}
 
 Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
 
@@ -2193,7 +2193,7 @@ Database defines that a database backend should be used as the backend for the v
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded}
+##### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -2205,7 +2205,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -2220,7 +2220,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -2238,7 +2238,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-identityProvider}
+##### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -2255,7 +2255,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -2270,7 +2270,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -2285,7 +2285,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -2300,7 +2300,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -2318,7 +2318,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external}
+##### `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -2330,7 +2330,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -2345,7 +2345,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -2363,7 +2363,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-identityProvider}
+##### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -2380,7 +2380,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -2395,7 +2395,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -2410,7 +2410,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -2425,7 +2425,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -2440,7 +2440,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-connector}
+##### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.
@@ -2467,7 +2467,7 @@ This is optional.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns}
+### `coredns` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns}
 
 CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
 
@@ -2479,7 +2479,7 @@ CoreDNS defines everything related to the coredns that is deployed and used with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-coredns-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-coredns-enabled}
 
 Enabled defines if coredns is enabled
 
@@ -2494,7 +2494,7 @@ Enabled defines if coredns is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-coredns-embedded}
+#### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-coredns-embedded}
 
 Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
 
@@ -2509,7 +2509,7 @@ Embedded defines if vCluster will start the embedded coredns service within the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-security}
+#### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-security}
 
 Security defines pod or container security context.
 
@@ -2521,7 +2521,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -2536,7 +2536,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -2554,7 +2554,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-service}
+#### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-service}
 
 Service holds extra options for the coredns service deployed within the virtual cluster
 
@@ -2566,7 +2566,7 @@ Service holds extra options for the coredns service deployed within the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-spec}
+##### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-spec}
 
 Spec holds extra options for the coredns service
 
@@ -2581,7 +2581,7 @@ Spec holds extra options for the coredns service
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2596,7 +2596,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -2614,7 +2614,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment}
+#### `deployment` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment}
 
 Deployment holds extra options for the coredns deployment deployed within the virtual cluster
 
@@ -2626,7 +2626,7 @@ Deployment holds extra options for the coredns deployment deployed within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-image}
 
 Image is the coredns image to use
 
@@ -2641,7 +2641,7 @@ Image is the coredns image to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-replicas}
 
 Replicas is the amount of coredns pods to run.
 
@@ -2656,7 +2656,7 @@ Replicas is the amount of coredns pods to run.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-nodeSelector}
 
 NodeSelector is the node selector to use for coredns.
 
@@ -2671,7 +2671,7 @@ NodeSelector is the node selector to use for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-affinity}
+##### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -2686,7 +2686,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -2701,7 +2701,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources}
 
 Resources are the desired resources for coredns.
 
@@ -2713,7 +2713,7 @@ Resources are the desired resources for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-limits}
 
 Limits are resource limits for the container
 
@@ -2728,7 +2728,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -2746,7 +2746,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods}
+##### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods}
 
 Pods is additional metadata for the coredns pods.
 
@@ -2758,7 +2758,7 @@ Pods is additional metadata for the coredns pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2773,7 +2773,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -2791,7 +2791,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2806,7 +2806,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-labels}
 
 Labels are extra labels for this resource.
 
@@ -2821,7 +2821,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
 
@@ -2839,7 +2839,7 @@ TopologySpreadConstraints are the topology spread constraints for the CoreDNS po
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteConfig}
+#### `overwriteConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteConfig}
 
 OverwriteConfig can be used to overwrite the coredns config
 
@@ -2854,7 +2854,7 @@ OverwriteConfig can be used to overwrite the coredns config
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteManifests}
+#### `overwriteManifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteManifests}
 
 OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
 
@@ -2869,7 +2869,7 @@ OverwriteManifests can be used to overwrite the coredns manifests used to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-priorityClassName}
 
 PriorityClassName specifies the priority class name for the CoreDNS pods.
 
@@ -2887,7 +2887,7 @@ PriorityClassName specifies the priority class name for the CoreDNS pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-proxy}
+### `proxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-proxy}
 
 Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
 
@@ -2899,7 +2899,7 @@ Proxy defines options for the virtual cluster control plane proxy that is used t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#controlPlane-proxy-bindAddress}
+#### `bindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#controlPlane-proxy-bindAddress}
 
 BindAddress under which vCluster will expose the proxy.
 
@@ -2914,7 +2914,7 @@ BindAddress under which vCluster will expose the proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#controlPlane-proxy-port}
+#### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#controlPlane-proxy-port}
 
 Port under which vCluster will expose the proxy. Changing port is currently not supported.
 
@@ -2929,7 +2929,7 @@ Port under which vCluster will expose the proxy. Changing port is currently not 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-proxy-extraSANs}
+#### `extraSANs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-proxy-extraSANs}
 
 ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 
@@ -2947,7 +2947,7 @@ ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper}
+### `hostPathMapper` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper}
 
 HostPathMapper defines if vCluster should rewrite host paths.
 
@@ -2959,7 +2959,7 @@ HostPathMapper defines if vCluster should rewrite host paths.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-enabled}
 
 Enabled specifies if the host path mapper will be used
 
@@ -2974,7 +2974,7 @@ Enabled specifies if the host path mapper will be used
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-central}
+#### `central` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-central}
 
 Central specifies if the central host path mapper will be used
 
@@ -2992,7 +2992,7 @@ Central specifies if the central host path mapper will be used
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-ingress}
+### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-ingress}
 
 Ingress defines options for vCluster ingress deployed by Helm.
 
@@ -3004,7 +3004,7 @@ Ingress defines options for vCluster ingress deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-ingress-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-ingress-enabled}
 
 Enabled defines if the control plane ingress should be enabled
 
@@ -3019,7 +3019,7 @@ Enabled defines if the control plane ingress should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-ingress-host}
+#### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-ingress-host}
 
 Host is the host where vCluster will be reachable
 
@@ -3034,7 +3034,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#controlPlane-ingress-pathType}
+#### `pathType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#controlPlane-ingress-pathType}
 
 PathType is the path type of the ingress
 
@@ -3049,7 +3049,7 @@ PathType is the path type of the ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-spec}
 
 Spec allows you to configure extra ingress options.
 
@@ -3064,7 +3064,7 @@ Spec allows you to configure extra ingress options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3079,7 +3079,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-labels}
 
 Labels are extra labels for this resource.
 
@@ -3097,7 +3097,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `tlsRoute` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute}
+### `tlsRoute` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute}
 
 TLSRoute defines options for vCluster TLS route deployed by Helm.
 
@@ -3109,7 +3109,7 @@ TLSRoute defines options for vCluster TLS route deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-enabled}
 
 Enabled defines if the control plane should be exposed via a gateway api tls route. Make sure to enable tls passthrough in the gateway via tls.mode to "Passthrough"
 
@@ -3124,7 +3124,7 @@ Enabled defines if the control plane should be exposed via a gateway api tls rou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">gateway.networking.k8s.io/v1</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">gateway.networking.k8s.io/v1</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-apiVersion}
 
 APIVersion is the version of the gateway api tls route.
 
@@ -3139,7 +3139,7 @@ APIVersion is the version of the gateway api tls route.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-host}
+#### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-host}
 
 Host is the host where vCluster will be reachable
 
@@ -3154,7 +3154,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `parentRefs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-parentRefs}
+#### `parentRefs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-parentRefs}
 
 ParentRefs are the parent references for the TLS route
 
@@ -3169,7 +3169,7 @@ ParentRefs are the parent references for the TLS route
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-spec}
 
 Spec allows you to configure extra tls route options.
 
@@ -3184,7 +3184,7 @@ Spec allows you to configure extra tls route options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3199,7 +3199,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-labels}
 
 Labels are extra labels for this resource.
 
@@ -3217,7 +3217,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-service}
+### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-service}
 
 Service defines options for vCluster service deployed by Helm.
 
@@ -3229,7 +3229,7 @@ Service defines options for vCluster service deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-service-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-service-enabled}
 
 Enabled defines if the control plane service should be enabled
 
@@ -3244,7 +3244,7 @@ Enabled defines if the control plane service should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-service-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-service-spec}
 
 Spec allows you to configure extra service options.
 
@@ -3259,7 +3259,7 @@ Spec allows you to configure extra service options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-kubeletNodePort}
+#### `kubeletNodePort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-kubeletNodePort}
 
 KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
 
@@ -3274,7 +3274,7 @@ KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-httpsNodePort}
+#### `httpsNodePort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-httpsNodePort}
 
 HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 
@@ -3289,7 +3289,7 @@ HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3304,7 +3304,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -3322,7 +3322,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet}
+### `statefulSet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet}
 
 StatefulSet defines options for vCluster statefulSet deployed by Helm.
 
@@ -3334,7 +3334,7 @@ StatefulSet defines options for vCluster statefulSet deployed by Helm.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability}
+#### `highAvailability` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability}
 
 HighAvailability holds options related to high availability.
 
@@ -3346,7 +3346,7 @@ HighAvailability holds options related to high availability.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-replicas}
 
 Replicas is the amount of replicas to use for the statefulSet.
 
@@ -3361,7 +3361,7 @@ Replicas is the amount of replicas to use for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-leaseDuration}
+##### `leaseDuration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-leaseDuration}
 
 LeaseDuration is the time to lease for the leader.
 
@@ -3376,7 +3376,7 @@ LeaseDuration is the time to lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-renewDeadline}
+##### `renewDeadline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-renewDeadline}
 
 RenewDeadline is the deadline to renew a lease for the leader.
 
@@ -3391,7 +3391,7 @@ RenewDeadline is the deadline to renew a lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-retryPeriod}
+##### `retryPeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-retryPeriod}
 
 RetryPeriod is the time until a replica will retry to get a lease.
 
@@ -3409,7 +3409,7 @@ RetryPeriod is the time until a replica will retry to get a lease.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources}
 
 Resources are the resource requests and limits for the statefulSet container.
 
@@ -3421,7 +3421,7 @@ Resources are the resource requests and limits for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:10Gi memory:4Gi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:10Gi memory:4Gi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -3436,7 +3436,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:1Gi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:1Gi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -3454,7 +3454,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling}
+#### `scheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling}
 
 Scheduling holds options related to scheduling.
 
@@ -3466,7 +3466,7 @@ Scheduling holds options related to scheduling.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -3481,7 +3481,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -3496,7 +3496,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -3511,7 +3511,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -3526,7 +3526,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -3541,7 +3541,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -3559,7 +3559,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security}
+#### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security}
 
 Security defines pod or container security context.
 
@@ -3571,7 +3571,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -3586,7 +3586,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -3604,7 +3604,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes}
+#### `probes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes}
 
 Probes enables or disables the main container probes.
 
@@ -3616,7 +3616,7 @@ Probes enables or disables the main container probes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe}
+##### `livenessProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe}
 
 LivenessProbe specifies if the liveness probe for the container should be enabled
 
@@ -3628,7 +3628,7 @@ LivenessProbe specifies if the liveness probe for the container should be enable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3643,7 +3643,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -3658,7 +3658,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initialDelaySeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-initialDelaySeconds}
+##### `initialDelaySeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-initialDelaySeconds}
 
 Time (in seconds) to wait before starting the liveness probe
 
@@ -3673,7 +3673,7 @@ Time (in seconds) to wait before starting the liveness probe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -3688,7 +3688,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -3706,7 +3706,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe}
+##### `readinessProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe}
 
 ReadinessProbe specifies if the readiness probe for the container should be enabled
 
@@ -3718,7 +3718,7 @@ ReadinessProbe specifies if the readiness probe for the container should be enab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3733,7 +3733,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -3748,7 +3748,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -3763,7 +3763,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -3781,7 +3781,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe}
+##### `startupProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe}
 
 StartupProbe specifies if the startup probe for the container should be enabled
 
@@ -3793,7 +3793,7 @@ StartupProbe specifies if the startup probe for the container should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3808,7 +3808,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-failureThreshold}
 
 Number of consecutive failures allowed before failing the pod
 
@@ -3823,7 +3823,7 @@ Number of consecutive failures allowed before failing the pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -3838,7 +3838,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -3859,7 +3859,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence}
+#### `persistence` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence}
 
 Persistence defines options around persistence for the statefulSet.
 
@@ -3871,7 +3871,7 @@ Persistence defines options around persistence for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -3883,7 +3883,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
 based on the chosen distro and other options if this is required.
@@ -3899,7 +3899,7 @@ based on the chosen distro and other options if this is required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -3914,7 +3914,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -3929,7 +3929,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -3944,7 +3944,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -3962,7 +3962,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -3977,7 +3977,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-dataVolume}
+##### `dataVolume` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-dataVolume}
 
 Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
 
@@ -3992,7 +3992,7 @@ Allows you to override the dataVolume. Only works correctly if volumeClaim.enabl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-binariesVolume}
+##### `binariesVolume` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-binariesVolume}
 
 BinariesVolume defines a binaries volume that is used to retrieve
 distro specific executables to be run by the syncer controller.
@@ -4009,7 +4009,7 @@ This volume doesn't need to be persistent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -4024,7 +4024,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -4036,7 +4036,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -4051,7 +4051,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -4067,7 +4067,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -4083,7 +4083,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -4099,7 +4099,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -4117,7 +4117,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -4141,7 +4141,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-enableServiceLinks}
+#### `enableServiceLinks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -4156,7 +4156,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4171,7 +4171,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -4186,7 +4186,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods}
+#### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods}
 
 Additional labels or annotations for the statefulSet pods.
 
@@ -4198,7 +4198,7 @@ Additional labels or annotations for the statefulSet pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4213,7 +4213,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -4231,7 +4231,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image}
 
 Image is the image for the controlPlane statefulSet container
 It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
@@ -4245,7 +4245,7 @@ If you still want to use the pure OSS build, set the repository to 'loft-sh/vclu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -4261,7 +4261,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -4276,7 +4276,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -4294,7 +4294,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -4309,7 +4309,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-workingDir}
+#### `workingDir` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-workingDir}
 
 WorkingDir specifies in what folder the main process should get started.
 
@@ -4324,7 +4324,7 @@ WorkingDir specifies in what folder the main process should get started.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-command}
+#### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-command}
 
 Command allows you to override the main command.
 
@@ -4339,7 +4339,7 @@ Command allows you to override the main command.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-args}
+#### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-args}
 
 Args allows you to override the main arguments.
 
@@ -4354,7 +4354,7 @@ Args allows you to override the main arguments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-env}
+#### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-env}
 
 Env are additional environment variables for the statefulSet container.
 
@@ -4369,7 +4369,7 @@ Env are additional environment variables for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsPolicy}
+#### `dnsPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsPolicy}
 
 Set DNS policy for the pod.
 
@@ -4384,7 +4384,7 @@ Set DNS policy for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig}
+#### `dnsConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig}
 
 Specifies the DNS parameters of a pod.
 
@@ -4396,7 +4396,7 @@ Specifies the DNS parameters of a pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-nameservers}
+##### `nameservers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-nameservers}
 
 A list of DNS name server IP addresses.
 This will be appended to the base nameservers generated from DNSPolicy.
@@ -4413,7 +4413,7 @@ Duplicated nameservers will be removed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-searches}
+##### `searches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-searches}
 
 A list of DNS search domains for host-name lookup.
 This will be appended to the base search paths generated from DNSPolicy.
@@ -4430,7 +4430,7 @@ Duplicated search paths will be removed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options}
+##### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options}
 
 A list of DNS resolver options.
 This will be merged with the base options generated from DNSPolicy.
@@ -4445,7 +4445,7 @@ will override those that appear in the base DNSPolicy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-name}
 
 Required.
 
@@ -4460,7 +4460,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-value}
 
 
 
@@ -4481,7 +4481,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `initContainers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-initContainers}
+#### `initContainers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-initContainers}
 
 InitContainers are additional init containers for the statefulSet.
 
@@ -4496,7 +4496,7 @@ InitContainers are additional init containers for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `sidecarContainers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-sidecarContainers}
+#### `sidecarContainers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-sidecarContainers}
 
 SidecarContainers are additional sidecar containers for the statefulSet.
 
@@ -4511,7 +4511,7 @@ SidecarContainers are additional sidecar containers for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hostAliases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases}
+#### `hostAliases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases}
 
 HostAliases allows you to add custom entries to the /etc/hosts file of each Pod created.
 
@@ -4523,7 +4523,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases-ip}
+##### `ip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases-ip}
 
 
 
@@ -4538,7 +4538,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostnames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases-hostnames}
+##### `hostnames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-hostAliases-hostnames}
 
 
 
@@ -4556,7 +4556,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-runtimeClassName}
+#### `runtimeClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for the statefulSet pods.
 
@@ -4574,7 +4574,7 @@ RuntimeClassName is the runtime class to set for the statefulSet pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor}
+### `serviceMonitor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor}
 
 ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
 
@@ -4586,7 +4586,7 @@ ServiceMonitor can be used to automatically create a service monitor for vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-enabled}
 
 Enabled configures if Helm should create the service monitor.
 
@@ -4601,7 +4601,7 @@ Enabled configures if Helm should create the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-labels}
 
 Labels are the extra labels to add to the service monitor.
 
@@ -4616,7 +4616,7 @@ Labels are the extra labels to add to the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-annotations}
 
 Annotations are the extra annotations to add to the service monitor.
 
@@ -4634,7 +4634,7 @@ Annotations are the extra annotations to add to the service monitor.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced}
+### `advanced` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced}
 
 Advanced holds additional configuration for the vCluster control plane.
 
@@ -4646,7 +4646,7 @@ Advanced holds additional configuration for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-defaultImageRegistry}
+#### `defaultImageRegistry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
@@ -4662,7 +4662,7 @@ upload all required vCluster images to a single private repository and set this 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler}
+#### `virtualScheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
@@ -4675,7 +4675,7 @@ Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4693,7 +4693,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount}
+#### `serviceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -4705,7 +4705,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -4720,7 +4720,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -4735,7 +4735,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets}
+##### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -4747,7 +4747,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -4765,7 +4765,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4780,7 +4780,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -4798,7 +4798,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount}
+#### `workloadServiceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -4810,7 +4810,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -4825,7 +4825,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -4840,7 +4840,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets}
+##### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -4852,7 +4852,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -4870,7 +4870,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4885,7 +4885,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -4903,7 +4903,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService}
+#### `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -4915,7 +4915,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4930,7 +4930,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-labels}
 
 Labels are extra labels for this resource.
 
@@ -4948,7 +4948,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `konnectivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity}
+#### `konnectivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity}
 
 Konnectivity holds dedicated konnectivity configuration. This is only available when privateNodes.enabled is true.
 
@@ -4960,7 +4960,7 @@ Konnectivity holds dedicated konnectivity configuration. This is only available 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server}
 
 Server holds configuration for the konnectivity server.
 
@@ -4972,7 +4972,7 @@ Server holds configuration for the konnectivity server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-enabled}
 
 Enabled defines if the konnectivity server should be enabled.
 
@@ -4987,7 +4987,7 @@ Enabled defines if the konnectivity server should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity server.
 
@@ -5005,7 +5005,7 @@ ExtraArgs are additional arguments to pass to the konnectivity server.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `agent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent}
+##### `agent` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent}
 
 Agent holds configuration for the konnectivity agent.
 
@@ -5017,7 +5017,7 @@ Agent holds configuration for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-enabled}
 
 Enabled defines if the konnectivity agent should be enabled.
 
@@ -5032,7 +5032,7 @@ Enabled defines if the konnectivity agent should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-replicas}
 
 Replicas is the number of replicas for the konnectivity agent.
 
@@ -5047,7 +5047,7 @@ Replicas is the number of replicas for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-image}
 
 Image is the image for the konnectivity agent.
 
@@ -5062,7 +5062,7 @@ Image is the image for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -5077,7 +5077,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-nodeSelector}
 
 NodeSelector is the node selector for the konnectivity agent.
 
@@ -5092,7 +5092,7 @@ NodeSelector is the node selector for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-priorityClassName}
 
 PriorityClassName is the priority class name for the konnectivity agent.
 
@@ -5107,7 +5107,7 @@ PriorityClassName is the priority class name for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-tolerations}
 
 Tolerations is the tolerations for the konnectivity agent.
 
@@ -5122,7 +5122,7 @@ Tolerations is the tolerations for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraEnv}
 
 ExtraEnv is the extra environment variables for the konnectivity agent.
 
@@ -5137,7 +5137,7 @@ ExtraEnv is the extra environment variables for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity agent.
 
@@ -5158,7 +5158,7 @@ ExtraArgs are additional arguments to pass to the konnectivity agent.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry}
+#### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry}
 
 Registry allows enabling an embedded docker image registry in vCluster. This is useful for air-gapped environments or when you don't have a public registry available to distribute images.
 
@@ -5170,7 +5170,7 @@ Registry allows enabling an embedded docker image registry in vCluster. This is 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-enabled}
 
 Enabled defines if the embedded registry should be enabled.
 
@@ -5185,7 +5185,7 @@ Enabled defines if the embedded registry should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `anonymousPull` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-anonymousPull}
+##### `anonymousPull` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-anonymousPull}
 
 AnonymousPull allows enabling anonymous pull for the embedded registry. This allows anybody to pull images from the registry without authentication.
 
@@ -5200,7 +5200,7 @@ AnonymousPull allows enabling anonymous pull for the embedded registry. This all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-config}
+##### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-config}
 
 Config is the regular docker registry config. See https://distribution.github.io/distribution/about/configuration/ for more details.
 
@@ -5218,7 +5218,7 @@ Config is the regular docker registry config. See https://distribution.github.io
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `cloudControllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-cloudControllerManager}
+#### `cloudControllerManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-cloudControllerManager}
 
 CloudControllerManager holds configuration for the embedded cloud controller manager. This is only available when private nodes are enabled.
 The cloud controller manager is responsible for setting the node's ip addresses as well as the provider id for the node and other node metadata.
@@ -5231,7 +5231,7 @@ The cloud controller manager is responsible for setting the node's ip addresses 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-cloudControllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-cloudControllerManager-enabled}
 
 Enabled defines if the embedded cloud controller manager should be enabled. This defaults to true, but can be disabled if you want to use
 an external cloud controller manager such as AWS or GCP. The cloud controller manager is responsible for setting the node's ip addresses as well
@@ -5251,7 +5251,7 @@ as the provider id for the node and other node metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata}
+#### `globalMetadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -5263,7 +5263,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -5281,7 +5281,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `kubeVip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip}
+#### `kubeVip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip}
 
 KubeVip holds configuration for embedded kube-vip that announces the virtual cluster endpoint IP on layer 2.
 
@@ -5293,7 +5293,7 @@ KubeVip holds configuration for embedded kube-vip that announces the virtual clu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-enabled}
 
 Enabled defines if embedded kube-vip should be enabled.
 
@@ -5308,7 +5308,7 @@ Enabled defines if embedded kube-vip should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `interface` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-interface}
+##### `interface` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-interface}
 
 Interface is the network interface on which the VIP is announced.
 
@@ -5323,7 +5323,7 @@ Interface is the network interface on which the VIP is announced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `gateway` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-gateway}
+##### `gateway` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-kubeVip-gateway}
 
 Gateway is the gateway address in CIDR notation (e.g., 10.100.0.1/24).
 This is used to configure policy-based routing for the VIP and must include the subnet prefix.
@@ -5342,7 +5342,7 @@ This is used to configure policy-based routing for the VIP and must include the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `podDisruptionBudget` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget}
+#### `podDisruptionBudget` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget}
 
 PodDisruptionBudget limits how many pods of an application can be voluntarily disrupted at once
 to ensure availability during maintenance or scaling operations.
@@ -5355,7 +5355,7 @@ to ensure availability during maintenance or scaling operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-enabled}
 
 Enabled defines if the pod disruption budget should be enabled.
 
@@ -5370,7 +5370,7 @@ Enabled defines if the pod disruption budget should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `minAvailable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-minAvailable}
+##### `minAvailable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-minAvailable}
 
 MinAvailable describes the minimal number or percentage of available pods.
 
@@ -5385,7 +5385,7 @@ MinAvailable describes the minimal number or percentage of available pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxUnavailable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-maxUnavailable}
+##### `maxUnavailable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-maxUnavailable}
 
 MaxUnavailable describes the minimal number or percentage of unavailable pods.
 
@@ -5400,7 +5400,7 @@ MaxUnavailable describes the minimal number or percentage of unavailable pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `unhealthyPodEvictionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-unhealthyPodEvictionPolicy}
+##### `unhealthyPodEvictionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-podDisruptionBudget-unhealthyPodEvictionPolicy}
 
 UnhealthyPodEvictionPolicy defines the criteria when unhealthy pods should be considered for eviction.
 Currently supported values are:

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds additional configuration for the vCluster control plane.
 
@@ -14,7 +14,7 @@ Advanced holds additional configuration for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-defaultImageRegistry}
+### `defaultImageRegistry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
@@ -30,7 +30,7 @@ upload all required vCluster images to a single private repository and set this 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-virtualScheduler}
+### `virtualScheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
@@ -43,7 +43,7 @@ Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-virtualScheduler-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -61,7 +61,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -73,7 +73,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -88,7 +88,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -103,7 +103,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -115,7 +115,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -133,7 +133,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -148,7 +148,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -166,7 +166,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount}
+### `workloadServiceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -178,7 +178,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -193,7 +193,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -208,7 +208,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -220,7 +220,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -238,7 +238,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -253,7 +253,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -271,7 +271,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -283,7 +283,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -298,7 +298,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-labels}
 
 Labels are extra labels for this resource.
 
@@ -316,7 +316,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `konnectivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity}
+### `konnectivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity}
 
 Konnectivity holds dedicated konnectivity configuration. This is only available when privateNodes.enabled is true.
 
@@ -328,7 +328,7 @@ Konnectivity holds dedicated konnectivity configuration. This is only available 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-server}
+#### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-server}
 
 Server holds configuration for the konnectivity server.
 
@@ -340,7 +340,7 @@ Server holds configuration for the konnectivity server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-enabled}
 
 Enabled defines if the konnectivity server should be enabled.
 
@@ -355,7 +355,7 @@ Enabled defines if the konnectivity server should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity server.
 
@@ -373,7 +373,7 @@ ExtraArgs are additional arguments to pass to the konnectivity server.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `agent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent}
+#### `agent` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent}
 
 Agent holds configuration for the konnectivity agent.
 
@@ -385,7 +385,7 @@ Agent holds configuration for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-enabled}
 
 Enabled defines if the konnectivity agent should be enabled.
 
@@ -400,7 +400,7 @@ Enabled defines if the konnectivity agent should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-replicas}
 
 Replicas is the number of replicas for the konnectivity agent.
 
@@ -415,7 +415,7 @@ Replicas is the number of replicas for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-image}
 
 Image is the image for the konnectivity agent.
 
@@ -430,7 +430,7 @@ Image is the image for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -445,7 +445,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-nodeSelector}
 
 NodeSelector is the node selector for the konnectivity agent.
 
@@ -460,7 +460,7 @@ NodeSelector is the node selector for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-priorityClassName}
 
 PriorityClassName is the priority class name for the konnectivity agent.
 
@@ -475,7 +475,7 @@ PriorityClassName is the priority class name for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-tolerations}
 
 Tolerations is the tolerations for the konnectivity agent.
 
@@ -490,7 +490,7 @@ Tolerations is the tolerations for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraEnv}
 
 ExtraEnv is the extra environment variables for the konnectivity agent.
 
@@ -505,7 +505,7 @@ ExtraEnv is the extra environment variables for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity agent.
 
@@ -526,7 +526,7 @@ ExtraArgs are additional arguments to pass to the konnectivity agent.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-registry}
+### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-registry}
 
 Registry allows enabling an embedded docker image registry in vCluster. This is useful for air-gapped environments or when you don't have a public registry available to distribute images.
 
@@ -538,7 +538,7 @@ Registry allows enabling an embedded docker image registry in vCluster. This is 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-registry-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-registry-enabled}
 
 Enabled defines if the embedded registry should be enabled.
 
@@ -553,7 +553,7 @@ Enabled defines if the embedded registry should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `anonymousPull` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-registry-anonymousPull}
+#### `anonymousPull` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-registry-anonymousPull}
 
 AnonymousPull allows enabling anonymous pull for the embedded registry. This allows anybody to pull images from the registry without authentication.
 
@@ -568,7 +568,7 @@ AnonymousPull allows enabling anonymous pull for the embedded registry. This all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-registry-config}
+#### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-registry-config}
 
 Config is the regular docker registry config. See https://distribution.github.io/distribution/about/configuration/ for more details.
 
@@ -586,7 +586,7 @@ Config is the regular docker registry config. See https://distribution.github.io
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cloudControllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-cloudControllerManager}
+### `cloudControllerManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-cloudControllerManager}
 
 CloudControllerManager holds configuration for the embedded cloud controller manager. This is only available when private nodes are enabled.
 The cloud controller manager is responsible for setting the node's ip addresses as well as the provider id for the node and other node metadata.
@@ -599,7 +599,7 @@ The cloud controller manager is responsible for setting the node's ip addresses 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-cloudControllerManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-cloudControllerManager-enabled}
 
 Enabled defines if the embedded cloud controller manager should be enabled. This defaults to true, but can be disabled if you want to use
 an external cloud controller manager such as AWS or GCP. The cloud controller manager is responsible for setting the node's ip addresses as well
@@ -619,7 +619,7 @@ as the provider id for the node and other node metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-globalMetadata}
+### `globalMetadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -631,7 +631,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-globalMetadata-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -649,7 +649,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip}
+### `kubeVip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip}
 
 KubeVip holds configuration for embedded kube-vip that announces the virtual cluster endpoint IP on layer 2.
 
@@ -661,7 +661,7 @@ KubeVip holds configuration for embedded kube-vip that announces the virtual clu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-kubeVip-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-kubeVip-enabled}
 
 Enabled defines if embedded kube-vip should be enabled.
 
@@ -676,7 +676,7 @@ Enabled defines if embedded kube-vip should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `interface` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip-interface}
+#### `interface` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip-interface}
 
 Interface is the network interface on which the VIP is announced.
 
@@ -691,7 +691,7 @@ Interface is the network interface on which the VIP is announced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `gateway` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip-gateway}
+#### `gateway` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-kubeVip-gateway}
 
 Gateway is the gateway address in CIDR notation (e.g., 10.100.0.1/24).
 This is used to configure policy-based routing for the VIP and must include the subnet prefix.
@@ -710,7 +710,7 @@ This is used to configure policy-based routing for the VIP and must include the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `podDisruptionBudget` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget}
+### `podDisruptionBudget` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget}
 
 PodDisruptionBudget limits how many pods of an application can be voluntarily disrupted at once
 to ensure availability during maintenance or scaling operations.
@@ -723,7 +723,7 @@ to ensure availability during maintenance or scaling operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-enabled}
 
 Enabled defines if the pod disruption budget should be enabled.
 
@@ -738,7 +738,7 @@ Enabled defines if the pod disruption budget should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `minAvailable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-minAvailable}
+#### `minAvailable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-minAvailable}
 
 MinAvailable describes the minimal number or percentage of available pods.
 
@@ -753,7 +753,7 @@ MinAvailable describes the minimal number or percentage of available pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `maxUnavailable` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-maxUnavailable}
+#### `maxUnavailable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-maxUnavailable}
 
 MaxUnavailable describes the minimal number or percentage of unavailable pods.
 
@@ -768,7 +768,7 @@ MaxUnavailable describes the minimal number or percentage of unavailable pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `unhealthyPodEvictionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-unhealthyPodEvictionPolicy}
+#### `unhealthyPodEvictionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-podDisruptionBudget-unhealthyPodEvictionPolicy}
 
 UnhealthyPodEvictionPolicy defines the criteria when unhealthy pods should be considered for eviction.
 Currently supported values are:

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultImageRegistry}
+## `defaultImageRegistry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/globalMetadata.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/globalMetadata.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#globalMetadata}
+## `globalMetadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -14,7 +14,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#globalMetadata-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/headlessService.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/headlessService.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#headlessService}
+## `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -14,7 +14,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -29,7 +29,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/kubeVip.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/kubeVip.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `kubeVip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip}
+## `kubeVip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip}
 
 KubeVip holds configuration for embedded kube-vip that announces the virtual cluster endpoint IP on layer 2.
 
@@ -14,7 +14,7 @@ KubeVip holds configuration for embedded kube-vip that announces the virtual clu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVip-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVip-enabled}
 
 Enabled defines if embedded kube-vip should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if embedded kube-vip should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `interface` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip-interface}
+### `interface` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip-interface}
 
 Interface is the network interface on which the VIP is announced.
 
@@ -44,7 +44,7 @@ Interface is the network interface on which the VIP is announced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `gateway` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip-gateway}
+### `gateway` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVip-gateway}
 
 Gateway is the gateway address in CIDR notation (e.g., 10.100.0.1/24).
 This is used to configure policy-based routing for the VIP and must include the subnet prefix.

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/serviceAccount.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/serviceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount}
+## `serviceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -14,7 +14,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#serviceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/virtualScheduler.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/virtualScheduler.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualScheduler}
+## `virtualScheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
@@ -15,7 +15,7 @@ Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#virtualScheduler-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount}
+## `workloadServiceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -14,7 +14,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#workloadServiceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/backingStore.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/backingStore.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore}
+## `backingStore` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore}
 
 BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
 
@@ -14,7 +14,7 @@ BackingStore defines which backing store to use for virtual cluster. If not defi
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd}
+### `etcd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd}
 
 Etcd defines that etcd should be used as the backend for the virtual cluster
 
@@ -26,7 +26,7 @@ Etcd defines that etcd should be used as the backend for the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded}
+#### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -38,7 +38,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -53,7 +53,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -68,7 +68,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-snapshotCount}
+##### `snapshotCount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -83,7 +83,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to the embedded etcd.
 
@@ -101,7 +101,7 @@ ExtraArgs are additional arguments to pass to the embedded etcd.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy}
+#### `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -113,7 +113,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -128,7 +128,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet}
+##### `statefulSet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -140,7 +140,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -155,7 +155,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+##### `enableServiceLinks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -170,7 +170,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -182,7 +182,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -198,7 +198,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -213,7 +213,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -231,7 +231,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -246,7 +246,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-env}
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -261,7 +261,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -276,7 +276,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -288,7 +288,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -303,7 +303,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -321,7 +321,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods}
+##### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -333,7 +333,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -348,7 +348,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -366,7 +366,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
+##### `highAvailability` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -378,7 +378,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -396,7 +396,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling}
+##### `scheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -408,7 +408,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -423,7 +423,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -438,7 +438,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -453,7 +453,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -468,7 +468,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -483,7 +483,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -501,7 +501,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security}
+##### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -513,7 +513,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -528,7 +528,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -546,7 +546,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence}
+##### `persistence` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -558,7 +558,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -570,7 +570,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -585,7 +585,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -600,7 +600,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -615,7 +615,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -630,7 +630,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -648,7 +648,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -663,7 +663,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -678,7 +678,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -690,7 +690,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -705,7 +705,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -721,7 +721,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -737,7 +737,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -753,7 +753,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -771,7 +771,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -795,7 +795,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -810,7 +810,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -828,7 +828,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -840,7 +840,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -855,7 +855,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -873,7 +873,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService}
+##### `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -885,7 +885,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 
@@ -906,7 +906,7 @@ Annotations are extra annotations for the external etcd headless service
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external}
+#### `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external}
 
 External defines to use a self-hosted external etcd that is not deployed by the helm chart
 
@@ -918,7 +918,7 @@ External defines to use a self-hosted external etcd that is not deployed by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-external-enabled}
 
 Enabled defines if the external etcd should be used.
 
@@ -933,7 +933,7 @@ Enabled defines if the external etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-endpoint}
+##### `endpoint` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-endpoint}
 
 Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379
 
@@ -948,7 +948,7 @@ Endpoint holds the endpoint of the external etcd server, e.g. my-example-service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls}
+##### `tls` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls}
 
 TLS defines the tls configuration for the external etcd server
 
@@ -960,7 +960,7 @@ TLS defines the tls configuration for the external etcd server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-caFile}
 
 CaFile is the path to the ca file
 
@@ -975,7 +975,7 @@ CaFile is the path to the ca file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-certFile}
 
 CertFile is the path to the cert file
 
@@ -990,7 +990,7 @@ CertFile is the path to the cert file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-keyFile}
 
 KeyFile is the path to the key file
 
@@ -1014,7 +1014,7 @@ KeyFile is the path to the key file
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database}
+### `database` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database}
 
 Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
 
@@ -1026,7 +1026,7 @@ Database defines that a database backend should be used as the backend for the v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded}
+#### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -1038,7 +1038,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1053,7 +1053,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -1071,7 +1071,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-identityProvider}
+##### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -1088,7 +1088,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1103,7 +1103,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1118,7 +1118,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1133,7 +1133,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -1151,7 +1151,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external}
+#### `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -1163,7 +1163,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1178,7 +1178,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -1196,7 +1196,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-identityProvider}
+##### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -1213,7 +1213,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1228,7 +1228,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-certFile}
+##### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1243,7 +1243,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-caFile}
+##### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1258,7 +1258,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-external-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-external-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -1273,7 +1273,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-connector}
+##### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/backingStore/database/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/backingStore/database/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -47,7 +47,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-identityProvider}
+### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -64,7 +64,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -79,7 +79,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-certFile}
+### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -94,7 +94,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-caFile}
+### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -109,7 +109,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/backingStore/database/external.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/backingStore/database/external.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external}
+## `external` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#external-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the external database. Examples:
@@ -47,7 +47,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `identityProvider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-identityProvider}
+### `identityProvider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-identityProvider}
 
 IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
 This is optional for the external database. Examples:
@@ -64,7 +64,7 @@ This is optional for the external database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -79,7 +79,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-certFile}
+### `certFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -94,7 +94,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-caFile}
+### `caFile` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -109,7 +109,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#external-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#external-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -124,7 +124,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-connector}
+### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -14,7 +14,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -29,7 +29,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet}
+### `statefulSet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -41,7 +41,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -56,7 +56,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enableServiceLinks}
+#### `enableServiceLinks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -71,7 +71,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -83,7 +83,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -99,7 +99,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -114,7 +114,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.6.8-0</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -132,7 +132,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -147,7 +147,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-env}
+#### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -162,7 +162,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -177,7 +177,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -189,7 +189,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -204,7 +204,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -222,7 +222,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods}
+#### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -234,7 +234,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -249,7 +249,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -267,7 +267,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability}
+#### `highAvailability` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -279,7 +279,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -297,7 +297,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling}
+#### `scheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -309,7 +309,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -324,7 +324,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -339,7 +339,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -354,7 +354,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -369,7 +369,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -384,7 +384,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -402,7 +402,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-security}
+#### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -414,7 +414,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -429,7 +429,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -447,7 +447,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence}
+#### `persistence` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -459,7 +459,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -471,7 +471,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -486,7 +486,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -501,7 +501,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -516,7 +516,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -531,7 +531,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -549,7 +549,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -564,7 +564,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -579,7 +579,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -591,7 +591,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -606,7 +606,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -622,7 +622,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -638,7 +638,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -654,7 +654,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -672,7 +672,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -696,7 +696,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -711,7 +711,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -729,7 +729,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-service}
+### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -741,7 +741,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-service-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -756,7 +756,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -774,7 +774,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -786,7 +786,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-migrateFromDeployedEtcd}
+### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -44,7 +44,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-snapshotCount}
+### `snapshotCount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -59,7 +59,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to the embedded etcd.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/coredns.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/coredns.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns}
+## `coredns` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns}
 
 CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
 
@@ -14,7 +14,7 @@ CoreDNS defines everything related to the coredns that is deployed and used with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#coredns-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#coredns-enabled}
 
 Enabled defines if coredns is enabled
 
@@ -29,7 +29,7 @@ Enabled defines if coredns is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#coredns-embedded}
+### `embedded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#coredns-embedded}
 
 Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
 
@@ -44,7 +44,7 @@ Embedded defines if vCluster will start the embedded coredns service within the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-security}
+### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-security}
 
 Security defines pod or container security context.
 
@@ -56,7 +56,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -71,7 +71,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -89,7 +89,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-service}
+### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-service}
 
 Service holds extra options for the coredns service deployed within the virtual cluster
 
@@ -101,7 +101,7 @@ Service holds extra options for the coredns service deployed within the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#coredns-service-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#coredns-service-spec}
 
 Spec holds extra options for the coredns service
 
@@ -116,7 +116,7 @@ Spec holds extra options for the coredns service
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -131,7 +131,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -149,7 +149,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment}
+### `deployment` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment}
 
 Deployment holds extra options for the coredns deployment deployed within the virtual cluster
 
@@ -161,7 +161,7 @@ Deployment holds extra options for the coredns deployment deployed within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-image}
 
 Image is the coredns image to use
 
@@ -176,7 +176,7 @@ Image is the coredns image to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#coredns-deployment-replicas}
+#### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#coredns-deployment-replicas}
 
 Replicas is the amount of coredns pods to run.
 
@@ -191,7 +191,7 @@ Replicas is the amount of coredns pods to run.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-nodeSelector}
 
 NodeSelector is the node selector to use for coredns.
 
@@ -206,7 +206,7 @@ NodeSelector is the node selector to use for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-affinity}
+#### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -221,7 +221,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -236,7 +236,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-resources}
 
 Resources are the desired resources for coredns.
 
@@ -248,7 +248,7 @@ Resources are the desired resources for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-limits}
 
 Limits are resource limits for the container
 
@@ -263,7 +263,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -281,7 +281,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-pods}
+#### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-pods}
 
 Pods is additional metadata for the coredns pods.
 
@@ -293,7 +293,7 @@ Pods is additional metadata for the coredns pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -308,7 +308,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -326,7 +326,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -341,7 +341,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-labels}
 
 Labels are extra labels for this resource.
 
@@ -356,7 +356,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
 
@@ -374,7 +374,7 @@ TopologySpreadConstraints are the topology spread constraints for the CoreDNS po
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteConfig}
+### `overwriteConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteConfig}
 
 OverwriteConfig can be used to overwrite the coredns config
 
@@ -389,7 +389,7 @@ OverwriteConfig can be used to overwrite the coredns config
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteManifests}
+### `overwriteManifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteManifests}
 
 OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
 
@@ -404,7 +404,7 @@ OverwriteManifests can be used to overwrite the coredns manifests used to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-priorityClassName}
 
 PriorityClassName specifies the priority class name for the CoreDNS pods.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/distro.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/distro.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro}
+## `distro` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -14,7 +14,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s}
+### `k8s` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -26,7 +26,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -41,7 +41,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-version}
 
 Version is the Kubernetes version to use.
 
@@ -56,7 +56,7 @@ Version is the Kubernetes version to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-apiServer}
+#### `apiServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -68,7 +68,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -83,7 +83,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -98,7 +98,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -116,7 +116,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager}
+#### `controllerManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -128,7 +128,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -143,7 +143,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -158,7 +158,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -176,7 +176,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-scheduler}
+#### `scheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler.
 
@@ -188,7 +188,7 @@ Scheduler holds configuration specific to starting the scheduler.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -203,7 +203,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -218,7 +218,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -236,7 +236,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-image}
 
 Image is the distro image
 
@@ -248,7 +248,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#distro-k8s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#distro-k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -264,7 +264,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#distro-k8s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#distro-k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -279,7 +279,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#distro-k8s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#distro-k8s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -297,7 +297,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -312,7 +312,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-env}
+#### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -327,7 +327,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -342,7 +342,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k8s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/distro/k8s.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/distro/k8s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s}
+## `k8s` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -14,7 +14,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-version}
+### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-version}
 
 Version is the Kubernetes version to use.
 
@@ -44,7 +44,7 @@ Version is the Kubernetes version to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-apiServer}
+### `apiServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -56,7 +56,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-apiServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -71,7 +71,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-command}
+#### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -86,7 +86,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -104,7 +104,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-controllerManager}
+### `controllerManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -116,7 +116,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-controllerManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -131,7 +131,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-command}
+#### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -146,7 +146,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -164,7 +164,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-scheduler}
+### `scheduler` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler.
 
@@ -176,7 +176,7 @@ Scheduler holds configuration specific to starting the scheduler.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-scheduler-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -191,7 +191,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-command}
+#### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -206,7 +206,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -224,7 +224,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-image}
+### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-image}
 
 Image is the distro image
 
@@ -236,7 +236,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#k8s-image-registry}
+#### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -252,7 +252,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#k8s-image-repository}
+#### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -267,7 +267,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#k8s-image-tag}
+#### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">v1.36.0</span> <span className="config-field-enum"></span> {#k8s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -285,7 +285,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -300,7 +300,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-env}
+### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -315,7 +315,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k8s-resources}
+### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k8s-resources}
 
 Resources for the distro init container
 
@@ -330,7 +330,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k8s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k8s-securityContext}
 
 Security options can be used for the distro init container
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/hostPathMapper.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/hostPathMapper.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper}
+## `hostPathMapper` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper}
 
 HostPathMapper defines if vCluster should rewrite host paths.
 
@@ -14,7 +14,7 @@ HostPathMapper defines if vCluster should rewrite host paths.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-enabled}
 
 Enabled specifies if the host path mapper will be used
 
@@ -29,7 +29,7 @@ Enabled specifies if the host path mapper will be used
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-central}
+### `central` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-central}
 
 Central specifies if the central host path mapper will be used
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/ingress.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/ingress.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingress}
+## `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingress}
 
 Ingress defines options for vCluster ingress deployed by Helm.
 
@@ -14,7 +14,7 @@ Ingress defines options for vCluster ingress deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingress-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingress-enabled}
 
 Enabled defines if the control plane ingress should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane ingress should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#ingress-host}
+### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#ingress-host}
 
 Host is the host where vCluster will be reachable
 
@@ -44,7 +44,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#ingress-pathType}
+### `pathType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#ingress-pathType}
 
 PathType is the path type of the ingress
 
@@ -59,7 +59,7 @@ PathType is the path type of the ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#ingress-spec}
+### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#ingress-spec}
 
 Spec allows you to configure extra ingress options.
 
@@ -74,7 +74,7 @@ Spec allows you to configure extra ingress options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#ingress-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#ingress-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#ingress-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#ingress-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/proxy.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/proxy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
+## `proxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
 
 Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
 
@@ -14,7 +14,7 @@ Proxy defines options for the virtual cluster control plane proxy that is used t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#proxy-bindAddress}
+### `bindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#proxy-bindAddress}
 
 BindAddress under which vCluster will expose the proxy.
 
@@ -29,7 +29,7 @@ BindAddress under which vCluster will expose the proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#proxy-port}
+### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#proxy-port}
 
 Port under which vCluster will expose the proxy. Changing port is currently not supported.
 
@@ -44,7 +44,7 @@ Port under which vCluster will expose the proxy. Changing port is currently not 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#proxy-extraSANs}
+### `extraSANs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#proxy-extraSANs}
 
 ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/service.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/service.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#service}
+## `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#service}
 
 Service defines options for vCluster service deployed by Helm.
 
@@ -14,7 +14,7 @@ Service defines options for vCluster service deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#service-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#service-enabled}
 
 Enabled defines if the control plane service should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane service should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#service-spec}
+### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#service-spec}
 
 Spec allows you to configure extra service options.
 
@@ -44,7 +44,7 @@ Spec allows you to configure extra service options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-kubeletNodePort}
+### `kubeletNodePort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-kubeletNodePort}
 
 KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
 
@@ -59,7 +59,7 @@ KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-httpsNodePort}
+### `httpsNodePort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-httpsNodePort}
 
 HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 
@@ -74,7 +74,7 @@ HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/serviceMonitor.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/serviceMonitor.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceMonitor}
+## `serviceMonitor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceMonitor}
 
 ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
 
@@ -14,7 +14,7 @@ ServiceMonitor can be used to automatically create a service monitor for vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceMonitor-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceMonitor-enabled}
 
 Enabled configures if Helm should create the service monitor.
 
@@ -29,7 +29,7 @@ Enabled configures if Helm should create the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-labels}
 
 Labels are the extra labels to add to the service monitor.
 
@@ -44,7 +44,7 @@ Labels are the extra labels to add to the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-annotations}
 
 Annotations are the extra annotations to add to the service monitor.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/standalone.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/standalone.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `standalone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone}
+## `standalone` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone}
 
 Standalone holds configuration for standalone mode. Standalone mode is set automatically when no container is detected and
 also implies privateNodes.enabled.
@@ -15,7 +15,7 @@ also implies privateNodes.enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-enabled}
 
 Enabled defines if standalone mode should be enabled.
 
@@ -30,7 +30,7 @@ Enabled defines if standalone mode should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">/var/lib/vcluster</span> <span className="config-field-enum"></span> {#standalone-dataDir}
+### `dataDir` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">/var/lib/vcluster</span> <span className="config-field-enum"></span> {#standalone-dataDir}
 
 DataDir defines the data directory for the standalone mode.
 
@@ -45,7 +45,7 @@ DataDir defines the data directory for the standalone mode.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes}
+### `autoNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes}
 
 AutoNodes automatically deploys nodes for standalone mode.
 
@@ -57,7 +57,7 @@ AutoNodes automatically deploys nodes for standalone mode.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `provider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-provider}
+#### `provider` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-provider}
 
 Provider is the node provider of the nodes in this pool.
 
@@ -72,7 +72,7 @@ Provider is the node provider of the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `quantity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-quantity}
+#### `quantity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-quantity}
 
 Quantity is the number of nodes to deploy for standalone mode.
 
@@ -87,7 +87,7 @@ Quantity is the number of nodes to deploy for standalone mode.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector}
+#### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -100,7 +100,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -115,7 +115,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -130,7 +130,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -145,7 +145,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-autoNodes-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -166,7 +166,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode}
+### `joinNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode}
 
 JoinNode holds configuration for the standalone control plane node.
 
@@ -178,7 +178,7 @@ JoinNode holds configuration for the standalone control plane node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#standalone-joinNode-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#standalone-joinNode-enabled}
 
 Enabled defines if the standalone node should be joined into the cluster. If false, only the control plane binaries will be executed and no node will show up in the actual cluster.
 
@@ -193,7 +193,7 @@ Enabled defines if the standalone node should be joined into the cluster. If fal
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preInstallCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-preInstallCommands}
+#### `preInstallCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-preInstallCommands}
 
 PreInstallCommands are commands that will be executed before containerd, kubelet etc. is installed.
 
@@ -208,7 +208,7 @@ PreInstallCommands are commands that will be executed before containerd, kubelet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-preJoinCommands}
+#### `preJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-preJoinCommands}
 
 PreJoinCommands are commands that will be executed before kubeadm join is executed.
 
@@ -223,7 +223,7 @@ PreJoinCommands are commands that will be executed before kubeadm join is execut
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-postJoinCommands}
+#### `postJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-postJoinCommands}
 
 PostJoinCommands are commands that will be executed after kubeadm join is executed.
 
@@ -238,7 +238,7 @@ PostJoinCommands are commands that will be executed after kubeadm join is execut
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd}
+#### `containerd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd}
 
 Containerd holds configuration for the containerd join process.
 
@@ -250,7 +250,7 @@ Containerd holds configuration for the containerd join process.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-enabled}
 
 Enabled defines if containerd should be installed and configured by vCluster.
 
@@ -265,7 +265,7 @@ Enabled defines if containerd should be installed and configured by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry}
 
 Registry holds configuration for how containerd should be configured to use a registries.
 
@@ -277,7 +277,7 @@ Registry holds configuration for how containerd should be configured to use a re
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-configPath}
+##### `configPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-configPath}
 
 ConfigPath is the path to the containerd registry config.
 
@@ -292,7 +292,7 @@ ConfigPath is the path to the containerd registry config.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors}
+##### `mirrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors}
 
 Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -304,7 +304,7 @@ Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-server}
 
 Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -319,7 +319,7 @@ Server is the fallback server to use for the containerd registry mirror. E.g. ht
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror.
 
@@ -334,7 +334,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -349,7 +349,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -364,7 +364,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -379,7 +379,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts}
+##### `hosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts}
 
 Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -391,7 +391,7 @@ Hosts holds configuration for the containerd registry mirror hosts. See https://
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-server}
 
 Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
 
@@ -406,7 +406,7 @@ Server is the server to use for the containerd registry mirror host. E.g. http:/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror host.
 
@@ -421,7 +421,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror ho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -436,7 +436,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -451,7 +451,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-mirrors-hosts-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -472,7 +472,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth}
 
 Auth holds configuration for the containerd registry auth. See https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials for more details.
 
@@ -484,7 +484,7 @@ Auth holds configuration for the containerd registry auth. See https://github.co
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-username}
 
 Username is the username for the containerd registry.
 
@@ -499,7 +499,7 @@ Username is the username for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-password}
 
 Password is the password for the containerd registry.
 
@@ -514,7 +514,7 @@ Password is the password for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-identityToken}
+##### `identityToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-identityToken}
 
 IdentityToken is the token for the containerd registry.
 
@@ -529,7 +529,7 @@ IdentityToken is the token for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-registry-auth-auth}
 
 Auth is the auth config for the containerd registry.
 
@@ -550,7 +550,7 @@ Auth is the auth config for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-pauseImage}
+##### `pauseImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-containerd-pauseImage}
 
 PauseImage is the image for the pause container.
 
@@ -568,7 +568,7 @@ PauseImage is the image for the pause container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-caCertPath}
+#### `caCertPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-caCertPath}
 
 CACertPath is the path to the SSL certificate authority used to
 secure communications between node and control-plane.
@@ -585,7 +585,7 @@ Defaults to "/etc/kubernetes/pki/ca.crt".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-skipPhases}
+#### `skipPhases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-skipPhases}
 
 SkipPhases is a list of phases to skip during command execution.
 The list of phases can be obtained with the "kubeadm join --help" command.
@@ -601,7 +601,7 @@ The list of phases can be obtained with the "kubeadm join --help" command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration}
+#### `nodeRegistration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration}
 
 NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
 
@@ -613,7 +613,7 @@ NodeRegistration holds configuration for the node registration similar to the ku
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-criSocket}
+##### `criSocket` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-criSocket}
 
 CRI socket is the socket for the CRI.
 
@@ -628,7 +628,7 @@ CRI socket is the socket for the CRI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs}
+##### `kubeletExtraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs}
 
 KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
 kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
@@ -644,7 +644,7 @@ Extra arguments will override existing default arguments. Duplicate extra argume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs-name}
 
 Name is the name of the argument.
 
@@ -659,7 +659,7 @@ Name is the name of the argument.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-kubeletExtraArgs-value}
 
 Value is the value of the argument.
 
@@ -677,7 +677,7 @@ Value is the value of the argument.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints}
+##### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints}
 
 Taints are additional taints to set for the kubelet.
 
@@ -689,7 +689,7 @@ Taints are additional taints to set for the kubelet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -704,7 +704,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -719,7 +719,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -739,7 +739,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-ignorePreflightErrors}
+##### `ignorePreflightErrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-ignorePreflightErrors}
 
 IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
 Value 'all' ignores errors from all checks.
@@ -755,7 +755,7 @@ Value 'all' ignores errors from all checks.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#standalone-joinNode-nodeRegistration-imagePullPolicy}
 
 ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
 The value of this field must be one of "Always", "IfNotPresent" or "Never".

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/standalone/joinNode.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/standalone/joinNode.mdx
@@ -14,7 +14,7 @@ For production deployments, keep the control-plane node dedicated by setting
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode}
+## `joinNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode}
 
 JoinNode holds configuration for the standalone control plane node.
 
@@ -26,7 +26,7 @@ JoinNode holds configuration for the standalone control plane node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#joinNode-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#joinNode-enabled}
 
 Enabled defines if the standalone node should be joined into the cluster. If false, only the control plane binaries will be executed and no node will show up in the actual cluster.
 
@@ -41,7 +41,7 @@ Enabled defines if the standalone node should be joined into the cluster. If fal
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `preInstallCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-preInstallCommands}
+### `preInstallCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-preInstallCommands}
 
 PreInstallCommands are commands that will be executed before containerd, kubelet etc. is installed.
 
@@ -56,7 +56,7 @@ PreInstallCommands are commands that will be executed before containerd, kubelet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-preJoinCommands}
+### `preJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-preJoinCommands}
 
 PreJoinCommands are commands that will be executed before kubeadm join is executed.
 
@@ -71,7 +71,7 @@ PreJoinCommands are commands that will be executed before kubeadm join is execut
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-postJoinCommands}
+### `postJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-postJoinCommands}
 
 PostJoinCommands are commands that will be executed after kubeadm join is executed.
 
@@ -86,7 +86,7 @@ PostJoinCommands are commands that will be executed after kubeadm join is execut
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd}
+### `containerd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd}
 
 Containerd holds configuration for the containerd join process.
 
@@ -98,7 +98,7 @@ Containerd holds configuration for the containerd join process.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#joinNode-containerd-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#joinNode-containerd-enabled}
 
 Enabled defines if containerd should be installed and configured by vCluster.
 
@@ -113,7 +113,7 @@ Enabled defines if containerd should be installed and configured by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry}
+#### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry}
 
 Registry holds configuration for how containerd should be configured to use a registries.
 
@@ -125,7 +125,7 @@ Registry holds configuration for how containerd should be configured to use a re
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-configPath}
+##### `configPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-configPath}
 
 ConfigPath is the path to the containerd registry config.
 
@@ -140,7 +140,7 @@ ConfigPath is the path to the containerd registry config.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors}
+##### `mirrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors}
 
 Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -152,7 +152,7 @@ Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-server}
 
 Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -167,7 +167,7 @@ Server is the fallback server to use for the containerd registry mirror. E.g. ht
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror.
 
@@ -182,7 +182,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -197,7 +197,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -212,7 +212,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -227,7 +227,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts}
+##### `hosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts}
 
 Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -239,7 +239,7 @@ Hosts holds configuration for the containerd registry mirror hosts. See https://
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-server}
 
 Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
 
@@ -254,7 +254,7 @@ Server is the server to use for the containerd registry mirror host. E.g. http:/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror host.
 
@@ -269,7 +269,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror ho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -284,7 +284,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -299,7 +299,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-mirrors-hosts-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -320,7 +320,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth}
 
 Auth holds configuration for the containerd registry auth. See https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials for more details.
 
@@ -332,7 +332,7 @@ Auth holds configuration for the containerd registry auth. See https://github.co
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-username}
 
 Username is the username for the containerd registry.
 
@@ -347,7 +347,7 @@ Username is the username for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-password}
 
 Password is the password for the containerd registry.
 
@@ -362,7 +362,7 @@ Password is the password for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-identityToken}
+##### `identityToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-identityToken}
 
 IdentityToken is the token for the containerd registry.
 
@@ -377,7 +377,7 @@ IdentityToken is the token for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-registry-auth-auth}
 
 Auth is the auth config for the containerd registry.
 
@@ -398,7 +398,7 @@ Auth is the auth config for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-pauseImage}
+#### `pauseImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-containerd-pauseImage}
 
 PauseImage is the image for the pause container.
 
@@ -416,7 +416,7 @@ PauseImage is the image for the pause container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-caCertPath}
+### `caCertPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-caCertPath}
 
 CACertPath is the path to the SSL certificate authority used to
 secure communications between node and control-plane.
@@ -433,7 +433,7 @@ Defaults to "/etc/kubernetes/pki/ca.crt".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-skipPhases}
+### `skipPhases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-skipPhases}
 
 SkipPhases is a list of phases to skip during command execution.
 The list of phases can be obtained with the "kubeadm join --help" command.
@@ -449,7 +449,7 @@ The list of phases can be obtained with the "kubeadm join --help" command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration}
+### `nodeRegistration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration}
 
 NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
 
@@ -461,7 +461,7 @@ NodeRegistration holds configuration for the node registration similar to the ku
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-criSocket}
+#### `criSocket` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-criSocket}
 
 CRI socket is the socket for the CRI.
 
@@ -476,7 +476,7 @@ CRI socket is the socket for the CRI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs}
+#### `kubeletExtraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs}
 
 KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
 kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
@@ -492,7 +492,7 @@ Extra arguments will override existing default arguments. Duplicate extra argume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs-name}
 
 Name is the name of the argument.
 
@@ -507,7 +507,7 @@ Name is the name of the argument.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-kubeletExtraArgs-value}
 
 Value is the value of the argument.
 
@@ -525,7 +525,7 @@ Value is the value of the argument.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints}
+#### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints}
 
 Taints are additional taints to set for the kubelet.
 
@@ -537,7 +537,7 @@ Taints are additional taints to set for the kubelet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -552,7 +552,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -567,7 +567,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -587,7 +587,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-ignorePreflightErrors}
+#### `ignorePreflightErrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-ignorePreflightErrors}
 
 IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
 Value 'all' ignores errors from all checks.
@@ -603,7 +603,7 @@ Value 'all' ignores errors from all checks.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#joinNode-nodeRegistration-imagePullPolicy}
 
 ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
 The value of this field must be one of "Always", "IfNotPresent" or "Never".

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/statefulSet.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/controlPlane/statefulSet.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet}
+## `statefulSet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet}
 
 StatefulSet defines options for vCluster statefulSet deployed by Helm.
 
@@ -14,7 +14,7 @@ StatefulSet defines options for vCluster statefulSet deployed by Helm.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-highAvailability}
+### `highAvailability` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-highAvailability}
 
 HighAvailability holds options related to high availability.
 
@@ -26,7 +26,7 @@ HighAvailability holds options related to high availability.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-replicas}
+#### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-replicas}
 
 Replicas is the amount of replicas to use for the statefulSet.
 
@@ -41,7 +41,7 @@ Replicas is the amount of replicas to use for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-leaseDuration}
+#### `leaseDuration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-leaseDuration}
 
 LeaseDuration is the time to lease for the leader.
 
@@ -56,7 +56,7 @@ LeaseDuration is the time to lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-renewDeadline}
+#### `renewDeadline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-renewDeadline}
 
 RenewDeadline is the deadline to renew a lease for the leader.
 
@@ -71,7 +71,7 @@ RenewDeadline is the deadline to renew a lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-retryPeriod}
+#### `retryPeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-retryPeriod}
 
 RetryPeriod is the time until a replica will retry to get a lease.
 
@@ -89,7 +89,7 @@ RetryPeriod is the time until a replica will retry to get a lease.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-resources}
+### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-resources}
 
 Resources are the resource requests and limits for the statefulSet container.
 
@@ -101,7 +101,7 @@ Resources are the resource requests and limits for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:10Gi memory:4Gi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-limits}
+#### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:10Gi memory:4Gi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -116,7 +116,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:1Gi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-requests}
+#### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:1Gi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -134,7 +134,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling}
+### `scheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling}
 
 Scheduling holds options related to scheduling.
 
@@ -146,7 +146,7 @@ Scheduling holds options related to scheduling.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -161,7 +161,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-affinity}
+#### `affinity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -176,7 +176,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -191,7 +191,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -206,7 +206,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-podManagementPolicy}
+#### `podManagementPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -221,7 +221,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -239,7 +239,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-security}
+### `security` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-security}
 
 Security defines pod or container security context.
 
@@ -251,7 +251,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-security-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -266,7 +266,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#statefulSet-security-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -284,7 +284,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes}
+### `probes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes}
 
 Probes enables or disables the main container probes.
 
@@ -296,7 +296,7 @@ Probes enables or disables the main container probes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe}
+#### `livenessProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe}
 
 LivenessProbe specifies if the liveness probe for the container should be enabled
 
@@ -308,7 +308,7 @@ LivenessProbe specifies if the liveness probe for the container should be enable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -323,7 +323,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -338,7 +338,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initialDelaySeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-initialDelaySeconds}
+##### `initialDelaySeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-initialDelaySeconds}
 
 Time (in seconds) to wait before starting the liveness probe
 
@@ -353,7 +353,7 @@ Time (in seconds) to wait before starting the liveness probe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -368,7 +368,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -386,7 +386,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe}
+#### `readinessProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe}
 
 ReadinessProbe specifies if the readiness probe for the container should be enabled
 
@@ -398,7 +398,7 @@ ReadinessProbe specifies if the readiness probe for the container should be enab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -413,7 +413,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -428,7 +428,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -443,7 +443,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -461,7 +461,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe}
+#### `startupProbe` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe}
 
 StartupProbe specifies if the startup probe for the container should be enabled
 
@@ -473,7 +473,7 @@ StartupProbe specifies if the startup probe for the container should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -488,7 +488,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-failureThreshold}
 
 Number of consecutive failures allowed before failing the pod
 
@@ -503,7 +503,7 @@ Number of consecutive failures allowed before failing the pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -518,7 +518,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -539,7 +539,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence}
+### `persistence` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence}
 
 Persistence defines options around persistence for the statefulSet.
 
@@ -551,7 +551,7 @@ Persistence defines options around persistence for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim}
+#### `volumeClaim` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -563,7 +563,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
 based on the chosen distro and other options if this is required.
@@ -579,7 +579,7 @@ based on the chosen distro and other options if this is required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -594,7 +594,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -609,7 +609,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -624,7 +624,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -642,7 +642,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaimTemplates}
+#### `volumeClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -657,7 +657,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-dataVolume}
+#### `dataVolume` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-dataVolume}
 
 Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
 
@@ -672,7 +672,7 @@ Allows you to override the dataVolume. Only works correctly if volumeClaim.enabl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-binariesVolume}
+#### `binariesVolume` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-binariesVolume}
 
 BinariesVolume defines a binaries volume that is used to retrieve
 distro specific executables to be run by the syncer controller.
@@ -689,7 +689,7 @@ This volume doesn't need to be persistent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumes}
+#### `addVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -704,7 +704,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts}
+#### `addVolumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -716,7 +716,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -731,7 +731,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -747,7 +747,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -763,7 +763,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -779,7 +779,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -797,7 +797,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -821,7 +821,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-enableServiceLinks}
+### `enableServiceLinks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -836,7 +836,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -851,7 +851,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -866,7 +866,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-pods}
+### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-pods}
 
 Additional labels or annotations for the statefulSet pods.
 
@@ -878,7 +878,7 @@ Additional labels or annotations for the statefulSet pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -893,7 +893,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -911,7 +911,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image}
+### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image}
 
 Image is the image for the controlPlane statefulSet container
 It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
@@ -925,7 +925,7 @@ If you still want to use the pure OSS build, set the repository to 'loft-sh/vclu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#statefulSet-image-registry}
+#### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -941,7 +941,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#statefulSet-image-repository}
+#### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -956,7 +956,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image-tag}
+#### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -974,7 +974,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -989,7 +989,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-workingDir}
+### `workingDir` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-workingDir}
 
 WorkingDir specifies in what folder the main process should get started.
 
@@ -1004,7 +1004,7 @@ WorkingDir specifies in what folder the main process should get started.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-command}
+### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-command}
 
 Command allows you to override the main command.
 
@@ -1019,7 +1019,7 @@ Command allows you to override the main command.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-args}
+### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-args}
 
 Args allows you to override the main arguments.
 
@@ -1034,7 +1034,7 @@ Args allows you to override the main arguments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-env}
+### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-env}
 
 Env are additional environment variables for the statefulSet container.
 
@@ -1049,7 +1049,7 @@ Env are additional environment variables for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsPolicy}
+### `dnsPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsPolicy}
 
 Set DNS policy for the pod.
 
@@ -1064,7 +1064,7 @@ Set DNS policy for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig}
+### `dnsConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig}
 
 Specifies the DNS parameters of a pod.
 
@@ -1076,7 +1076,7 @@ Specifies the DNS parameters of a pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-nameservers}
+#### `nameservers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-nameservers}
 
 A list of DNS name server IP addresses.
 This will be appended to the base nameservers generated from DNSPolicy.
@@ -1093,7 +1093,7 @@ Duplicated nameservers will be removed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-searches}
+#### `searches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-searches}
 
 A list of DNS search domains for host-name lookup.
 This will be appended to the base search paths generated from DNSPolicy.
@@ -1110,7 +1110,7 @@ Duplicated search paths will be removed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options}
+#### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options}
 
 A list of DNS resolver options.
 This will be merged with the base options generated from DNSPolicy.
@@ -1125,7 +1125,7 @@ will override those that appear in the base DNSPolicy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-name}
 
 Required.
 
@@ -1140,7 +1140,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-value}
 
 
 
@@ -1161,7 +1161,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `initContainers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-initContainers}
+### `initContainers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-initContainers}
 
 InitContainers are additional init containers for the statefulSet.
 
@@ -1176,7 +1176,7 @@ InitContainers are additional init containers for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `sidecarContainers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-sidecarContainers}
+### `sidecarContainers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-sidecarContainers}
 
 SidecarContainers are additional sidecar containers for the statefulSet.
 
@@ -1191,7 +1191,7 @@ SidecarContainers are additional sidecar containers for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hostAliases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases}
+### `hostAliases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases}
 
 HostAliases allows you to add custom entries to the /etc/hosts file of each Pod created.
 
@@ -1203,7 +1203,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases-ip}
+#### `ip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases-ip}
 
 
 
@@ -1218,7 +1218,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostnames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases-hostnames}
+#### `hostnames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-hostAliases-hostnames}
 
 
 
@@ -1236,7 +1236,7 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-runtimeClassName}
+### `runtimeClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for the statefulSet pods.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/deletion.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/deletion.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deletion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion}
+## `deletion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion}
 
 Deletion holds configuration for automatic vCluster deletion.
 
@@ -14,7 +14,7 @@ Deletion holds configuration for automatic vCluster deletion.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `prevent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-prevent}
+### `prevent` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-prevent}
 
 Prevent prevents the vCluster from being deleted
 
@@ -29,7 +29,7 @@ Prevent prevents the vCluster from being deleted
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `auto` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-auto}
+### `auto` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-auto}
 
 Auto holds automatic deletion configuration
 
@@ -41,9 +41,9 @@ Auto holds automatic deletion configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-auto-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deletion-auto-afterInactivity}
 
-AfterInactivity specifies after how long of inactivity the tenant cluster will be deleted.
+AfterInactivity specifies after how long of inactivity the virtual cluster will be deleted.
 Uses Go duration format (e.g., "720h" for 30 days).
 
 </summary>

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy holds configuration for the deployment of vCluster.
 
@@ -14,7 +14,7 @@ Deploy holds configuration for the deployment of vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeProxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy}
+### `kubeProxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy}
 
 KubeProxy holds dedicated kube proxy configuration.
 
@@ -26,7 +26,7 @@ KubeProxy holds dedicated kube proxy configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-enabled}
 
 Enabled defines if the kube proxy should be enabled.
 
@@ -41,7 +41,7 @@ Enabled defines if the kube proxy should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-image}
 
 Image is the image for the kube-proxy.
 
@@ -56,7 +56,7 @@ Image is the image for the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -71,7 +71,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-nodeSelector}
 
 NodeSelector is the node selector for the kube-proxy.
 
@@ -86,7 +86,7 @@ NodeSelector is the node selector for the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-kubeProxy-priorityClassName}
 
 PriorityClassName is the priority class name for the kube-proxy.
 
@@ -101,7 +101,7 @@ PriorityClassName is the priority class name for the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-tolerations}
 
 Tolerations is the tolerations for the kube-proxy.
 
@@ -116,7 +116,7 @@ Tolerations is the tolerations for the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-extraEnv}
+#### `extraEnv` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-extraEnv}
 
 ExtraEnv is the extra environment variables for the kube-proxy.
 
@@ -131,7 +131,7 @@ ExtraEnv is the extra environment variables for the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-extraArgs}
 
 ExtraArgs are additional arguments to pass to the kube-proxy.
 
@@ -146,7 +146,7 @@ ExtraArgs are additional arguments to pass to the kube-proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-config}
+#### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-kubeProxy-config}
 
 Config is the config for the kube-proxy that will be merged into the default kube-proxy config. More information can be found here:
 https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration
@@ -165,7 +165,7 @@ https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kube
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metallb` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb}
+### `metallb` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb}
 
 Metallb holds dedicated metallb configuration.
 
@@ -177,7 +177,7 @@ Metallb holds dedicated metallb configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-metallb-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-metallb-enabled}
 
 Enabled defines if metallb should be enabled.
 
@@ -192,7 +192,7 @@ Enabled defines if metallb should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `controllerImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-controllerImage}
+#### `controllerImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-controllerImage}
 
 ControllerImage is the image for metallb controller.
 
@@ -207,7 +207,7 @@ ControllerImage is the image for metallb controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `speakerImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-speakerImage}
+#### `speakerImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-speakerImage}
 
 SpeakerImage is the image for metallb speaker.
 
@@ -222,7 +222,7 @@ SpeakerImage is the image for metallb speaker.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ipAddressPool` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool}
+#### `ipAddressPool` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool}
 
 IPAddressPool is the IP address pool to use for metallb.
 
@@ -234,7 +234,7 @@ IPAddressPool is the IP address pool to use for metallb.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool-addresses}
+##### `addresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool-addresses}
 
 Addresses is a list of IP addresses to use for the IP address pool.
 
@@ -249,7 +249,7 @@ Addresses is a list of IP addresses to use for the IP address pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `l2Advertisement` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool-l2Advertisement}
+##### `l2Advertisement` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-metallb-ipAddressPool-l2Advertisement}
 
 L2Advertisement defines if L2 advertisement should be enabled for the IP address pool.
 
@@ -270,7 +270,7 @@ L2Advertisement defines if L2 advertisement should be enabled for the IP address
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `cni` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni}
+### `cni` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni}
 
 CNI holds dedicated CNI configuration.
 
@@ -282,7 +282,7 @@ CNI holds dedicated CNI configuration.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `flannel` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel}
+#### `flannel` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel}
 
 Flannel holds dedicated Flannel configuration.
 
@@ -294,7 +294,7 @@ Flannel holds dedicated Flannel configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-cni-flannel-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-cni-flannel-enabled}
 
 Enabled defines if Flannel should be enabled.
 
@@ -309,7 +309,7 @@ Enabled defines if Flannel should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-image}
 
 Image is the image for Flannel main container.
 
@@ -324,7 +324,7 @@ Image is the image for Flannel main container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-initImage}
+##### `initImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-initImage}
 
 InitImage is the image for Flannel init container.
 
@@ -339,7 +339,7 @@ InitImage is the image for Flannel init container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-cni-flannel-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -360,7 +360,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `localPathProvisioner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner}
+### `localPathProvisioner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner}
 
 LocalPathProvisioner holds dedicated local path provisioner configuration.
 
@@ -372,7 +372,7 @@ LocalPathProvisioner holds dedicated local path provisioner configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-enabled}
 
 Enabled defines if LocalPathProvisioner should be enabled.
 
@@ -387,7 +387,7 @@ Enabled defines if LocalPathProvisioner should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-image}
 
 Image is the image for local path provisioner.
 
@@ -402,7 +402,7 @@ Image is the image for local path provisioner.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -417,7 +417,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-nodePath}
+#### `nodePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-localPathProvisioner-nodePath}
 
 NodePath is the path on the node where to create the persistent volume directories.
 
@@ -435,7 +435,7 @@ NodePath is the path on the node where to create the persistent volume directori
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingressNginx` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-ingressNginx}
+### `ingressNginx` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-ingressNginx}
 
 IngressNginx holds dedicated ingress-nginx configuration.
 Deprecated: We do not deploy ingress nginx and the project is being deprecated.
@@ -448,7 +448,7 @@ Deprecated: We do not deploy ingress nginx and the project is being deprecated.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-ingressNginx-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-ingressNginx-enabled}
 
 Enabled defines if ingress-nginx should be enabled.
 
@@ -463,7 +463,7 @@ Enabled defines if ingress-nginx should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultIngressClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-ingressNginx-defaultIngressClass}
+#### `defaultIngressClass` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-ingressNginx-defaultIngressClass}
 
 DefaultIngressClass defines if the deployed ingress class should be the default ingress class.
 
@@ -481,7 +481,7 @@ DefaultIngressClass defines if the deployed ingress class should be the default 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metricsServer}
+### `metricsServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-metricsServer}
 
 MetricsServer holds dedicated metrics server configuration.
 
@@ -493,7 +493,7 @@ MetricsServer holds dedicated metrics server configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-metricsServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-metricsServer-enabled}
 
 Enabled defines if metrics server should be enabled.
 
@@ -511,7 +511,7 @@ Enabled defines if metrics server should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotController` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-volumeSnapshotController}
+### `volumeSnapshotController` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-volumeSnapshotController}
 
 VolumeSnapshotController holds dedicated CSI snapshot-controller configuration.
 
@@ -523,7 +523,7 @@ VolumeSnapshotController holds dedicated CSI snapshot-controller configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-volumeSnapshotController-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-volumeSnapshotController-enabled}
 
 Enabled defines if the CSI volumes snapshot-controller should be enabled.
 
@@ -541,7 +541,7 @@ Enabled defines if the CSI volumes snapshot-controller should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `argoCD` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD}
+### `argoCD` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD}
 
 ArgoCD holds dedicated configuration for argoCD Apps to deploy
 
@@ -553,7 +553,7 @@ ArgoCD holds dedicated configuration for argoCD Apps to deploy
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `applications` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications}
+#### `applications` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications}
 
 Applications specifies the applications to deploy. This requires the argo cd integration to be enabled.
 
@@ -565,7 +565,7 @@ Applications specifies the applications to deploy. This requires the argo cd int
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-name}
 
 Name specifies the stable identifier of the argo cd application. It is used to derive generated
 ArgoCDApplication resource names and the final Argo CD application name.
@@ -581,7 +581,7 @@ ArgoCDApplication resource names and the final Argo CD application name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `displayName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-displayName}
+##### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-displayName}
 
 DisplayName specifies the display name of the argo cd application.
 
@@ -596,7 +596,7 @@ DisplayName specifies the display name of the argo cd application.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-target}
+##### `target` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-target}
 
 Target specifies the target of the argo cd application. This can be "vCluster" or "host". Defaults to "vCluster".
 
@@ -611,7 +611,7 @@ Target specifies the target of the argo cd application. This can be "vCluster" o
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `inline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-inline}
+##### `inline` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-inline}
 
 Inline specifies the inline argo cd application definition. This requires the argo cd integration to be enabled.
 
@@ -626,7 +626,7 @@ Inline specifies the inline argo cd application definition. This requires the ar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `template` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template}
+##### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template}
 
 Template specifies the argo cd application template to use. This requires the argo cd integration to be enabled.
 
@@ -638,7 +638,7 @@ Template specifies the argo cd application template to use. This requires the ar
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template-name}
 
 Name specifies the name of the argo cd application template
 
@@ -653,7 +653,7 @@ Name specifies the name of the argo cd application template
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `parameters` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template-parameters}
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-argoCD-applications-template-parameters}
 
 Parameters specifies the parameters to pass to the argo cd application template.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `experimental` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental}
+## `experimental` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental}
 
 Experimental features for vCluster. Configuration here might change, so be careful with this.
 
@@ -14,7 +14,7 @@ Experimental features for vCluster. Configuration here might change, so be caref
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy}
+### `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -26,7 +26,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host}
+#### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -38,7 +38,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifests}
+##### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -53,7 +53,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -71,7 +71,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster}
+#### `vcluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -83,7 +83,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifests}
+##### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -98,7 +98,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -113,7 +113,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm}
+##### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -125,7 +125,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -137,7 +137,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-name}
 
 
 
@@ -152,7 +152,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-repo}
 
 
 
@@ -167,7 +167,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -182,7 +182,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-version}
 
 
 
@@ -197,7 +197,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-username}
 
 
 
@@ -212,7 +212,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-password}
 
 
 
@@ -230,7 +230,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -242,7 +242,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -257,7 +257,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -275,7 +275,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -290,7 +290,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -305,7 +305,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 
@@ -329,7 +329,7 @@ Bundle allows to compress the Helm chart and specify this instead of an online c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings}
+### `syncSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -341,7 +341,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-syncSettings-setOwner}
+#### `setOwner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -356,7 +356,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-hostMetricsBindAddress}
+#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -371,7 +371,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-virtualMetricsBindAddress}
+#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 
@@ -389,7 +389,7 @@ VirtualMetricsBindAddress is the bind address for the virtual manager
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig}
+### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 Deprecated: Removed in 0.29.0.
@@ -402,7 +402,7 @@ Deprecated: Removed in 0.29.0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-kubeConfig}
+#### `kubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -417,7 +417,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCAKey}
+#### `serverCAKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -432,7 +432,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCACert}
+#### `serverCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCACert}
 
 ServerCACert is the server ca cert path.
 
@@ -447,7 +447,7 @@ ServerCACert is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCACert}
+#### `clientCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCACert}
 
 ClientCACert is the client ca cert path.
 
@@ -462,7 +462,7 @@ ClientCACert is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCAKey}
+#### `clientCAKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCAKey}
 
 ClientCAKey is the client ca key path.
 
@@ -477,7 +477,7 @@ ClientCAKey is the client ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
+#### `requestHeaderCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 
@@ -495,7 +495,7 @@ RequestHeaderCACert is the request header ca cert path.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests}
+### `denyProxyRequests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -507,7 +507,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-name}
 
 The name of the check.
 
@@ -522,7 +522,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -539,7 +539,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules}
+#### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -553,7 +553,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -568,7 +568,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiVersions}
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -583,7 +583,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -598,7 +598,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-scope}
+##### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -613,7 +613,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-operations}
+##### `operations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -633,7 +633,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-excludedUsers}
+#### `excludedUsers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.
@@ -652,7 +652,7 @@ Impersonation attempts on these users will still be subjected to the checks.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy}
+### `proxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy}
 
 Proxy enables vCluster-to-vCluster proxying of resources
 
@@ -664,7 +664,7 @@ Proxy enables vCluster-to-vCluster proxying of resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources}
+#### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources}
 
 CustomResources is a map of resource keys (format: "kind.apiGroup/version") to proxy configuration
 
@@ -676,7 +676,7 @@ CustomResources is a map of resource keys (format: "kind.apiGroup/version") to p
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-enabled}
 
 Enabled defines if this resource proxy should be enabled
 
@@ -691,7 +691,7 @@ Enabled defines if this resource proxy should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `targetVirtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster}
+##### `targetVirtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster}
 
 TargetVirtualCluster is the target virtual cluster for the custom resource proxy
 
@@ -703,7 +703,7 @@ TargetVirtualCluster is the target virtual cluster for the custom resource proxy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster-name}
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster-name}
 
 Name is the name of the target virtual cluster.
 
@@ -718,7 +718,7 @@ Name is the name of the target virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-targetVirtualCluster-project}
 
 Project is the project of the target virtual cluster. If empty, defaults to the same project as the source vCluster.
 
@@ -736,7 +736,7 @@ Project is the project of the target virtual cluster. If empty, defaults to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-accessResources}
+##### `accessResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-proxy-customResources-accessResources}
 
 AccessResources defines which resources should be accessible in the proxy.
 
@@ -757,7 +757,7 @@ AccessResources defines which resources should be accessible in the proxy.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `docker` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker}
+### `docker` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker}
 
 Docker allows you to configure Docker related settings when deploying a vCluster using Docker.
 
@@ -769,7 +769,7 @@ Docker allows you to configure Docker related settings when deploying a vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-image}
 
 Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container.
 
@@ -784,7 +784,7 @@ Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-ports}
+#### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-ports}
 
 Ports defines extra port mappings to be added to the container.
 
@@ -799,7 +799,7 @@ Ports defines extra port mappings to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `volumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-volumes}
+#### `volumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-volumes}
 
 Volumes defines extra volumes to be added to the container.
 
@@ -814,7 +814,7 @@ Volumes defines extra volumes to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-env}
+#### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-env}
 
 Env defines extra environment variables to be added to the container. Use key=value.
 
@@ -829,7 +829,7 @@ Env defines extra environment variables to be added to the container. Use key=va
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-args}
+#### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-args}
 
 Args defines extra arguments to be added to the docker run command of the container.
 
@@ -844,7 +844,7 @@ Args defines extra arguments to be added to the docker run command of the contai
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-enabled}
 
 Enabled defines if the vCluster was deployed using Docker. This is automatically set by vCluster and should not be set by the user.
 
@@ -859,7 +859,7 @@ Enabled defines if the vCluster was deployed using Docker. This is automatically
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `network` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-network}
+#### `network` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-network}
 
 Network defines the network to use for the vCluster. If not specified, the a network will be created for the vCluster.
 
@@ -874,7 +874,7 @@ Network defines the network to use for the vCluster. If not specified, the a net
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes}
+#### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes}
 
 Nodes defines the nodes of the vCluster.
 
@@ -886,7 +886,7 @@ Nodes defines the nodes of the vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-image}
 
 Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container.
 
@@ -901,7 +901,7 @@ Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-ports}
 
 Ports defines extra port mappings to be added to the container.
 
@@ -916,7 +916,7 @@ Ports defines extra port mappings to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-volumes}
+##### `volumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-volumes}
 
 Volumes defines extra volumes to be added to the container.
 
@@ -931,7 +931,7 @@ Volumes defines extra volumes to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-env}
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-env}
 
 Env defines extra environment variables to be added to the container. Use key=value.
 
@@ -946,7 +946,7 @@ Env defines extra environment variables to be added to the container. Use key=va
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-args}
+##### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-args}
 
 Args defines extra arguments to be added to the docker run command of the container.
 
@@ -961,7 +961,7 @@ Args defines extra arguments to be added to the docker run command of the contai
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-nodes-name}
 
 Name defines the name of the node. If not specified, a random name will be generated.
 
@@ -979,7 +979,7 @@ Name defines the name of the node. If not specified, a random name will be gener
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `registryProxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-registryProxy}
+#### `registryProxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-registryProxy}
 
 Defines if docker images should be pulled from the host docker daemon. This prevents pulling images again and allows to
 use purely local images. Only works if containerd image storage is used. For more information, see https://docs.docker.com/engine/storage/containerd
@@ -992,7 +992,7 @@ use purely local images. Only works if containerd image storage is used. For mor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-registryProxy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-registryProxy-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1010,7 +1010,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `loadBalancer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer}
+#### `loadBalancer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer}
 
 Defines if vCluster should configure load balancer services inside the vCluster. This might require
 sudo access on the host cluster for docker desktop or rancher desktop on macos.
@@ -1023,7 +1023,7 @@ sudo access on the host cluster for docker desktop or rancher desktop on macos.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1038,7 +1038,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `forwardPorts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer-forwardPorts}
+##### `forwardPorts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-docker-loadBalancer-forwardPorts}
 
 ForwardPorts defines if the load balancer ips should be made available locally
 via port forwarding. This will be only done if necessary for example on macos when using docker desktop.
@@ -1060,7 +1060,7 @@ via port forwarding. This will be only done if necessary for example on macos wh
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodeMonitors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors}
+### `nodeMonitors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors}
 
 NodeMonitors allows you to create a service monitor for each node.
 
@@ -1072,7 +1072,7 @@ NodeMonitors allows you to create a service monitor for each node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-name}
 
 Name is the name of the monitor. It will be suffixed with the node name.
 
@@ -1087,7 +1087,7 @@ Name is the name of the monitor. It will be suffixed with the node name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-nodeSelector}
 
 NodeSelector defines the node selector for the service monitor.
 
@@ -1102,7 +1102,7 @@ NodeSelector defines the node selector for the service monitor.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints}
+#### `endpoints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints}
 
 Endpoints is a list of endpoints to add to the service monitor. By default, vCluster will relabel the node and instance label to the node name.
 
@@ -1114,7 +1114,7 @@ Endpoints is a list of endpoints to add to the service monitor. By default, vClu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-path}
 
 Path is the kubelet path of the endpoint. vCluster will prepend /api/v1/nodes/NODE_NAME to the path.
 
@@ -1129,7 +1129,7 @@ Path is the kubelet path of the endpoint. vCluster will prepend /api/v1/nodes/NO
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `params` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-params}
+##### `params` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-params}
 
 Params allows you to configure extra parameters to add to the endpoint.
 
@@ -1144,7 +1144,7 @@ Params allows you to configure extra parameters to add to the endpoint.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraRelabelings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-extraRelabelings}
+##### `extraRelabelings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-extraRelabelings}
 
 ExtraRelabelings allows you to configure extra relabelings to add to the endpoint. By default, vCluster will relabel the node and instance label to the node name.
 
@@ -1159,7 +1159,7 @@ ExtraRelabelings allows you to configure extra relabelings to add to the endpoin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `metricsRelabelings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-metricsRelabelings}
+##### `metricsRelabelings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-metricsRelabelings}
 
 MetricsRelabelings allows you to configure extra metrics relabelings to add to the endpoint.
 
@@ -1174,7 +1174,7 @@ MetricsRelabelings allows you to configure extra metrics relabelings to add to t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `interval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-interval}
+##### `interval` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-interval}
 
 Interval is the interval at which to scrape the endpoint.
 
@@ -1189,7 +1189,7 @@ Interval is the interval at which to scrape the endpoint.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scrapeTimeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-scrapeTimeout}
+##### `scrapeTimeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-scrapeTimeout}
 
 ScrapeTimeout is the timeout for the scrape of the endpoint.
 
@@ -1207,7 +1207,7 @@ ScrapeTimeout is the timeout for the scrape of the endpoint.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-spec}
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-spec}
 
 Spec allows you to configure extra service monitor options that will be merged into the spec.
 
@@ -1222,7 +1222,7 @@ Spec allows you to configure extra service monitor options that will be merged i
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1237,7 +1237,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/denyProxyRequests.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/denyProxyRequests.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests}
+## `denyProxyRequests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -14,7 +14,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-name}
 
 The name of the check.
 
@@ -29,7 +29,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -46,7 +46,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules}
+### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -60,7 +60,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiGroups}
+#### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -75,7 +75,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiVersions}
+#### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -90,7 +90,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-resources}
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -105,7 +105,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-scope}
+#### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -120,7 +120,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-operations}
+#### `operations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -140,7 +140,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-excludedUsers}
+### `excludedUsers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -14,7 +14,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host}
+### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -26,7 +26,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifests}
+#### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -41,7 +41,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -59,7 +59,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster}
+### `vcluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -71,7 +71,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifests}
+#### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -86,7 +86,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -101,7 +101,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm}
+#### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -113,7 +113,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -125,7 +125,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-name}
 
 
 
@@ -140,7 +140,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-repo}
 
 
 
@@ -155,7 +155,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -170,7 +170,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-version}
 
 
 
@@ -185,7 +185,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-username}
 
 
 
@@ -200,7 +200,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-password}
 
 
 
@@ -218,7 +218,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -230,7 +230,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -245,7 +245,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -263,7 +263,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -278,7 +278,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -293,7 +293,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/docker.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/docker.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `docker` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker}
+## `docker` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker}
 
 Docker allows you to configure Docker related settings when deploying a vCluster using Docker.
 
@@ -14,7 +14,7 @@ Docker allows you to configure Docker related settings when deploying a vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-image}
+### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-image}
 
 Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container.
 
@@ -29,7 +29,7 @@ Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-ports}
+### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-ports}
 
 Ports defines extra port mappings to be added to the container.
 
@@ -44,7 +44,7 @@ Ports defines extra port mappings to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `volumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-volumes}
+### `volumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-volumes}
 
 Volumes defines extra volumes to be added to the container.
 
@@ -59,7 +59,7 @@ Volumes defines extra volumes to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-env}
+### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-env}
 
 Env defines extra environment variables to be added to the container. Use key=value.
 
@@ -74,7 +74,7 @@ Env defines extra environment variables to be added to the container. Use key=va
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-args}
+### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-args}
 
 Args defines extra arguments to be added to the docker run command of the container.
 
@@ -89,7 +89,7 @@ Args defines extra arguments to be added to the docker run command of the contai
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-enabled}
 
 Enabled defines if the vCluster was deployed using Docker. This is automatically set by vCluster and should not be set by the user.
 
@@ -104,7 +104,7 @@ Enabled defines if the vCluster was deployed using Docker. This is automatically
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `network` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-network}
+### `network` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-network}
 
 Network defines the network to use for the vCluster. If not specified, the a network will be created for the vCluster.
 
@@ -119,7 +119,7 @@ Network defines the network to use for the vCluster. If not specified, the a net
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes}
+### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes}
 
 Nodes defines the nodes of the vCluster.
 
@@ -131,7 +131,7 @@ Nodes defines the nodes of the vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-image}
 
 Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container.
 
@@ -146,7 +146,7 @@ Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-ports}
+#### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-ports}
 
 Ports defines extra port mappings to be added to the container.
 
@@ -161,7 +161,7 @@ Ports defines extra port mappings to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `volumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-volumes}
+#### `volumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-volumes}
 
 Volumes defines extra volumes to be added to the container.
 
@@ -176,7 +176,7 @@ Volumes defines extra volumes to be added to the container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-env}
+#### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-env}
 
 Env defines extra environment variables to be added to the container. Use key=value.
 
@@ -191,7 +191,7 @@ Env defines extra environment variables to be added to the container. Use key=va
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-args}
+#### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-args}
 
 Args defines extra arguments to be added to the docker run command of the container.
 
@@ -206,7 +206,7 @@ Args defines extra arguments to be added to the docker run command of the contai
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-nodes-name}
 
 Name defines the name of the node. If not specified, a random name will be generated.
 
@@ -224,7 +224,7 @@ Name defines the name of the node. If not specified, a random name will be gener
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `registryProxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-registryProxy}
+### `registryProxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-registryProxy}
 
 Defines if docker images should be pulled from the host docker daemon. This prevents pulling images again and allows to
 use purely local images. Only works if containerd image storage is used. For more information, see https://docs.docker.com/engine/storage/containerd
@@ -237,7 +237,7 @@ use purely local images. Only works if containerd image storage is used. For mor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-registryProxy-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-registryProxy-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -255,7 +255,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `loadBalancer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-loadBalancer}
+### `loadBalancer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#docker-loadBalancer}
 
 Defines if vCluster should configure load balancer services inside the vCluster. This might require
 sudo access on the host cluster for docker desktop or rancher desktop on macos.
@@ -268,7 +268,7 @@ sudo access on the host cluster for docker desktop or rancher desktop on macos.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-loadBalancer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-loadBalancer-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -283,7 +283,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `forwardPorts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-loadBalancer-forwardPorts}
+#### `forwardPorts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#docker-loadBalancer-forwardPorts}
 
 ForwardPorts defines if the load balancer ips should be made available locally
 via port forwarding. This will be only done if necessary for example on macos when using docker desktop.

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/proxy.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/proxy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
+## `proxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
 
 Proxy enables vCluster-to-vCluster proxying of resources
 
@@ -14,7 +14,7 @@ Proxy enables vCluster-to-vCluster proxying of resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources}
+### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources}
 
 CustomResources is a map of resource keys (format: "kind.apiGroup/version") to proxy configuration
 
@@ -26,7 +26,7 @@ CustomResources is a map of resource keys (format: "kind.apiGroup/version") to p
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-enabled}
 
 Enabled defines if this resource proxy should be enabled
 
@@ -41,7 +41,7 @@ Enabled defines if this resource proxy should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `targetVirtualCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster}
+#### `targetVirtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster}
 
 TargetVirtualCluster is the target virtual cluster for the custom resource proxy
 
@@ -53,7 +53,7 @@ TargetVirtualCluster is the target virtual cluster for the custom resource proxy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster-name}
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster-name}
 
 Name is the name of the target virtual cluster.
 
@@ -68,7 +68,7 @@ Name is the name of the target virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster-project}
+##### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-targetVirtualCluster-project}
 
 Project is the project of the target virtual cluster. If empty, defaults to the same project as the source vCluster.
 
@@ -86,7 +86,7 @@ Project is the project of the target virtual cluster. If empty, defaults to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `accessResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-accessResources}
+#### `accessResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy-customResources-accessResources}
 
 AccessResources defines which resources should be accessible in the proxy.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/syncSettings.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/syncSettings.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings}
+## `syncSettings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -14,7 +14,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#syncSettings-setOwner}
+### `setOwner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -29,7 +29,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-hostMetricsBindAddress}
+### `hostMetricsBindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -44,7 +44,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-virtualMetricsBindAddress}
+### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/virtualClusterKubeConfig.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/experimental/virtualClusterKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig}
+## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 Deprecated: Removed in 0.29.0.
@@ -15,7 +15,7 @@ Deprecated: Removed in 0.29.0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -30,7 +30,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCAKey}
+### `serverCAKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -45,7 +45,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCACert}
+### `serverCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCACert}
 
 ServerCACert is the server ca cert path.
 
@@ -60,7 +60,7 @@ ServerCACert is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCACert}
+### `clientCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCACert}
 
 ClientCACert is the client ca cert path.
 
@@ -75,7 +75,7 @@ ClientCACert is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clientCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCAKey}
+### `clientCAKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCAKey}
 
 ClientCAKey is the client ca key path.
 
@@ -90,7 +90,7 @@ ClientCAKey is the client ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-requestHeaderCACert}
+### `requestHeaderCACert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/exportKubeConfig.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/exportKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `exportKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig}
+## `exportKubeConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig}
 
 ExportKubeConfig describes how vCluster should export the vCluster kubeConfig file.
 
@@ -14,7 +14,7 @@ ExportKubeConfig describes how vCluster should export the vCluster kubeConfig fi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-context}
+### `context` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -29,7 +29,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-server}
+### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -44,7 +44,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#exportKubeConfig-insecure}
+### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#exportKubeConfig-insecure}
 
 If tls should get skipped for the server
 
@@ -59,7 +59,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -71,7 +71,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -86,7 +86,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -102,7 +102,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -120,7 +120,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret}
+### `secret` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret}
 
 Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
 If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
@@ -136,7 +136,7 @@ Deprecated: Use AdditionalSecrets instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-name}
 
 Name is the name of the secret where the kubeconfig should get stored.
 
@@ -151,7 +151,7 @@ Name is the name of the secret where the kubeconfig should get stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-namespace}
 
 Namespace where vCluster should store the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.
@@ -170,7 +170,7 @@ where you deployed vCluster, you need to make sure vCluster has access to this o
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `additionalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets}
+### `additionalSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets}
 
 AdditionalSecrets specifies the additional host cluster secrets in which vCluster will store the
 generated virtual cluster kubeconfigs.
@@ -183,7 +183,7 @@ generated virtual cluster kubeconfigs.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-context}
+#### `context` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -198,7 +198,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-server}
+#### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -213,7 +213,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-insecure}
+#### `insecure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-insecure}
 
 If tls should get skipped for the server
 
@@ -228,7 +228,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount}
+#### `serviceAccount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -240,7 +240,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -255,7 +255,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -271,7 +271,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -289,7 +289,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-name}
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-name}
 
 Name is the name of the secret where the kubeconfig is stored.
 
@@ -304,7 +304,7 @@ Name is the name of the secret where the kubeconfig is stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-namespace}
 
 Namespace where vCluster stores the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `integrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations}
+## `integrations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations}
 
 Integrations holds config for vCluster integrations with other operators or tools running on the host cluster
 
@@ -14,7 +14,7 @@ Integrations holds config for vCluster integrations with other operators or tool
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer}
+### `metricsServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -26,7 +26,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-metricsServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -41,7 +41,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService}
+#### `apiService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -53,7 +53,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -65,7 +65,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -80,7 +80,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -95,7 +95,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -116,7 +116,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-nodes}
+#### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -131,7 +131,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-pods}
+#### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 
@@ -149,7 +149,7 @@ Pods defines if metrics-server pods api should get proxied from host to virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt}
+### `kubeVirt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -161,7 +161,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -176,7 +176,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService}
+#### `apiService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -188,7 +188,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -200,7 +200,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -215,7 +215,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -230,7 +230,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -251,7 +251,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook}
+#### `webhook` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -263,7 +263,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -281,7 +281,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync}
+#### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -293,7 +293,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes}
+##### `dataVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -305,7 +305,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -323,7 +323,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
+##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -335,7 +335,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -353,7 +353,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances}
+##### `virtualMachineInstances` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -365,7 +365,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -383,7 +383,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines}
+##### `virtualMachines` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -395,7 +395,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -413,7 +413,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones}
+##### `virtualMachineClones` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -425,7 +425,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -443,7 +443,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools}
+##### `virtualMachinePools` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -455,7 +455,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -479,7 +479,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets}
+### `externalSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
 - ExternalSecrets will be synced from the virtual cluster to the host cluster.
@@ -494,7 +494,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -509,7 +509,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-version}
+#### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-version}
 
 Version defines the version of the external secrets operator to use. If empty, the storage version will be used.
 
@@ -524,7 +524,7 @@ Version defines the version of the external secrets operator to use. If empty, t
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook}
+#### `webhook` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -536,7 +536,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -554,7 +554,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync}
+#### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -566,7 +566,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost}
 
 ToHost defines what resources are synced from the virtual cluster to the host
 
@@ -578,7 +578,7 @@ ToHost defines what resources are synced from the virtual cluster to the host
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets}
+##### `externalSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets}
 
 ExternalSecrets allows to configure if only a subset of ExternalSecrets matching a label selector should get synced from the virtual cluster to the host cluster.
 
@@ -590,7 +590,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector}
 
 
 
@@ -602,7 +602,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
 
 
 
@@ -617,7 +617,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
 
 
 
@@ -629,22 +629,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
 
 
 
@@ -659,7 +644,22 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
 
 
 
@@ -683,7 +683,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores}
+##### `stores` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 
@@ -695,7 +695,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector}
 
 
 
@@ -707,7 +707,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchLabels}
 
 
 
@@ -722,7 +722,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions}
 
 
 
@@ -734,22 +734,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
 
 
 
@@ -764,7 +749,22 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
 
 
 
@@ -785,7 +785,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -806,7 +806,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost}
+##### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost}
 
 FromHost defines what resources are synced from the host cluster to the virtual cluster
 
@@ -818,7 +818,7 @@ FromHost defines what resources are synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores}
+##### `clusterStores` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
@@ -830,7 +830,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector}
 
 
 
@@ -842,7 +842,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
 
 
 
@@ -857,7 +857,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
 
 
 
@@ -869,22 +869,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
 
 
 
@@ -899,7 +884,22 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
 
 
 
@@ -920,7 +920,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -947,7 +947,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager}
+### `certManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -961,7 +961,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-certManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -976,7 +976,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync}
+#### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -988,7 +988,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost}
 
 
 
@@ -1000,7 +1000,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -1012,7 +1012,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1030,7 +1030,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -1042,7 +1042,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1063,7 +1063,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost}
+##### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost}
 
 
 
@@ -1075,7 +1075,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -1087,7 +1087,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1102,7 +1102,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -1114,7 +1114,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -1144,7 +1144,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio}
+### `istio` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio}
 
 Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
 
@@ -1156,7 +1156,7 @@ Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-istio-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-istio-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1171,7 +1171,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync}
+#### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync}
 
 
 
@@ -1183,7 +1183,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost}
 
 
 
@@ -1195,7 +1195,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules}
+##### `destinationRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules}
 
 
 
@@ -1207,7 +1207,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1225,7 +1225,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways}
+##### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways}
 
 
 
@@ -1237,7 +1237,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1255,7 +1255,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices}
+##### `virtualServices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices}
 
 
 
@@ -1267,7 +1267,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1294,7 +1294,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `netris` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris}
+### `netris` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris}
 
 Netris integration helps configuring netris networking for vCluster.
 
@@ -1306,7 +1306,7 @@ Netris integration helps configuring netris networking for vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-enabled}
 
 Enabled defines if netris integration is enabled
 
@@ -1321,7 +1321,7 @@ Enabled defines if netris integration is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-connector}
+#### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-connector}
 
 Connector specifies the netris connector name
 
@@ -1336,7 +1336,7 @@ Connector specifies the netris connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `kubeVip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip}
+#### `kubeVip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip}
 
 KubeVip holds kube-vip configuration for netris
 
@@ -1348,7 +1348,7 @@ KubeVip holds kube-vip configuration for netris
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `serverCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-serverCluster}
+##### `serverCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-serverCluster}
 
 ServerCluster specifies the server cluster name
 
@@ -1363,7 +1363,7 @@ ServerCluster specifies the server cluster name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bridge` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-bridge}
+##### `bridge` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-bridge}
 
 Bridge specifies the bridge interface name
 
@@ -1378,7 +1378,7 @@ Bridge specifies the bridge interface name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ipRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-ipRange}
+##### `ipRange` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-netris-kubeVip-ipRange}
 
 IPRange specifies the IP range for kube-vip
 
@@ -1399,7 +1399,7 @@ IPRange specifies the IP range for kube-vip
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `argoCD` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD}
+### `argoCD` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD}
 
 ArgoCD integration helps configuring ArgoCD for vCluster.
 
@@ -1411,7 +1411,7 @@ ArgoCD integration helps configuring ArgoCD for vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD-enabled}
 
 Enabled defines if argo cd integration is enabled
 
@@ -1426,7 +1426,7 @@ Enabled defines if argo cd integration is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD-connector}
+#### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-argoCD-connector}
 
 Connector specifies the argo cd connector name
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/certManager.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/certManager.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager}
+## `certManager` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -16,7 +16,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#certManager-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -31,7 +31,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync}
+### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -43,7 +43,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost}
 
 
 
@@ -55,7 +55,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -67,7 +67,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -85,7 +85,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -97,7 +97,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -118,7 +118,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost}
 
 
 
@@ -130,7 +130,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -142,7 +142,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -157,7 +157,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -169,7 +169,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/externalSecrets.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/externalSecrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets}
+## `externalSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
 - ExternalSecrets will be synced from the virtual cluster to the host cluster.
@@ -17,7 +17,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -32,7 +32,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-version}
+### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-version}
 
 Version defines the version of the external secrets operator to use. If empty, the storage version will be used.
 
@@ -47,7 +47,7 @@ Version defines the version of the external secrets operator to use. If empty, t
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-webhook}
+### `webhook` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -59,7 +59,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -77,7 +77,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync}
+### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -89,7 +89,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost}
 
 ToHost defines what resources are synced from the virtual cluster to the host
 
@@ -101,7 +101,7 @@ ToHost defines what resources are synced from the virtual cluster to the host
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets}
+##### `externalSecrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets}
 
 ExternalSecrets allows to configure if only a subset of ExternalSecrets matching a label selector should get synced from the virtual cluster to the host cluster.
 
@@ -113,7 +113,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector}
 
 
 
@@ -125,7 +125,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
 
 
 
@@ -140,7 +140,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
 
 
 
@@ -152,22 +152,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
 
 
 
@@ -182,7 +167,22 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
 
 
 
@@ -206,7 +206,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores}
+##### `stores` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 
@@ -218,7 +218,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector}
 
 
 
@@ -230,7 +230,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchLabels}
 
 
 
@@ -245,7 +245,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions}
 
 
 
@@ -257,22 +257,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
 
 
 
@@ -287,7 +272,22 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
 
 
 
@@ -308,7 +308,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -329,7 +329,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost}
 
 FromHost defines what resources are synced from the host cluster to the virtual cluster
 
@@ -341,7 +341,7 @@ FromHost defines what resources are synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores}
+##### `clusterStores` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
@@ -353,7 +353,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector}
 
 
 
@@ -365,7 +365,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
 
 
 
@@ -380,7 +380,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
 
 
 
@@ -392,22 +392,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
 
 
 
@@ -422,7 +407,22 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
 
 
 
@@ -443,7 +443,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/istio.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/istio.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio}
+## `istio` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio}
 
 Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
 
@@ -14,7 +14,7 @@ Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#istio-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#istio-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync}
+### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync}
 
 
 
@@ -41,7 +41,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost}
 
 
 
@@ -53,7 +53,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules}
+##### `destinationRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules}
 
 
 
@@ -65,37 +65,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules-enabled}
-
-Enabled defines if this option should be enabled.
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -113,7 +83,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices}
+##### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways}
 
 
 
@@ -125,7 +95,37 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualServices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/kubeVirt.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/kubeVirt.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt}
+## `kubeVirt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -14,7 +14,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -29,7 +29,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService}
+### `apiService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service}
+#### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-webhook}
+### `webhook` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -116,7 +116,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -134,7 +134,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync}
+### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -146,7 +146,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes}
+#### `dataVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -158,7 +158,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -176,7 +176,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
+#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -188,7 +188,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -206,7 +206,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances}
+#### `virtualMachineInstances` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -218,7 +218,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -236,7 +236,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines}
+#### `virtualMachines` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -248,7 +248,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -266,7 +266,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones}
+#### `virtualMachineClones` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -278,7 +278,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -296,7 +296,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools}
+#### `virtualMachinePools` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -308,7 +308,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/metricsServer.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/metricsServer.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer}
+## `metricsServer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -14,7 +14,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#metricsServer-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -29,7 +29,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService}
+### `apiService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service}
+#### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-nodes}
+### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -119,7 +119,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-pods}
+### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/netris.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/integrations/netris.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `netris` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris}
+## `netris` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris}
 
 Netris integration helps configuring netris networking for vCluster.
 
@@ -14,7 +14,7 @@ Netris integration helps configuring netris networking for vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-enabled}
 
 Enabled defines if netris integration is enabled
 
@@ -29,7 +29,7 @@ Enabled defines if netris integration is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-connector}
+### `connector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-connector}
 
 Connector specifies the netris connector name
 
@@ -44,7 +44,7 @@ Connector specifies the netris connector name
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip}
+### `kubeVip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip}
 
 KubeVip holds kube-vip configuration for netris
 
@@ -56,7 +56,7 @@ KubeVip holds kube-vip configuration for netris
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-serverCluster}
+#### `serverCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-serverCluster}
 
 ServerCluster specifies the server cluster name
 
@@ -71,7 +71,7 @@ ServerCluster specifies the server cluster name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `bridge` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-bridge}
+#### `bridge` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-bridge}
 
 Bridge specifies the bridge interface name
 
@@ -86,7 +86,7 @@ Bridge specifies the bridge interface name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ipRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-ipRange}
+#### `ipRange` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#netris-kubeVip-ipRange}
 
 IPRange specifies the IP range for kube-vip
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/logging.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/logging.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `logging` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#logging}
+## `logging` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#logging}
 
 Logging provides structured logging options
 
@@ -14,7 +14,7 @@ Logging provides structured logging options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `encoding` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">console</span> <span className="config-field-enum"></span> {#logging-encoding}
+### `encoding` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">console</span> <span className="config-field-enum"></span> {#logging-encoding}
 
 Encoding specifies the format of vCluster logs, it can either be json or console.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/networking.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/networking.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networking` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking}
+## `networking` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking}
 
 Networking options related to the virtual cluster.
 
@@ -14,7 +14,7 @@ Networking options related to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serviceCIDR` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-serviceCIDR}
+### `serviceCIDR` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-serviceCIDR}
 
 ServiceCIDR holds the service cidr for the virtual cluster. This should only be set if privateNodes.enabled is true or vCluster cannot detect the host service cidr.
 
@@ -29,7 +29,7 @@ ServiceCIDR holds the service cidr for the virtual cluster. This should only be 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `podCIDR` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">10.244.0.0/16</span> <span className="config-field-enum"></span> {#networking-podCIDR}
+### `podCIDR` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">10.244.0.0/16</span> <span className="config-field-enum"></span> {#networking-podCIDR}
 
 PodCIDR holds the pod cidr for the virtual cluster. This should only be set if privateNodes.enabled is true.
 
@@ -44,7 +44,7 @@ PodCIDR holds the pod cidr for the virtual cluster. This should only be set if p
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices}
+### `replicateServices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -56,7 +56,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost}
+#### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -70,7 +70,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -85,7 +85,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -103,7 +103,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -115,7 +115,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -130,7 +130,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -151,7 +151,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS}
+### `resolveDNS` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -163,7 +163,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-hostname}
+#### `hostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -178,7 +178,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-service}
+#### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -193,7 +193,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -208,7 +208,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target}
+#### `target` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -220,7 +220,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostname}
+##### `hostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -235,7 +235,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-ip}
+##### `ip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -250,7 +250,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostService}
+##### `hostService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -265,7 +265,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostNamespace}
+##### `hostNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -280,7 +280,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-vClusterService}
+##### `vClusterService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 
@@ -301,7 +301,7 @@ VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterS
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced}
+### `advanced` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced}
 
 Advanced holds advanced network options.
 
@@ -313,7 +313,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#networking-advanced-clusterDomain}
+#### `clusterDomain` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#networking-advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -328,7 +328,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networking-advanced-fallbackHostCluster}
+#### `fallbackHostCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networking-advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -344,7 +344,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets}
+#### `proxyKubelets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -357,7 +357,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byHostname}
+##### `byHostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -373,7 +373,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byIP}
+##### `byIP` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/networking/advanced.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/networking/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds advanced network options.
 
@@ -14,7 +14,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#advanced-clusterDomain}
+### `clusterDomain` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -29,7 +29,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-fallbackHostCluster}
+### `fallbackHostCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -45,7 +45,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-proxyKubelets}
+### `proxyKubelets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -58,7 +58,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byHostname}
+#### `byHostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -74,7 +74,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byIP}
+#### `byIP` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/networking/replicateServices.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/networking/replicateServices.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices}
+## `replicateServices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -14,7 +14,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost}
+### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -28,7 +28,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-from}
+#### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -43,7 +43,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-to}
+#### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -61,7 +61,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -73,7 +73,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-from}
+#### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -88,7 +88,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-to}
+#### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/networking/resolveDNS.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/networking/resolveDNS.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS}
+## `resolveDNS` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -14,7 +14,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-hostname}
+### `hostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -29,7 +29,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-service}
+### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -44,7 +44,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-namespace}
+### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -59,7 +59,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target}
+### `target` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -71,7 +71,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostname}
+#### `hostname` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -86,7 +86,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-ip}
+#### `ip` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -101,7 +101,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostService}
+#### `hostService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -116,7 +116,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostNamespace}
+#### `hostNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -131,7 +131,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-vClusterService}
+#### `vClusterService` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/platform.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/platform.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform}
+## `platform` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform}
 
 Platform holds vCluster Platform specific configuration.
 
@@ -14,7 +14,7 @@ Platform holds vCluster Platform specific configuration.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey}
+### `apiKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey}
 
 APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
 * environment variable called LICENSE
@@ -29,7 +29,7 @@ APIKey defines where to find the platform access key and host. By default, vClus
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-secretName}
+#### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-secretName}
 
 SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.
 
@@ -44,7 +44,7 @@ SecretName is the name of the secret where the platform access key is stored. Th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-namespace}
+#### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-namespace}
 
 Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace
 where the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.
@@ -60,7 +60,7 @@ where the vCluster instance is deployed, you need to make sure vCluster has acce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-createRBAC}
+#### `createRBAC` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-createRBAC}
 
 CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified
 in the above namespace, if specified.
@@ -80,7 +80,7 @@ This defaults to true.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-project}
+### `project` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-project}
 
 Project specifies which platform project the vcluster should be imported to
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/plugins.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/plugins.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `plugins` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins}
+## `plugins` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins}
 
 Define which vCluster plugins to load.
 
@@ -14,7 +14,7 @@ Define which vCluster plugins to load.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-name}
+### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-name}
 
 Name is the name of the init-container and NOT the plugin name
 
@@ -29,7 +29,7 @@ Name is the name of the init-container and NOT the plugin name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-image}
+### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-image}
 
 Image is the container image that should be used for the plugin
 
@@ -44,7 +44,7 @@ Image is the container image that should be used for the plugin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-imagePullPolicy}
 
 ImagePullPolicy is the pull policy to use for the container image
 
@@ -59,7 +59,7 @@ ImagePullPolicy is the pull policy to use for the container image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-config}
+### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-config}
 
 Config is the plugin config to use. This can be arbitrary config used for the plugin.
 
@@ -74,7 +74,7 @@ Config is the plugin config to use. This can be arbitrary config used for the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac}
+### `rbac` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac}
 
 RBAC holds additional rbac configuration for the plugin
 
@@ -86,7 +86,7 @@ RBAC holds additional rbac configuration for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role}
+#### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role}
 
 Role holds extra virtual cluster role permissions for the plugin
 
@@ -98,7 +98,7 @@ Role holds extra virtual cluster role permissions for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -110,7 +110,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -125,7 +125,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -141,7 +141,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -156,7 +156,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -171,7 +171,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -194,7 +194,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole}
 
 ClusterRole holds extra virtual cluster cluster role permissions required for the plugin
 
@@ -206,7 +206,7 @@ ClusterRole holds extra virtual cluster cluster role permissions required for th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -218,7 +218,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -233,7 +233,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -249,7 +249,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -264,7 +264,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -279,7 +279,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -305,7 +305,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-command}
+### `command` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-command}
 
 Command is the command that should be used for the init container
 
@@ -320,7 +320,7 @@ Command is the command that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-args}
+### `args` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-args}
 
 Args are the arguments that should be used for the init container
 
@@ -335,7 +335,7 @@ Args are the arguments that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-securityContext}
 
 SecurityContext is the container security context used for the init container
 
@@ -350,7 +350,7 @@ SecurityContext is the container security context used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-resources}
+### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-resources}
 
 Resources are the container resources used for the init container
 
@@ -365,7 +365,7 @@ Resources are the container resources used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `volumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-volumeMounts}
+### `volumeMounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-volumeMounts}
 
 VolumeMounts are extra volume mounts for the init container
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/policies.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/policies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `policies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies}
+## `policies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies}
 
 Policies to enforce for the virtual cluster deployment as well as within the virtual cluster.
 
@@ -14,7 +14,7 @@ Policies to enforce for the virtual cluster deployment as well as within the vir
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy}
+### `networkPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -26,7 +26,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#policies-networkPolicy-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#policies-networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -41,7 +41,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -56,7 +56,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-labels}
 
 Labels are extra labels for this resource.
 
@@ -71,7 +71,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#policies-networkPolicy-fallbackDns}
+#### `fallbackDns` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#policies-networkPolicy-fallbackDns}
 
 FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server.
 
@@ -86,7 +86,7 @@ FallbackDNS is the fallback DNS server to use if the virtual cluster does not ha
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane}
+#### `controlPlane` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane}
 
 ControlPlane network policy rules
 
@@ -98,7 +98,7 @@ ControlPlane network policy rules
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress}
 
 Ingress rules for the vCluster control plane.
 
@@ -110,7 +110,7 @@ Ingress rules for the vCluster control plane.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports}
 
 ports is a list of ports which should be made accessible on the pods selected for
 this rule. Each item in this list is combined using a logical OR. If this field is
@@ -126,7 +126,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -142,7 +142,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -160,7 +160,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -181,7 +181,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from}
 
 from is a list of sources which should be able to access the pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -197,7 +197,7 @@ allows traffic only if the traffic matches at least one item in the from list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -214,7 +214,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchLabels}
 
 
 
@@ -229,7 +229,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions}
 
 
 
@@ -241,22 +241,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-key}
 
 
 
@@ -271,7 +256,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-values}
 
 
 
@@ -292,7 +292,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -309,7 +309,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchLabels}
 
 
 
@@ -324,7 +324,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions}
 
 
 
@@ -336,22 +336,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-key}
 
 
 
@@ -366,7 +351,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-values}
 
 
 
@@ -387,7 +387,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -400,7 +400,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -416,7 +416,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-ingress-from-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -441,7 +441,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `egress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress}
+##### `egress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress}
 
 Egress rules for the vCluster control plane.
 
@@ -453,7 +453,7 @@ Egress rules for the vCluster control plane.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports}
 
 ports is a list of destination ports for outgoing traffic.
 Each item in this list is combined using a logical OR. If this field is
@@ -469,7 +469,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -485,7 +485,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -503,7 +503,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -524,7 +524,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to}
 
 to is a list of destinations for outgoing traffic of pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -540,7 +540,7 @@ allows traffic only if the traffic matches at least one item in the to list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -557,7 +557,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchLabels}
 
 
 
@@ -572,7 +572,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions}
 
 
 
@@ -584,22 +584,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-key}
 
 
 
@@ -614,7 +599,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-values}
 
 
 
@@ -635,7 +635,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -652,7 +652,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchLabels}
 
 
 
@@ -667,7 +667,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions}
 
 
 
@@ -679,22 +679,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-key}
 
 
 
@@ -709,7 +694,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-values}
 
 
 
@@ -730,7 +730,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -743,7 +743,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -759,7 +759,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-controlPlane-egress-to-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -787,7 +787,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `workload` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload}
+#### `workload` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload}
 
 Workload network policy rules
 
@@ -799,7 +799,7 @@ Workload network policy rules
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `publicEgress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress}
+##### `publicEgress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress}
 
 PublicEgress holds the public outgoing connections options for the vCluster workloads.
 
@@ -811,7 +811,7 @@ PublicEgress holds the public outgoing connections options for the vCluster work
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-enabled}
 
 Enabled defines if the workload public egress should be enabled or disabled.
 
@@ -826,7 +826,7 @@ Enabled defines if the workload public egress should be enabled or disabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -842,7 +842,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-publicEgress-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -861,7 +861,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress}
+##### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress}
 
 Ingress rules for the vCluster workloads.
 
@@ -873,7 +873,7 @@ Ingress rules for the vCluster workloads.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports}
 
 ports is a list of ports which should be made accessible on the pods selected for
 this rule. Each item in this list is combined using a logical OR. If this field is
@@ -889,7 +889,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -905,7 +905,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -923,7 +923,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -944,7 +944,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from}
 
 from is a list of sources which should be able to access the pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -960,7 +960,7 @@ allows traffic only if the traffic matches at least one item in the from list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -977,7 +977,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchLabels}
 
 
 
@@ -992,7 +992,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions}
 
 
 
@@ -1004,22 +1004,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-key}
 
 
 
@@ -1034,7 +1019,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-podSelector-matchExpressions-values}
 
 
 
@@ -1055,7 +1055,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -1072,7 +1072,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchLabels}
 
 
 
@@ -1087,7 +1087,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions}
 
 
 
@@ -1099,22 +1099,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-key}
 
 
 
@@ -1129,7 +1114,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-values}
 
 
 
@@ -1150,7 +1150,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -1163,7 +1163,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -1179,7 +1179,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-ingress-from-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -1204,7 +1204,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `egress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress}
+##### `egress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress}
 
 Egress rules for the vCluster workloads.
 
@@ -1216,7 +1216,7 @@ Egress rules for the vCluster workloads.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports}
 
 ports is a list of destination ports for outgoing traffic.
 Each item in this list is combined using a logical OR. If this field is
@@ -1232,7 +1232,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -1248,7 +1248,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -1266,7 +1266,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -1287,7 +1287,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to}
 
 to is a list of destinations for outgoing traffic of pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -1303,7 +1303,7 @@ allows traffic only if the traffic matches at least one item in the to list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -1320,7 +1320,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchLabels}
 
 
 
@@ -1335,7 +1335,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions}
 
 
 
@@ -1347,22 +1347,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-key}
 
 
 
@@ -1377,7 +1362,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-podSelector-matchExpressions-values}
 
 
 
@@ -1398,7 +1398,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -1415,7 +1415,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchLabels}
 
 
 
@@ -1430,7 +1430,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions}
 
 
 
@@ -1442,22 +1442,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-key}
 
 
 
@@ -1472,7 +1457,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-values}
 
 
 
@@ -1493,7 +1493,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -1506,7 +1506,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -1522,7 +1522,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-workload-egress-to-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -1553,7 +1553,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-podSecurityStandard}
+### `podSecurityStandard` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 
@@ -1568,7 +1568,7 @@ PodSecurityStandard that can be enforced can be one of: empty (""), baseline, re
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-resourceQuota}
+### `resourceQuota` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -1580,7 +1580,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-resourceQuota-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -1596,7 +1596,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-quota}
+#### `quota` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-quota}
 
 Quota are the quota options
 
@@ -1611,7 +1611,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopeSelector}
+#### `scopeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -1626,7 +1626,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopes}
+#### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -1641,7 +1641,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1656,7 +1656,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-labels}
 
 Labels are extra labels for this resource.
 
@@ -1674,7 +1674,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-limitRange}
+### `limitRange` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-limitRange}
 
 LimitRange specifies limit range options.
 
@@ -1686,7 +1686,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-limitRange-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -1702,7 +1702,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-default}
+#### `default` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -1717,7 +1717,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-defaultRequest}
+#### `defaultRequest` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -1732,7 +1732,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-max}
+#### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -1747,7 +1747,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-min}
+#### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -1762,7 +1762,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-annotations}
+#### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1777,7 +1777,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-labels}
 
 Labels are extra labels for this resource.
 
@@ -1795,7 +1795,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission}
+### `centralAdmission` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -1807,7 +1807,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks}
+#### `validatingWebhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -1819,7 +1819,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -1835,7 +1835,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -1852,7 +1852,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -1864,7 +1864,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -1882,7 +1882,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -1899,7 +1899,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -1918,7 +1918,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -1930,7 +1930,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -1948,7 +1948,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -1960,7 +1960,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -1977,7 +1977,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -1992,7 +1992,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -2007,7 +2007,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -2022,7 +2022,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -2038,7 +2038,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -2058,7 +2058,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -2077,7 +2077,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -2093,7 +2093,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -2109,7 +2109,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -2125,7 +2125,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -2144,7 +2144,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -2162,7 +2162,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -2177,7 +2177,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -2192,7 +2192,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -2208,7 +2208,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -2232,7 +2232,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks}
+#### `mutatingWebhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -2244,7 +2244,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -2260,7 +2260,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -2277,7 +2277,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -2289,7 +2289,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -2307,7 +2307,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -2324,7 +2324,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -2343,7 +2343,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -2355,7 +2355,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -2371,7 +2371,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -2389,7 +2389,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -2401,7 +2401,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -2418,7 +2418,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -2433,7 +2433,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -2448,7 +2448,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -2463,7 +2463,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -2479,7 +2479,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -2499,7 +2499,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -2518,7 +2518,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -2534,7 +2534,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -2550,7 +2550,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -2566,7 +2566,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -2585,7 +2585,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -2603,7 +2603,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -2618,7 +2618,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -2633,7 +2633,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -2649,7 +2649,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/policies/centralAdmission.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/policies/centralAdmission.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission}
+## `centralAdmission` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -14,7 +14,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks}
+### `validatingWebhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -26,7 +26,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -42,7 +42,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -59,7 +59,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -71,7 +71,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -89,7 +89,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -106,7 +106,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -125,7 +125,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -137,7 +137,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -155,7 +155,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -167,7 +167,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -184,7 +184,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -199,7 +199,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -214,7 +214,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -229,7 +229,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -245,7 +245,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -265,7 +265,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -284,7 +284,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -300,7 +300,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -316,7 +316,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -332,7 +332,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -351,7 +351,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -369,7 +369,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -384,7 +384,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -399,7 +399,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -415,7 +415,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -439,7 +439,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks}
+### `mutatingWebhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -451,7 +451,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -467,7 +467,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -484,7 +484,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -496,7 +496,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -514,7 +514,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -531,7 +531,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -550,7 +550,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -562,7 +562,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -578,7 +578,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -596,7 +596,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -608,7 +608,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -625,7 +625,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -640,7 +640,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -655,7 +655,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -670,7 +670,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -686,7 +686,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -706,7 +706,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -725,7 +725,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -741,7 +741,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -757,7 +757,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -773,7 +773,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -792,7 +792,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -810,7 +810,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -825,7 +825,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -840,7 +840,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -856,7 +856,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/policies/limitRange.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/policies/limitRange.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#limitRange}
+## `limitRange` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#limitRange}
 
 LimitRange specifies limit range options.
 
@@ -14,7 +14,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#limitRange-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -30,7 +30,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-default}
+### `default` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -45,7 +45,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-defaultRequest}
+### `defaultRequest` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -60,7 +60,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-max}
+### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -75,7 +75,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-min}
+### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -90,7 +90,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -105,7 +105,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/policies/networkPolicy.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/policies/networkPolicy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy}
+## `networkPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -14,7 +14,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicy-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -29,7 +29,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -44,7 +44,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-labels}
 
 Labels are extra labels for this resource.
 
@@ -59,7 +59,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#networkPolicy-fallbackDns}
+### `fallbackDns` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#networkPolicy-fallbackDns}
 
 FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server.
 
@@ -74,7 +74,7 @@ FallbackDNS is the fallback DNS server to use if the virtual cluster does not ha
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane}
+### `controlPlane` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane}
 
 ControlPlane network policy rules
 
@@ -86,7 +86,7 @@ ControlPlane network policy rules
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress}
+#### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress}
 
 Ingress rules for the vCluster control plane.
 
@@ -98,7 +98,7 @@ Ingress rules for the vCluster control plane.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports}
 
 ports is a list of ports which should be made accessible on the pods selected for
 this rule. Each item in this list is combined using a logical OR. If this field is
@@ -114,7 +114,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -130,7 +130,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -148,7 +148,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -169,7 +169,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from}
 
 from is a list of sources which should be able to access the pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -185,7 +185,7 @@ allows traffic only if the traffic matches at least one item in the from list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -202,7 +202,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchLabels}
 
 
 
@@ -217,7 +217,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions}
 
 
 
@@ -229,22 +229,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-key}
 
 
 
@@ -259,7 +244,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-podSelector-matchExpressions-values}
 
 
 
@@ -280,7 +280,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -297,7 +297,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchLabels}
 
 
 
@@ -312,7 +312,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions}
 
 
 
@@ -324,22 +324,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-key}
 
 
 
@@ -354,7 +339,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-namespaceSelector-matchExpressions-values}
 
 
 
@@ -375,7 +375,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -388,7 +388,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -404,7 +404,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-ingress-from-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -429,7 +429,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `egress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress}
+#### `egress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress}
 
 Egress rules for the vCluster control plane.
 
@@ -441,7 +441,7 @@ Egress rules for the vCluster control plane.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports}
 
 ports is a list of destination ports for outgoing traffic.
 Each item in this list is combined using a logical OR. If this field is
@@ -457,7 +457,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -473,7 +473,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -491,7 +491,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -512,7 +512,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to}
 
 to is a list of destinations for outgoing traffic of pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -528,7 +528,7 @@ allows traffic only if the traffic matches at least one item in the to list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -545,7 +545,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchLabels}
 
 
 
@@ -560,7 +560,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions}
 
 
 
@@ -572,22 +572,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-key}
 
 
 
@@ -602,7 +587,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-podSelector-matchExpressions-values}
 
 
 
@@ -623,7 +623,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -640,7 +640,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchLabels}
 
 
 
@@ -655,7 +655,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions}
 
 
 
@@ -667,22 +667,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-key}
 
 
 
@@ -697,7 +682,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-namespaceSelector-matchExpressions-values}
 
 
 
@@ -718,7 +718,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -731,7 +731,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -747,7 +747,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-controlPlane-egress-to-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -775,7 +775,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `workload` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload}
+### `workload` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload}
 
 Workload network policy rules
 
@@ -787,7 +787,7 @@ Workload network policy rules
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `publicEgress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress}
+#### `publicEgress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress}
 
 PublicEgress holds the public outgoing connections options for the vCluster workloads.
 
@@ -799,7 +799,7 @@ PublicEgress holds the public outgoing connections options for the vCluster work
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-enabled}
 
 Enabled defines if the workload public egress should be enabled or disabled.
 
@@ -814,7 +814,7 @@ Enabled defines if the workload public egress should be enabled or disabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -830,7 +830,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-workload-publicEgress-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -849,7 +849,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress}
+#### `ingress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress}
 
 Ingress rules for the vCluster workloads.
 
@@ -861,7 +861,7 @@ Ingress rules for the vCluster workloads.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports}
 
 ports is a list of ports which should be made accessible on the pods selected for
 this rule. Each item in this list is combined using a logical OR. If this field is
@@ -877,7 +877,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -893,7 +893,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -911,7 +911,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -932,7 +932,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from}
 
 from is a list of sources which should be able to access the pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -948,7 +948,7 @@ allows traffic only if the traffic matches at least one item in the from list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -965,7 +965,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchLabels}
 
 
 
@@ -980,7 +980,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions}
 
 
 
@@ -992,22 +992,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-key}
 
 
 
@@ -1022,7 +1007,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-podSelector-matchExpressions-values}
 
 
 
@@ -1043,7 +1043,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -1060,7 +1060,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchLabels}
 
 
 
@@ -1075,7 +1075,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions}
 
 
 
@@ -1087,22 +1087,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-key}
 
 
 
@@ -1117,7 +1102,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-namespaceSelector-matchExpressions-values}
 
 
 
@@ -1138,7 +1138,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -1151,7 +1151,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -1167,7 +1167,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-ingress-from-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".
@@ -1192,7 +1192,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64".
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `egress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress}
+#### `egress` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress}
 
 Egress rules for the vCluster workloads.
 
@@ -1204,7 +1204,7 @@ Egress rules for the vCluster workloads.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ports` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports}
+##### `ports` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports}
 
 ports is a list of destination ports for outgoing traffic.
 Each item in this list is combined using a logical OR. If this field is
@@ -1220,7 +1220,7 @@ traffic only if the traffic matches at least one port in the list.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `protocol` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-protocol}
+##### `protocol` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-protocol}
 
 protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
 If not specified, this field defaults to TCP.
@@ -1236,7 +1236,7 @@ If not specified, this field defaults to TCP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-port}
 
 port represents the port on the given protocol. This can either be a numerical or named
 port on a pod. If this field is not provided, this matches all port names and
@@ -1254,7 +1254,7 @@ If present, only traffic on the specified protocol AND port will be matched.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endPort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-endPort}
+##### `endPort` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-ports-endPort}
 
 endPort indicates that the range of ports from port to endPort if set, inclusive,
 should be allowed by the policy. This field cannot be defined if the port field
@@ -1275,7 +1275,7 @@ The endPort must be equal or greater than port.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to}
+##### `to` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to}
 
 to is a list of destinations for outgoing traffic of pods selected for this rule.
 Items in this list are combined using a logical OR operation. If this field is
@@ -1291,7 +1291,7 @@ allows traffic only if the traffic matches at least one item in the to list.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `podSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector}
+##### `podSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector}
 
 podSelector is a label selector which selects pods. This field follows standard label
 selector semantics; if present but empty, it selects all pods.
@@ -1308,7 +1308,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchLabels}
 
 
 
@@ -1323,7 +1323,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions}
 
 
 
@@ -1335,22 +1335,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-key}
 
 
 
@@ -1365,7 +1350,22 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-podSelector-matchExpressions-values}
 
 
 
@@ -1386,7 +1386,7 @@ Otherwise it selects the pods matching podSelector in the policy's own namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector}
 
 namespaceSelector selects namespaces using cluster-scoped labels. This field follows
 standard label selector semantics; if present but empty, it selects all namespaces.
@@ -1403,7 +1403,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchLabels}
 
 
 
@@ -1418,7 +1418,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions}
 
 
 
@@ -1430,22 +1430,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-key}
 
 
 
@@ -1460,7 +1445,22 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-namespaceSelector-matchExpressions-values}
 
 
 
@@ -1481,7 +1481,7 @@ Otherwise it selects all pods in the namespaces selected by namespaceSelector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock}
 
 ipBlock defines policy on a particular IPBlock. If this field is set then
 neither of the other fields can be.
@@ -1494,7 +1494,7 @@ neither of the other fields can be.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock-cidr}
 
 CIDR defines the allowed workload public egress destination.
 Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
@@ -1510,7 +1510,7 @@ Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-workload-egress-to-ipBlock-except}
 
 Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
 Valid examples are "192.168.1.0/24" or "2001:db8::/64".

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/policies/podSecurityStandard.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/policies/podSecurityStandard.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podSecurityStandard}
+## `podSecurityStandard` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/policies/resourceQuota.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/policies/resourceQuota.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resourceQuota}
+## `resourceQuota` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -14,7 +14,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#resourceQuota-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -30,7 +30,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-quota}
+### `quota` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-quota}
 
 Quota are the quota options
 
@@ -45,7 +45,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopeSelector}
+### `scopeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -60,7 +60,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopes}
+### `scopes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -75,7 +75,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-annotations}
+### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -90,7 +90,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-labels}
+### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/privateNodes.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/privateNodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `privateNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes}
+## `privateNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes}
 
 PrivateNodes holds configuration for vCluster private nodes mode.
 
@@ -14,7 +14,7 @@ PrivateNodes holds configuration for vCluster private nodes mode.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-enabled}
 
 Enabled defines if dedicated nodes should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if dedicated nodes should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubelet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-kubelet}
+### `kubelet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-kubelet}
 
 Kubelet holds kubelet configuration that is used for all nodes.
 
@@ -41,7 +41,7 @@ Kubelet holds kubelet configuration that is used for all nodes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-kubelet-config}
+#### `config` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-kubelet-config}
 
 Config is the config for the kubelet that will be merged into the default kubelet config. More information can be found here:
 https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
@@ -60,7 +60,7 @@ https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoUpgrade` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade}
+### `autoUpgrade` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade}
 
 AutoUpgrade holds configuration for auto upgrade.
 
@@ -72,7 +72,7 @@ AutoUpgrade holds configuration for auto upgrade.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-enabled}
 
 Enabled defines if auto upgrade should be enabled.
 
@@ -87,7 +87,7 @@ Enabled defines if auto upgrade should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-image}
+#### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-image}
 
 Image is the image for the auto upgrade pod started by vCluster. If empty defaults to the controlPlane.statefulSet.image.
 
@@ -102,7 +102,7 @@ Image is the image for the auto upgrade pod started by vCluster. If empty defaul
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -117,7 +117,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-nodeSelector}
 
 NodeSelector is the node selector for the auto upgrade. If empty will select all worker nodes.
 
@@ -132,7 +132,7 @@ NodeSelector is the node selector for the auto upgrade. If empty will select all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `binariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-binariesPath}
+#### `binariesPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-binariesPath}
 
 BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/bin
 
@@ -147,7 +147,7 @@ BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `cniBinariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-cniBinariesPath}
+#### `cniBinariesPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-cniBinariesPath}
 
 CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 
@@ -162,7 +162,7 @@ CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `concurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-concurrency}
+#### `concurrency` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-concurrency}
 
 Concurrency is the number of nodes that can be upgraded at the same time.
 
@@ -177,7 +177,7 @@ Concurrency is the number of nodes that can be upgraded at the same time.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level for the upgrade pod.
 
@@ -192,7 +192,7 @@ PodSecurityContext specifies security context options on the pod level for the u
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level for the upgrade container.
 
@@ -210,7 +210,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode}
+### `joinNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode}
 
 JoinNode holds configuration specifically used during joining the node (see "kubeadm join").
 
@@ -222,7 +222,7 @@ JoinNode holds configuration specifically used during joining the node (see "kub
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preInstallCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-preInstallCommands}
+#### `preInstallCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-preInstallCommands}
 
 PreInstallCommands are commands that will be executed before containerd, kubelet etc. is installed.
 
@@ -237,7 +237,7 @@ PreInstallCommands are commands that will be executed before containerd, kubelet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-preJoinCommands}
+#### `preJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-preJoinCommands}
 
 PreJoinCommands are commands that will be executed before kubeadm join is executed.
 
@@ -252,7 +252,7 @@ PreJoinCommands are commands that will be executed before kubeadm join is execut
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-postJoinCommands}
+#### `postJoinCommands` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-postJoinCommands}
 
 PostJoinCommands are commands that will be executed after kubeadm join is executed.
 
@@ -267,7 +267,7 @@ PostJoinCommands are commands that will be executed after kubeadm join is execut
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd}
+#### `containerd` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd}
 
 Containerd holds configuration for the containerd join process.
 
@@ -279,7 +279,7 @@ Containerd holds configuration for the containerd join process.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-enabled}
 
 Enabled defines if containerd should be installed and configured by vCluster.
 
@@ -294,7 +294,7 @@ Enabled defines if containerd should be installed and configured by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry}
 
 Registry holds configuration for how containerd should be configured to use a registries.
 
@@ -306,7 +306,7 @@ Registry holds configuration for how containerd should be configured to use a re
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-configPath}
+##### `configPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-configPath}
 
 ConfigPath is the path to the containerd registry config.
 
@@ -321,7 +321,7 @@ ConfigPath is the path to the containerd registry config.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors}
+##### `mirrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors}
 
 Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -333,7 +333,7 @@ Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-server}
 
 Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -348,7 +348,7 @@ Server is the fallback server to use for the containerd registry mirror. E.g. ht
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror.
 
@@ -363,7 +363,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -378,7 +378,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -393,7 +393,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -408,7 +408,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts}
+##### `hosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts}
 
 Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -420,7 +420,7 @@ Hosts holds configuration for the containerd registry mirror hosts. See https://
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-server}
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-server}
 
 Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
 
@@ -435,7 +435,7 @@ Server is the server to use for the containerd registry mirror host. E.g. http:/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-caCert}
+##### `caCert` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror host.
 
@@ -450,7 +450,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror ho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -465,7 +465,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -480,7 +480,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `overridePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-overridePath}
+##### `overridePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-overridePath}
 
 OverridePath is a boolean to override the path for the containerd registry mirror.
 
@@ -501,7 +501,7 @@ OverridePath is a boolean to override the path for the containerd registry mirro
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth}
 
 Auth holds configuration for the containerd registry auth. See https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials for more details.
 
@@ -513,7 +513,7 @@ Auth holds configuration for the containerd registry auth. See https://github.co
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-username}
 
 Username is the username for the containerd registry.
 
@@ -528,7 +528,7 @@ Username is the username for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-password}
 
 Password is the password for the containerd registry.
 
@@ -543,7 +543,7 @@ Password is the password for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `identityToken` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-identityToken}
+##### `identityToken` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-identityToken}
 
 IdentityToken is the token for the containerd registry.
 
@@ -558,7 +558,7 @@ IdentityToken is the token for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `auth` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-auth}
+##### `auth` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-auth-auth}
 
 Auth is the auth config for the containerd registry.
 
@@ -579,7 +579,7 @@ Auth is the auth config for the containerd registry.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-pauseImage}
+##### `pauseImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-pauseImage}
 
 PauseImage is the image for the pause container.
 
@@ -597,7 +597,7 @@ PauseImage is the image for the pause container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-caCertPath}
+#### `caCertPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-caCertPath}
 
 CACertPath is the path to the SSL certificate authority used to
 secure communications between node and control-plane.
@@ -614,7 +614,7 @@ Defaults to "/etc/kubernetes/pki/ca.crt".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-skipPhases}
+#### `skipPhases` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-skipPhases}
 
 SkipPhases is a list of phases to skip during command execution.
 The list of phases can be obtained with the "kubeadm join --help" command.
@@ -630,7 +630,7 @@ The list of phases can be obtained with the "kubeadm join --help" command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration}
+#### `nodeRegistration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration}
 
 NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
 
@@ -642,7 +642,7 @@ NodeRegistration holds configuration for the node registration similar to the ku
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-criSocket}
+##### `criSocket` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-criSocket}
 
 CRI socket is the socket for the CRI.
 
@@ -657,7 +657,7 @@ CRI socket is the socket for the CRI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs}
+##### `kubeletExtraArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs}
 
 KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
 kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
@@ -673,7 +673,7 @@ Extra arguments will override existing default arguments. Duplicate extra argume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-name}
 
 Name is the name of the argument.
 
@@ -688,7 +688,7 @@ Name is the name of the argument.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-value}
 
 Value is the value of the argument.
 
@@ -706,7 +706,7 @@ Value is the value of the argument.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints}
+##### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints}
 
 Taints are additional taints to set for the kubelet.
 
@@ -718,7 +718,7 @@ Taints are additional taints to set for the kubelet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -733,7 +733,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -748,7 +748,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -768,7 +768,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-ignorePreflightErrors}
+##### `ignorePreflightErrors` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-ignorePreflightErrors}
 
 IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
 Value 'all' ignores errors from all checks.
@@ -784,7 +784,7 @@ Value 'all' ignores errors from all checks.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-imagePullPolicy}
 
 ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
 The value of this field must be one of "Always", "IfNotPresent" or "Never".
@@ -807,7 +807,7 @@ If this field is unset kubeadm will default it to "IfNotPresent", or pull the re
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes}
+### `autoNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes}
 
 AutoNodes stores auto nodes configuration.
 
@@ -819,7 +819,7 @@ AutoNodes stores auto nodes configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `provider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-provider}
+#### `provider` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-provider}
 
 Provider is the node provider of the nodes in this pool.
 
@@ -834,7 +834,7 @@ Provider is the node provider of the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-properties}
+#### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-properties}
 
 Properties are the node provider properties. This is a simple key value map and can contain things
 like region, subscription, etc. that is then used by the node provider to create the nodes and node environment.
@@ -850,7 +850,7 @@ like region, subscription, etc. that is then used by the node provider to create
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `static` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static}
+#### `static` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static}
 
 Static defines static node pools. Static node pools have a fixed size and are not scaled automatically.
 
@@ -862,7 +862,7 @@ Static defines static node pools. Static node pools have a fixed size and are no
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-name}
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-name}
 
 Name is the name of this static nodePool
 
@@ -877,7 +877,7 @@ Name is the name of this static nodePool
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector}
+##### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -890,7 +890,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -905,7 +905,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -920,7 +920,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -935,7 +935,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -953,7 +953,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints}
+##### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints}
 
 Taints are the taints to apply to the nodes in this pool.
 
@@ -965,7 +965,7 @@ Taints are the taints to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -980,7 +980,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -995,7 +995,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -1015,7 +1015,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeLabels}
+##### `nodeLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-nodeLabels}
 
 NodeLabels are the labels to apply to the nodes in this pool.
 
@@ -1030,7 +1030,7 @@ NodeLabels are the labels to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `terminationGracePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-terminationGracePeriod}
+##### `terminationGracePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-terminationGracePeriod}
 
 TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
@@ -1057,7 +1057,7 @@ Defaults to 30s. Set to Never to wait indefinitely for pods to be drained.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `quantity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-quantity}
+##### `quantity` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-static-quantity}
 
 Quantity is the number of desired nodes in this pool.
 
@@ -1075,7 +1075,7 @@ Quantity is the number of desired nodes in this pool.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dynamic` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic}
+#### `dynamic` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic}
 
 Dynamic defines dynamic node pools. Dynamic node pools are scaled automatically based on the requirements within the cluster.
 Karpenter is used under the hood to handle the scheduling of the nodes.
@@ -1088,7 +1088,7 @@ Karpenter is used under the hood to handle the scheduling of the nodes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-name}
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-name}
 
 Name is the name of this NodePool
 
@@ -1103,7 +1103,7 @@ Name is the name of this NodePool
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector}
+##### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -1116,7 +1116,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -1131,7 +1131,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -1146,7 +1146,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -1161,7 +1161,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -1179,7 +1179,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints}
+##### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints}
 
 Taints are the taints to apply to the nodes in this pool.
 
@@ -1191,7 +1191,7 @@ Taints are the taints to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -1206,7 +1206,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -1221,7 +1221,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -1241,7 +1241,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeLabels}
+##### `nodeLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-nodeLabels}
 
 NodeLabels are the labels to apply to the nodes in this pool.
 
@@ -1256,7 +1256,7 @@ NodeLabels are the labels to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-limits}
 
 Limits specify the maximum resources that can be provisioned by this node pool,
 mapping to the 'limits' field in Karpenter's NodePool API.
@@ -1272,7 +1272,7 @@ mapping to the 'limits' field in Karpenter's NodePool API.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `disruption` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption}
+##### `disruption` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption}
 
 Disruption contains the parameters that relate to Karpenter's disruption logic
 
@@ -1284,7 +1284,7 @@ Disruption contains the parameters that relate to Karpenter's disruption logic
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `consolidateAfter` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-consolidateAfter}
+##### `consolidateAfter` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-consolidateAfter}
 
 ConsolidateAfter is the duration the controller will wait
 before attempting to terminate nodes that are underutilized.
@@ -1301,7 +1301,7 @@ Refer to ConsolidationPolicy for how underutilization is considered.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `consolidationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-consolidationPolicy}
+##### `consolidationPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-consolidationPolicy}
 
 ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
 algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
@@ -1317,7 +1317,7 @@ algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `budgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets}
+##### `budgets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets}
 
 Budgets is a list of Budgets.
 If there are multiple active budgets, Karpenter uses
@@ -1332,7 +1332,7 @@ this will default to one budget with a value to 10%.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-nodes}
+##### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-nodes}
 
 Nodes dictates the maximum number of NodeClaims owned by this NodePool
 that can be terminating at once. This is calculated by counting nodes that
@@ -1350,7 +1350,7 @@ This field is required when specifying a budget.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-schedule}
+##### `schedule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-schedule}
 
 Schedule specifies when a budget begins being active, following
 the upstream cronjob syntax. If omitted, the budget is always active.
@@ -1367,7 +1367,7 @@ Timezones are not supported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `duration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-duration}
+##### `duration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-disruption-budgets-duration}
 
 Duration determines how long a Budget is active since each Schedule hit.
 Only minutes and hours are accepted, as cron does not work in seconds.
@@ -1391,7 +1391,7 @@ This is required if Schedule is set.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `terminationGracePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-terminationGracePeriod}
+##### `terminationGracePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-terminationGracePeriod}
 
 TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
@@ -1418,7 +1418,7 @@ Defaults to 30s. Set to Never to wait indefinitely for pods to be drained.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expireAfter` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-expireAfter}
+##### `expireAfter` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-expireAfter}
 
 The amount of time a Node can live on the cluster before being removed
 
@@ -1433,7 +1433,7 @@ The amount of time a Node can live on the cluster before being removed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `weight` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-weight}
+##### `weight` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoNodes-dynamic-weight}
 
 Weight is the weight of this node pool.
 
@@ -1454,7 +1454,7 @@ Weight is the weight of this node pool.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vpn` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-vpn}
+### `vpn` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-vpn}
 
 VPN holds configuration for the private nodes vpn. This can be used to connect the private nodes to the control plane or
 connect the private nodes to each other if they are not running in the same network. Platform connection is required for the vpn to work.
@@ -1467,7 +1467,7 @@ connect the private nodes to each other if they are not running in the same netw
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-vpn-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-vpn-enabled}
 
 Enabled defines if the private nodes vpn should be enabled.
 
@@ -1482,7 +1482,7 @@ Enabled defines if the private nodes vpn should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeToNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-vpn-nodeToNode}
+#### `nodeToNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-vpn-nodeToNode}
 
 NodeToNode holds configuration for the node to node vpn. This can be used to connect the private nodes to each other if they are not running in the same network.
 
@@ -1494,7 +1494,7 @@ NodeToNode holds configuration for the node to node vpn. This can be used to con
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-vpn-nodeToNode-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-vpn-nodeToNode-enabled}
 
 Enabled defines if the node to node vpn should be enabled.
 
@@ -1515,7 +1515,7 @@ Enabled defines if the node to node vpn should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `daemon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon}
+### `daemon` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon}
 
 Daemon holds configuration for the private nodes daemon that is deployed on the nodes.
 
@@ -1527,7 +1527,7 @@ Daemon holds configuration for the private nodes daemon that is deployed on the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-enabled}
 
 Enabled defines if the private nodes daemon should be enabled.
 
@@ -1542,7 +1542,7 @@ Enabled defines if the private nodes daemon should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controlPlaneLoadBalancer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer}
+#### `controlPlaneLoadBalancer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer}
 
 ControlPlaneLoadBalancer holds configuration for the control plane load balancer. This is used to load balance the control plane traffic on the node to the control plane nodes.
 This is useful to achieve true high availability for the control plane without having to deploy a separate load balancer.
@@ -1555,7 +1555,7 @@ This is useful to achieve true high availability for the control plane without h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-enabled}
 
 Enabled defines if the control plane load balancer should be enabled. The control plane load balancer is used to load balance the control plane traffic on the node to the control plane nodes.
 
@@ -1570,7 +1570,7 @@ Enabled defines if the control plane load balancer should be enabled. The contro
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kubeProxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-kubeProxy}
+##### `kubeProxy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-kubeProxy}
 
 KubeProxy defines if the kube proxy should be proxied through the control plane load balancer as well.
 
@@ -1585,7 +1585,7 @@ KubeProxy defines if the kube proxy should be proxied through the control plane 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">11343</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-port}
+##### `port` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">11343</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-port}
 
 Port defines the port for the control plane load balancer.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/privateNodes/autoNodes.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/privateNodes/autoNodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes}
+## `autoNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes}
 
 AutoNodes stores auto nodes configuration.
 
@@ -14,7 +14,7 @@ AutoNodes stores auto nodes configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `provider` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-provider}
+### `provider` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-provider}
 
 Provider is the node provider of the nodes in this pool.
 
@@ -29,7 +29,7 @@ Provider is the node provider of the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `properties` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-properties}
+### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-properties}
 
 Properties are the node provider properties. This is a simple key value map and can contain things
 like region, subscription, etc. that is then used by the node provider to create the nodes and node environment.
@@ -45,7 +45,7 @@ like region, subscription, etc. that is then used by the node provider to create
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `static` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static}
+### `static` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static}
 
 Static defines static node pools. Static node pools have a fixed size and are not scaled automatically.
 
@@ -57,7 +57,7 @@ Static defines static node pools. Static node pools have a fixed size and are no
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-name}
+#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-name}
 
 Name is the name of this static nodePool
 
@@ -72,7 +72,7 @@ Name is the name of this static nodePool
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector}
+#### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -85,7 +85,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -100,7 +100,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -115,7 +115,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -130,7 +130,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -148,7 +148,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints}
+#### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints}
 
 Taints are the taints to apply to the nodes in this pool.
 
@@ -160,7 +160,7 @@ Taints are the taints to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -175,7 +175,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -190,7 +190,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -210,7 +210,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeLabels}
+#### `nodeLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-nodeLabels}
 
 NodeLabels are the labels to apply to the nodes in this pool.
 
@@ -225,7 +225,7 @@ NodeLabels are the labels to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `terminationGracePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-terminationGracePeriod}
+#### `terminationGracePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-terminationGracePeriod}
 
 TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
@@ -252,7 +252,7 @@ Defaults to 30s. Set to Never to wait indefinitely for pods to be drained.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `quantity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-quantity}
+#### `quantity` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-static-quantity}
 
 Quantity is the number of desired nodes in this pool.
 
@@ -270,7 +270,7 @@ Quantity is the number of desired nodes in this pool.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `dynamic` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic}
+### `dynamic` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic}
 
 Dynamic defines dynamic node pools. Dynamic node pools are scaled automatically based on the requirements within the cluster.
 Karpenter is used under the hood to handle the scheduling of the nodes.
@@ -283,7 +283,7 @@ Karpenter is used under the hood to handle the scheduling of the nodes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-name}
+#### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-name}
 
 Name is the name of this NodePool
 
@@ -298,7 +298,7 @@ Name is the name of this NodePool
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeTypeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector}
+#### `nodeTypeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector}
 
 NodeTypeSelector filters the types of nodes that can be provisioned by this pool.
 All requirements must be met for a node type to be eligible.
@@ -311,7 +311,7 @@ All requirements must be met for a node type to be eligible.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `property` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-property}
+##### `property` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-property}
 
 Property is the property on the node type to select.
 
@@ -326,7 +326,7 @@ Property is the property on the node type to select.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-operator}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-operator}
 
 Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, defaults to "In".
 
@@ -341,7 +341,7 @@ Operator is the comparison operator, such as "In", "NotIn", "Exists". If empty, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-values}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-values}
 
 Values is the list of values to use for comparison. This is mutually exclusive with value.
 
@@ -356,7 +356,7 @@ Values is the list of values to use for comparison. This is mutually exclusive w
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeTypeSelector-value}
 
 Value is the value to use for comparison. This is mutually exclusive with values.
 
@@ -374,7 +374,7 @@ Value is the value to use for comparison. This is mutually exclusive with values
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints}
+#### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints}
 
 Taints are the taints to apply to the nodes in this pool.
 
@@ -386,7 +386,7 @@ Taints are the taints to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-key}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -401,7 +401,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-value}
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -416,7 +416,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -436,7 +436,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeLabels}
+#### `nodeLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-nodeLabels}
 
 NodeLabels are the labels to apply to the nodes in this pool.
 
@@ -451,7 +451,7 @@ NodeLabels are the labels to apply to the nodes in this pool.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-limits}
+#### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-limits}
 
 Limits specify the maximum resources that can be provisioned by this node pool,
 mapping to the 'limits' field in Karpenter's NodePool API.
@@ -467,7 +467,7 @@ mapping to the 'limits' field in Karpenter's NodePool API.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `disruption` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption}
+#### `disruption` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption}
 
 Disruption contains the parameters that relate to Karpenter's disruption logic
 
@@ -479,7 +479,7 @@ Disruption contains the parameters that relate to Karpenter's disruption logic
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `consolidateAfter` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-consolidateAfter}
+##### `consolidateAfter` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-consolidateAfter}
 
 ConsolidateAfter is the duration the controller will wait
 before attempting to terminate nodes that are underutilized.
@@ -496,7 +496,7 @@ Refer to ConsolidationPolicy for how underutilization is considered.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `consolidationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-consolidationPolicy}
+##### `consolidationPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-consolidationPolicy}
 
 ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
 algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
@@ -512,7 +512,7 @@ algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `budgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets}
+##### `budgets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets}
 
 Budgets is a list of Budgets.
 If there are multiple active budgets, Karpenter uses
@@ -527,7 +527,7 @@ this will default to one budget with a value to 10%.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-nodes}
+##### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-nodes}
 
 Nodes dictates the maximum number of NodeClaims owned by this NodePool
 that can be terminating at once. This is calculated by counting nodes that
@@ -545,7 +545,7 @@ This field is required when specifying a budget.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-schedule}
+##### `schedule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-schedule}
 
 Schedule specifies when a budget begins being active, following
 the upstream cronjob syntax. If omitted, the budget is always active.
@@ -562,7 +562,7 @@ Timezones are not supported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `duration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-duration}
+##### `duration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-disruption-budgets-duration}
 
 Duration determines how long a Budget is active since each Schedule hit.
 Only minutes and hours are accepted, as cron does not work in seconds.
@@ -586,7 +586,7 @@ This is required if Schedule is set.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `terminationGracePeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-terminationGracePeriod}
+#### `terminationGracePeriod` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-terminationGracePeriod}
 
 TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 
@@ -613,7 +613,7 @@ Defaults to 30s. Set to Never to wait indefinitely for pods to be drained.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expireAfter` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-expireAfter}
+#### `expireAfter` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-expireAfter}
 
 The amount of time a Node can live on the cluster before being removed
 
@@ -628,7 +628,7 @@ The amount of time a Node can live on the cluster before being removed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `weight` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-weight}
+#### `weight` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoNodes-dynamic-weight}
 
 Weight is the weight of this node pool.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/privateNodes/autoUpgrade.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/privateNodes/autoUpgrade.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoUpgrade` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade}
+## `autoUpgrade` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade}
 
 AutoUpgrade holds configuration for auto upgrade.
 
@@ -14,7 +14,7 @@ AutoUpgrade holds configuration for auto upgrade.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#autoUpgrade-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#autoUpgrade-enabled}
 
 Enabled defines if auto upgrade should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if auto upgrade should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-image}
+### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-image}
 
 Image is the image for the auto upgrade pod started by vCluster. If empty defaults to the controlPlane.statefulSet.image.
 
@@ -44,7 +44,7 @@ Image is the image for the auto upgrade pod started by vCluster. If empty defaul
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -59,7 +59,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-nodeSelector}
+### `nodeSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-nodeSelector}
 
 NodeSelector is the node selector for the auto upgrade. If empty will select all worker nodes.
 
@@ -74,7 +74,7 @@ NodeSelector is the node selector for the auto upgrade. If empty will select all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `binariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-binariesPath}
+### `binariesPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-binariesPath}
 
 BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/bin
 
@@ -89,7 +89,7 @@ BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `cniBinariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-cniBinariesPath}
+### `cniBinariesPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-cniBinariesPath}
 
 CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 
@@ -104,7 +104,7 @@ CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `concurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#autoUpgrade-concurrency}
+### `concurrency` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#autoUpgrade-concurrency}
 
 Concurrency is the number of nodes that can be upgraded at the same time.
 
@@ -119,7 +119,7 @@ Concurrency is the number of nodes that can be upgraded at the same time.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-podSecurityContext}
+### `podSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level for the upgrade pod.
 
@@ -134,7 +134,7 @@ PodSecurityContext specifies security context options on the pod level for the u
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-containerSecurityContext}
+### `containerSecurityContext` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level for the upgrade container.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/privateNodes/vpn.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/privateNodes/vpn.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `vpn` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vpn}
+## `vpn` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vpn}
 
 VPN holds configuration for the private nodes vpn. This can be used to connect the private nodes to the control plane or
 connect the private nodes to each other if they are not running in the same network. Platform connection is required for the vpn to work.
@@ -15,7 +15,7 @@ connect the private nodes to each other if they are not running in the same netw
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#vpn-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#vpn-enabled}
 
 Enabled defines if the private nodes vpn should be enabled.
 
@@ -30,7 +30,7 @@ Enabled defines if the private nodes vpn should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodeToNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vpn-nodeToNode}
+### `nodeToNode` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#vpn-nodeToNode}
 
 NodeToNode holds configuration for the node to node vpn. This can be used to connect the private nodes to each other if they are not running in the same network.
 
@@ -42,7 +42,7 @@ NodeToNode holds configuration for the node to node vpn. This can be used to con
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#vpn-nodeToNode-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#vpn-nodeToNode-enabled}
 
 Enabled defines if the node to node vpn should be enabled.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/rbac.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/rbac.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac}
+## `rbac` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac}
 
 RBAC options for the virtual cluster.
 
@@ -14,7 +14,7 @@ RBAC options for the virtual cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-role}
+### `role` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-role}
 
 Role holds virtual cluster role configuration
 
@@ -26,7 +26,7 @@ Role holds virtual cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#rbac-role-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#rbac-role-enabled}
 
 Enabled defines if the role should be enabled or disabled.
 
@@ -41,7 +41,7 @@ Enabled defines if the role should be enabled or disabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-extraRules}
 
 ExtraRules will add rules to the role.
 
@@ -56,7 +56,7 @@ ExtraRules will add rules to the role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-overwriteRules}
 
 OverwriteRules will overwrite the role rules completely.
 
@@ -74,7 +74,7 @@ OverwriteRules will overwrite the role rules completely.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-clusterRole}
+### `clusterRole` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-clusterRole}
 
 ClusterRole holds virtual cluster cluster role configuration
 
@@ -86,7 +86,7 @@ ClusterRole holds virtual cluster cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-clusterRole-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-clusterRole-enabled}
 
 Enabled defines if the cluster role should be enabled or disabled. If auto, vCluster automatically determines whether the virtual cluster requires a cluster role.
 
@@ -101,7 +101,7 @@ Enabled defines if the cluster role should be enabled or disabled. If auto, vClu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-extraRules}
 
 ExtraRules will add rules to the cluster role.
 
@@ -116,7 +116,7 @@ ExtraRules will add rules to the cluster role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-overwriteRules}
 
 OverwriteRules will overwrite the cluster role rules completely.
 
@@ -134,7 +134,7 @@ OverwriteRules will overwrite the cluster role rules completely.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `enableVolumeSnapshotRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-enableVolumeSnapshotRules}
+### `enableVolumeSnapshotRules` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-enableVolumeSnapshotRules}
 
 EnableVolumeSnapshotRules enables all required volume snapshot rules in the Role and
 ClusterRole.
@@ -147,7 +147,7 @@ ClusterRole.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-enableVolumeSnapshotRules-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-enableVolumeSnapshotRules-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sleep.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sleep.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep}
+## `sleep` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep}
 
 Sleep holds configuration for automatically putting the virtual cluster to sleep.
 
@@ -14,7 +14,7 @@ Sleep holds configuration for automatically putting the virtual cluster to sleep
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `auto` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto}
+### `auto` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto}
 
 Auto holds automatic sleep configuration
 
@@ -26,7 +26,7 @@ Auto holds automatic sleep configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-afterInactivity}
 
 AfterInactivity represents how long a vCluster can be idle before workloads are automatically put to sleep
 
@@ -41,7 +41,7 @@ AfterInactivity represents how long a vCluster can be idle before workloads are 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-schedule}
+#### `schedule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-schedule}
 
 Schedule represents a cron schedule for when to sleep workloads
 
@@ -56,7 +56,7 @@ Schedule represents a cron schedule for when to sleep workloads
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `exclude` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude}
+#### `exclude` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude}
 
 Exclude holds configuration for labels that, if present, will prevent a workload from going to sleep
 
@@ -68,7 +68,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude-selector}
 
 
 
@@ -80,7 +80,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-exclude-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -101,7 +101,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `wakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-wakeup}
+#### `wakeup` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-wakeup}
 
 Wakeup holds configuration for waking the vCluster on a schedule
 
@@ -113,7 +113,7 @@ Wakeup holds configuration for waking the vCluster on a schedule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-wakeup-schedule}
+##### `schedule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-wakeup-schedule}
 
 
 
@@ -131,7 +131,7 @@ Wakeup holds configuration for waking the vCluster on a schedule
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-timezone}
+#### `timezone` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleep-auto-timezone}
 
 Timezone specifies time zone used for scheduled sleep operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/snapshots.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/snapshots.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `snapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots}
+## `snapshots` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots}
 
 Snapshots holds configuration for automatic vCluster snapshots.
 
@@ -14,7 +14,7 @@ Snapshots holds configuration for automatic vCluster snapshots.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `auto` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto}
+### `auto` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto}
 
 Auto holds automatic snapshot configuration
 
@@ -26,9 +26,9 @@ Auto holds automatic snapshot configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-schedule}
+#### `schedule` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-schedule}
 
-Schedule specifies a scheduled time in Cron format, see https://en.wikipedia.org/wiki/Cron for a tenant cluster snapshot to be taken
+Schedule specifies a scheduled time in Cron format, see https://en.wikipedia.org/wiki/Cron for a virtual cluster snapshot to be taken
 
 </summary>
 
@@ -41,7 +41,7 @@ Schedule specifies a scheduled time in Cron format, see https://en.wikipedia.org
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-timezone}
+#### `timezone` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-timezone}
 
 Timezone specifies time zone used for scheduled snapshot operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).
@@ -58,7 +58,7 @@ The value should be a location name corresponding to a file in the IANA Time Zon
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `retention` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention}
+#### `retention` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention}
 
 Retention specifies how long snapshots will be kept
 
@@ -70,7 +70,7 @@ Retention specifies how long snapshots will be kept
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `period` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention-period}
+##### `period` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention-period}
 
 Period defines the number of days a snapshot will be kept
 
@@ -85,7 +85,7 @@ Period defines the number of days a snapshot will be kept
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `maxSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention-maxSnapshots}
+##### `maxSnapshots` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-retention-maxSnapshots}
 
 MaxSnapshots defines the number of snapshots that can be taken
 
@@ -103,7 +103,7 @@ MaxSnapshots defines the number of snapshots that can be taken
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage}
+#### `storage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage}
 
 Storage specifies where the snapshot will be stored
 
@@ -115,7 +115,7 @@ Storage specifies where the snapshot will be stored
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `type` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-type}
+##### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-type}
 
 Type specifies supported type of storage services for a snapshot S3/OCI/Container, see https://www.vcluster.com/docs/vcluster/manage/backup-restore#store-snapshots-in-s3-buckets
 
@@ -130,7 +130,7 @@ Type specifies supported type of storage services for a snapshot S3/OCI/Containe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `s3` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3}
+##### `s3` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3}
 
 S3 holds configuration for storing snapshots in S3-compatible bucket
 
@@ -142,7 +142,7 @@ S3 holds configuration for storing snapshots in S3-compatible bucket
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-url}
+##### `url` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-url}
 
 Url specifies url to the storage service
 
@@ -157,7 +157,7 @@ Url specifies url to the storage service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credential` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential}
+##### `credential` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential}
 
 Credential secret with the S3 Credentials, it should contain AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN
 
@@ -169,7 +169,7 @@ Credential secret with the S3 Credentials, it should contain AWS_ACCESS_KEY_ID, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential-secretName}
 
 SecretName is the secret name with credential
 
@@ -184,7 +184,7 @@ SecretName is the secret name with credential
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-s3-credential-secretNamespace}
 
 SecretNamespace is the secret namespace with credential
 
@@ -205,7 +205,7 @@ SecretNamespace is the secret namespace with credential
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `oci` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci}
+##### `oci` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci}
 
 OCI holds configuration for storing snapshots in OCI image registries
 
@@ -217,7 +217,7 @@ OCI holds configuration for storing snapshots in OCI image registries
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-repository}
 
 Repository OCI repository to store the snapshot
 
@@ -232,7 +232,7 @@ Repository OCI repository to store the snapshot
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credential` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential}
+##### `credential` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential}
 
 Credential secret with the OCI Credentials
 
@@ -244,7 +244,7 @@ Credential secret with the OCI Credentials
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential-secretName}
 
 SecretName is the secret name with credential
 
@@ -259,7 +259,7 @@ SecretName is the secret name with credential
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-credential-secretNamespace}
 
 SecretNamespace is the secret namespace with credential
 
@@ -277,7 +277,7 @@ SecretNamespace is the secret namespace with credential
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-username}
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-username}
 
 Username to authenticate with the OCI registry
 
@@ -292,7 +292,7 @@ Username to authenticate with the OCI registry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-password}
+##### `password` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-oci-password}
 
 Password to authenticate with the OCI registry
 
@@ -310,7 +310,7 @@ Password to authenticate with the OCI registry
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `container` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container}
+##### `container` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container}
 
 Container holds configuration for storing snapshots as local files inside a vCluster container
 
@@ -322,7 +322,7 @@ Container holds configuration for storing snapshots as local files inside a vClu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-path}
 
 Path specifies directory to store the snapshot
 
@@ -337,7 +337,7 @@ Path specifies directory to store the snapshot
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume}
+##### `volume` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume}
 
 Volume specifies which volume needs to be mounted into the container to store the snapshot
 
@@ -349,7 +349,7 @@ Volume specifies which volume needs to be mounted into the container to store th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume-name}
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume-name}
 
 Name to be used to mount the volume
 
@@ -364,7 +364,7 @@ Name to be used to mount the volume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume-path}
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-container-volume-path}
 
 Path to the volume mount
 
@@ -385,7 +385,7 @@ Path to the volume mount
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `azure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure}
+##### `azure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure}
 
 Azure holds configuration for storing snapshots in Azure Blob Storage
 
@@ -397,7 +397,7 @@ Azure holds configuration for storing snapshots in Azure Blob Storage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `blobUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-blobUrl}
+##### `blobUrl` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-blobUrl}
 
 BlobURL specifies the Azure Blob Storage URL in the format https://&#123;account&#125;.blob.core.windows.net/&#123;container&#125;/&#123;path&#125;
 
@@ -412,7 +412,7 @@ BlobURL specifies the Azure Blob Storage URL in the format https://&#123;account
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `credential` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential}
+##### `credential` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential}
 
 Credential secret with the Azure credentials. The secret should contain either:
 AZURE_STORAGE_KEY (storage account access key), or
@@ -426,7 +426,7 @@ AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID, AZ
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretName}
+##### `secretName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretName}
 
 SecretName is the secret name with credential
 
@@ -441,7 +441,7 @@ SecretName is the secret name with credential
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretNamespace}
+##### `secretNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretNamespace}
 
 SecretNamespace is the secret namespace with credential
 
@@ -465,7 +465,7 @@ SecretNamespace is the secret namespace with credential
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-volumes}
+#### `volumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-volumes}
 
 Volumes specifies configuration for volume snapshots
 
@@ -477,7 +477,7 @@ Volumes specifies configuration for volume snapshots
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-volumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-volumes-enabled}
 
 Enabled specifies whether a snapshot should also include volumes in the snapshot
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync}
+## `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync}
 
 Sync describes how to sync resources from the virtual cluster to host cluster and back.
 
@@ -14,7 +14,7 @@ Sync describes how to sync resources from the virtual cluster to host cluster an
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost}
+### `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -26,7 +26,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods}
+#### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -38,7 +38,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -53,7 +53,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-translateImage}
+##### `translateImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -69,7 +69,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enforceTolerations}
+##### `enforceTolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -84,7 +84,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-useSecretsForSATokens}
+##### `useSecretsForSATokens` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -100,7 +100,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-runtimeClassName}
+##### `runtimeClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -115,7 +115,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -130,7 +130,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts}
+##### `rewriteHosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -144,7 +144,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -159,7 +159,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -171,7 +171,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -183,7 +183,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -199,7 +199,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -214,7 +214,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -232,7 +232,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -244,7 +244,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -259,7 +259,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -283,7 +283,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -295,7 +295,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -310,7 +310,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -325,7 +325,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -340,7 +340,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -354,7 +354,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -369,7 +369,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -384,7 +384,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -399,7 +399,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -414,7 +414,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -429,7 +429,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -448,7 +448,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -466,7 +466,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling}
+##### `hybridScheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -478,7 +478,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -493,7 +493,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-hostSchedulers}
+##### `hostSchedulers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 
@@ -514,7 +514,7 @@ HostSchedulers is a list of schedulers that are deployed on the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -526,7 +526,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -541,7 +541,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-all}
+##### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -556,7 +556,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -568,7 +568,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -583,7 +583,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -598,7 +598,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -613,7 +613,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -627,7 +627,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -642,7 +642,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -657,7 +657,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -672,7 +672,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -687,7 +687,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -702,7 +702,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -721,7 +721,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -742,7 +742,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -754,7 +754,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -769,7 +769,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-all}
+##### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -784,7 +784,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -796,7 +796,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -811,7 +811,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -826,7 +826,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -841,7 +841,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -855,7 +855,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -870,7 +870,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -885,7 +885,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -900,7 +900,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -915,7 +915,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -930,7 +930,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -949,7 +949,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -970,7 +970,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses}
+#### `ingresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -982,7 +982,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -997,7 +997,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1009,7 +1009,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1024,7 +1024,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1039,7 +1039,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1054,7 +1054,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1068,7 +1068,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1083,7 +1083,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1098,7 +1098,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1113,7 +1113,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1128,7 +1128,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1143,7 +1143,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1162,7 +1162,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1183,10 +1183,9 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gatewayApi` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi}
+#### `gatewayApi` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi}
 
 GatewayAPI defines Gateway API resources created within the tenant cluster that should get synced to the control plane cluster.
-Setting enabled: true turns on Gateway and HTTPRoute sync, imports control plane cluster GatewayClasses so tenant Gateways can resolve them, and serves tenant ReferenceGrants for validation; TLSRoutes and BackendTLSPolicies must be enabled individually.
 
 </summary>
 
@@ -1196,7 +1195,7 @@ Setting enabled: true turns on Gateway and HTTPRoute sync, imports control plane
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1211,7 +1210,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1223,7 +1222,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1238,7 +1237,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1253,7 +1252,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1268,7 +1267,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1282,7 +1281,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1297,7 +1296,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1312,7 +1311,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1327,7 +1326,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1342,7 +1341,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1357,7 +1356,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1376,7 +1375,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1394,7 +1393,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `httpRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes}
+##### `httpRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes}
 
 HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 
@@ -1406,7 +1405,7 @@ HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1421,7 +1420,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1433,7 +1432,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1448,7 +1447,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1463,7 +1462,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1478,7 +1477,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1492,7 +1491,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1507,7 +1506,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1522,7 +1521,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1537,7 +1536,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1552,7 +1551,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1567,7 +1566,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1586,7 +1585,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-httpRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1607,7 +1606,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways}
+##### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways}
 
 Gateways configures tenant-created Gateway sync to the control plane cluster.
 
@@ -1619,7 +1618,7 @@ Gateways configures tenant-created Gateway sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1634,7 +1633,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1646,7 +1645,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1661,7 +1660,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1676,7 +1675,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1691,7 +1690,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1705,7 +1704,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1720,7 +1719,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1735,7 +1734,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1750,7 +1749,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1765,7 +1764,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1780,7 +1779,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1799,7 +1798,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-gateways-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1820,7 +1819,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tlsRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes}
+##### `tlsRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes}
 
 TLSRoutes configures TLSRoute sync to the control plane cluster.
 
@@ -1832,7 +1831,7 @@ TLSRoutes configures TLSRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1847,7 +1846,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1859,7 +1858,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1874,7 +1873,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1889,7 +1888,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1904,7 +1903,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1918,7 +1917,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1933,7 +1932,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1948,7 +1947,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1963,7 +1962,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1978,7 +1977,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1993,7 +1992,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2012,7 +2011,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-tlsRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2033,7 +2032,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `backendTLSPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies}
+##### `backendTLSPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies}
 
 BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster.
 
@@ -2045,7 +2044,7 @@ BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2060,7 +2059,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2072,7 +2071,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2087,7 +2086,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2102,7 +2101,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2117,7 +2116,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2131,7 +2130,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2146,7 +2145,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2161,7 +2160,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2176,7 +2175,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2191,7 +2190,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2206,7 +2205,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2225,7 +2224,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-backendTLSPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2246,10 +2245,9 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `referenceGrants` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants}
+##### `referenceGrants` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants}
 
 ReferenceGrants configures ReferenceGrant sync to the control plane cluster. Enabled may be "auto", "true", or "false".
-In auto mode grants follow route sync and are validated within the tenant cluster; they sync to the control plane cluster only when namespace sync is also enabled.
 
 </summary>
 
@@ -2259,7 +2257,7 @@ In auto mode grants follow route sync and are validated within the tenant cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2274,7 +2272,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2286,7 +2284,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2301,7 +2299,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2316,7 +2314,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2331,7 +2329,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2345,7 +2343,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2360,7 +2358,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2375,7 +2373,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2390,7 +2388,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2405,7 +2403,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2420,7 +2418,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2439,7 +2437,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-gatewayApi-referenceGrants-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2463,7 +2461,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services}
+#### `services` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -2475,7 +2473,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-services-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2490,7 +2488,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2502,7 +2500,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2517,7 +2515,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2532,7 +2530,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2547,7 +2545,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2561,7 +2559,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2576,7 +2574,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2591,7 +2589,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2606,7 +2604,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2621,7 +2619,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2636,7 +2634,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2655,7 +2653,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2676,7 +2674,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints}
+#### `endpoints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -2688,7 +2686,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2703,7 +2701,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2715,7 +2713,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2730,7 +2728,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2745,7 +2743,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2760,7 +2758,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2774,7 +2772,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2789,7 +2787,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2804,7 +2802,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2819,7 +2817,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2834,7 +2832,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2849,7 +2847,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2868,7 +2866,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2889,7 +2887,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `endpointSlices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices}
+#### `endpointSlices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices}
 
 EndpointSlices defines if endpointslices created within the virtual cluster should get synced to the host cluster.
 
@@ -2901,7 +2899,7 @@ EndpointSlices defines if endpointslices created within the virtual cluster shou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2916,7 +2914,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2928,7 +2926,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2943,7 +2941,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2958,7 +2956,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2973,7 +2971,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2987,7 +2985,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3002,7 +3000,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3017,7 +3015,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3032,7 +3030,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3047,7 +3045,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3062,7 +3060,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3081,7 +3079,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpointSlices-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3102,7 +3100,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies}
+#### `networkPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -3114,7 +3112,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3129,7 +3127,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3141,7 +3139,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3156,7 +3154,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3171,7 +3169,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3186,7 +3184,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3200,7 +3198,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3215,7 +3213,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3230,7 +3228,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3245,7 +3243,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3260,7 +3258,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3275,7 +3273,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3294,7 +3292,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3315,7 +3313,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims}
+#### `persistentVolumeClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -3327,7 +3325,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3342,7 +3340,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3354,7 +3352,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3369,7 +3367,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3384,7 +3382,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3399,7 +3397,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3413,7 +3411,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3428,7 +3426,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3443,7 +3441,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3458,7 +3456,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3473,7 +3471,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3488,7 +3486,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3507,7 +3505,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3528,7 +3526,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes}
+#### `persistentVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -3540,7 +3538,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3555,7 +3553,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3567,7 +3565,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3582,7 +3580,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3597,7 +3595,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3612,7 +3610,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3626,7 +3624,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3641,7 +3639,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3656,7 +3654,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3671,7 +3669,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3686,7 +3684,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3701,7 +3699,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3720,7 +3718,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3741,7 +3739,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots}
+#### `volumeSnapshots` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -3753,7 +3751,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3768,7 +3766,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3780,7 +3778,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3795,7 +3793,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3810,7 +3808,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3825,7 +3823,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3839,7 +3837,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3854,7 +3852,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3869,7 +3867,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3884,7 +3882,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3899,7 +3897,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3914,7 +3912,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3933,7 +3931,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3954,7 +3952,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents}
+#### `volumeSnapshotContents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -3966,7 +3964,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3981,7 +3979,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3993,7 +3991,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4008,7 +4006,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4023,7 +4021,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4038,7 +4036,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4052,7 +4050,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4067,7 +4065,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4082,7 +4080,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4097,7 +4095,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4112,7 +4110,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4127,7 +4125,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4146,7 +4144,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4167,7 +4165,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -4179,7 +4177,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4194,7 +4192,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4206,7 +4204,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4221,7 +4219,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4236,7 +4234,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4251,7 +4249,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4265,7 +4263,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4280,7 +4278,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4295,7 +4293,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4310,7 +4308,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4325,7 +4323,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4340,7 +4338,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4359,7 +4357,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4380,7 +4378,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts}
+#### `serviceAccounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -4392,7 +4390,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4407,7 +4405,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4419,7 +4417,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4434,7 +4432,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4449,7 +4447,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4464,7 +4462,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4478,7 +4476,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4493,7 +4491,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4508,7 +4506,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4523,7 +4521,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4538,7 +4536,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4553,7 +4551,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4572,7 +4570,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4593,7 +4591,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets}
+#### `podDisruptionBudgets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -4605,7 +4603,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4620,7 +4618,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4632,7 +4630,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4647,7 +4645,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4662,7 +4660,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4677,7 +4675,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4691,7 +4689,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4706,7 +4704,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4721,7 +4719,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4736,7 +4734,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4751,7 +4749,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4766,7 +4764,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4785,7 +4783,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4806,7 +4804,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -4818,7 +4816,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4833,7 +4831,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4845,7 +4843,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4860,7 +4858,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4875,7 +4873,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4890,7 +4888,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4904,7 +4902,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4919,7 +4917,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4934,7 +4932,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4949,7 +4947,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4964,7 +4962,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4979,7 +4977,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4998,7 +4996,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5019,7 +5017,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -5032,7 +5030,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5047,7 +5045,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -5062,7 +5060,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5074,7 +5072,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5089,7 +5087,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5104,7 +5102,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5119,7 +5117,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5133,7 +5131,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5148,7 +5146,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5163,7 +5161,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5178,7 +5176,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5193,7 +5191,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5208,7 +5206,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5227,7 +5225,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5248,7 +5246,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces}
 
 Namespaces defines if namespaces created within the virtual cluster should get synced to the host cluster.
 
@@ -5260,7 +5258,7 @@ Namespaces defines if namespaces created within the virtual cluster should get s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-enabled}
+##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5275,7 +5273,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5287,7 +5285,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5302,7 +5300,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5317,7 +5315,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5332,7 +5330,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5346,7 +5344,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5361,7 +5359,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5376,7 +5374,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5391,7 +5389,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5406,7 +5404,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5421,7 +5419,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5440,7 +5438,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5458,7 +5456,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings}
+##### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings}
 
 Mappings for Namespace and Object
 
@@ -5470,7 +5468,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -5504,7 +5502,7 @@ byName:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappingsOnly}
+##### `mappingsOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappingsOnly}
 
 MappingsOnly defines if creation of namespaces not matched by mappings should be allowed.
 
@@ -5519,7 +5517,7 @@ MappingsOnly defines if creation of namespaces not matched by mappings should be
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-extraLabels}
+##### `extraLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-extraLabels}
 
 ExtraLabels are additional labels to add to the namespace in the host cluster.
 
@@ -5537,7 +5535,7 @@ ExtraLabels are additional labels to add to the namespace in the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resourceClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims}
+#### `resourceClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims}
 
 ResourceClaim defines if resource claims created within the virtual cluster should get synced to the host cluster.
 
@@ -5549,7 +5547,7 @@ ResourceClaim defines if resource claims created within the virtual cluster shou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5564,7 +5562,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5576,7 +5574,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5591,7 +5589,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5606,7 +5604,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5621,7 +5619,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5635,7 +5633,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5650,7 +5648,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5665,7 +5663,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5680,7 +5678,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5695,7 +5693,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5710,7 +5708,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5729,7 +5727,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5750,7 +5748,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resourceClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates}
+#### `resourceClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates}
 
 ResourceClaimTemplates defines if resourceClaimTemplates created within the virtual cluster should get synced to the host cluster.
 
@@ -5762,7 +5760,7 @@ ResourceClaimTemplates defines if resourceClaimTemplates created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5777,7 +5775,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5789,7 +5787,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5804,7 +5802,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5819,7 +5817,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5834,7 +5832,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5848,7 +5846,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5863,7 +5861,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5878,7 +5876,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5893,7 +5891,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5908,7 +5906,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5923,7 +5921,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5942,7 +5940,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-resourceClaimTemplates-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5966,7 +5964,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -5978,7 +5976,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes}
+#### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -5990,7 +5988,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -6005,7 +6003,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-syncBackChanges}
+##### `syncBackChanges` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -6020,7 +6018,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-clearImageStatus}
+##### `clearImageStatus` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -6035,7 +6033,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -6047,7 +6045,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -6062,7 +6060,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -6080,7 +6078,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6092,7 +6090,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6107,7 +6105,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6122,7 +6120,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6137,7 +6135,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6151,7 +6149,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6166,7 +6164,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6181,7 +6179,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6196,7 +6194,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6211,7 +6209,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6226,7 +6224,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6245,7 +6243,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6266,7 +6264,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events}
+#### `events` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -6278,7 +6276,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-events-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6293,7 +6291,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6305,7 +6303,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6320,7 +6318,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6335,7 +6333,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6350,7 +6348,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6364,7 +6362,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6379,7 +6377,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6394,7 +6392,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6409,7 +6407,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6424,7 +6422,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6439,7 +6437,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6458,7 +6456,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6479,7 +6477,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses}
+#### `ingressClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -6491,7 +6489,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6506,7 +6504,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6518,7 +6516,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6533,7 +6531,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6548,7 +6546,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6563,7 +6561,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6577,7 +6575,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6592,7 +6590,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6607,7 +6605,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6622,7 +6620,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6637,7 +6635,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6652,7 +6650,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6671,7 +6669,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6689,7 +6687,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -6701,7 +6699,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchLabels}
 
 
 
@@ -6716,7 +6714,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions}
 
 
 
@@ -6728,22 +6726,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -6758,7 +6741,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-values}
 
 
 
@@ -6782,7 +6780,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gatewayClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses}
+#### `gatewayClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses}
 
 GatewayClasses defines if gateway classes should get synced from the control plane cluster to the tenant cluster, but not back.
 
@@ -6794,7 +6792,7 @@ GatewayClasses defines if gateway classes should get synced from the control pla
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6809,7 +6807,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6821,7 +6819,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6836,7 +6834,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6851,7 +6849,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6866,7 +6864,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6880,7 +6878,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6895,7 +6893,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6910,7 +6908,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6925,7 +6923,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6940,7 +6938,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6955,7 +6953,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6974,7 +6972,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6992,7 +6990,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -7004,7 +7002,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchLabels}
 
 
 
@@ -7019,7 +7017,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions}
 
 
 
@@ -7031,22 +7029,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-key}
 
 
 
@@ -7061,7 +7044,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gatewayClasses-selector-matchExpressions-values}
 
 
 
@@ -7085,7 +7083,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways}
+#### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways}
 
 Gateways defines if selected control plane Gateways should get synced from the control plane cluster to the tenant cluster, but not back.
 
@@ -7097,7 +7095,7 @@ Gateways defines if selected control plane Gateways should get synced from the c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -7112,7 +7110,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -7124,7 +7122,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -7139,7 +7137,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -7154,7 +7152,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -7169,7 +7167,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -7183,7 +7181,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -7198,7 +7196,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -7213,7 +7211,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -7228,7 +7226,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -7243,7 +7241,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -7258,7 +7256,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -7277,7 +7275,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -7295,7 +7293,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -7307,7 +7305,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchLabels}
 
 
 
@@ -7322,7 +7320,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions}
 
 
 
@@ -7334,22 +7332,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-key}
 
 
 
@@ -7364,7 +7347,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-selector-matchExpressions-values}
 
 
 
@@ -7385,7 +7383,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-mappings}
+##### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-mappings}
 
 Mappings define control plane Gateway namespace/name to tenant-facing namespace/name placement.
 
@@ -7397,7 +7395,7 @@ Mappings define control plane Gateway namespace/name to tenant-facing namespace/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -7431,7 +7429,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `allowedRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes}
+##### `allowedRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes}
 
 AllowedRoutes configures the tenant-facing allowedRoutes policy shown on imported Gateways and enforced for Routes.
 
@@ -7443,7 +7441,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `defaultVirtualNamespacePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy}
+##### `defaultVirtualNamespacePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy}
 
 
 
@@ -7455,7 +7453,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-from}
 
 
 
@@ -7470,7 +7468,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector}
 
 
 
@@ -7482,7 +7480,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchLabels}
 
 
 
@@ -7497,7 +7495,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions}
 
 
 
@@ -7509,22 +7507,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-key}
 
 
 
@@ -7539,43 +7522,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-values}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `overrides` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-hostNamespace}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-operator}
 
 
 
@@ -7590,7 +7537,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-name}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-values}
 
 
 
@@ -7599,138 +7546,6 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 
 
 </details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `virtualNamespacePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-from}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchLabels}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-operator}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-values}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `allowedHostnames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-allowedHostnames}
-
-
-
-</summary>
-
 
 
 </details>
@@ -7746,7 +7561,190 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-status}
+##### `overrides` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `hostNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-hostNamespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualNamespacePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-from}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-key}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `allowedHostnames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-allowedRoutes-overrides-allowedHostnames}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-status}
 
 Status configures how Gateway status is mirrored.
 
@@ -7758,7 +7756,7 @@ Status configures how Gateway status is mirrored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `exposeAddresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-status-exposeAddresses}
+##### `exposeAddresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-status-exposeAddresses}
 
 
 
@@ -7776,7 +7774,7 @@ Status configures how Gateway status is mirrored.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-metadata}
+##### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-metadata}
 
 Metadata configures imported Gateway metadata visibility.
 
@@ -7788,7 +7786,7 @@ Metadata configures imported Gateway metadata visibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `exposeSourceGateway` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-metadata-exposeSourceGateway}
+##### `exposeSourceGateway` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-metadata-exposeSourceGateway}
 
 
 
@@ -7806,7 +7804,7 @@ Metadata configures imported Gateway metadata visibility.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sanitize` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize}
+##### `sanitize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize}
 
 Sanitize configures sensitive control plane field sanitization.
 
@@ -7818,7 +7816,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certificateRefs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize-certificateRefs}
+##### `certificateRefs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize-certificateRefs}
 
 
 
@@ -7833,7 +7831,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `infrastructure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize-infrastructure}
+##### `infrastructure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-gateways-sanitize-infrastructure}
 
 
 
@@ -7854,7 +7852,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses}
+#### `runtimeClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -7866,7 +7864,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -7881,7 +7879,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -7893,7 +7891,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -7908,7 +7906,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -7923,7 +7921,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -7938,7 +7936,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -7952,7 +7950,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -7967,7 +7965,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -7982,7 +7980,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -7997,7 +7995,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -8012,7 +8010,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -8027,7 +8025,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -8046,7 +8044,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -8064,7 +8062,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -8076,7 +8074,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchLabels}
 
 
 
@@ -8091,7 +8089,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions}
 
 
 
@@ -8103,22 +8101,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -8133,7 +8116,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-values}
 
 
 
@@ -8157,7 +8155,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -8169,7 +8167,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -8184,7 +8182,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -8196,7 +8194,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -8211,7 +8209,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -8226,7 +8224,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -8241,7 +8239,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -8255,7 +8253,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -8270,7 +8268,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -8285,7 +8283,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -8300,7 +8298,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -8315,7 +8313,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -8330,7 +8328,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -8349,7 +8347,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -8367,7 +8365,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -8379,7 +8377,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchLabels}
 
 
 
@@ -8394,7 +8392,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions}
 
 
 
@@ -8406,22 +8404,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -8436,7 +8419,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-values}
 
 
 
@@ -8460,7 +8458,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -8472,7 +8470,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -8487,7 +8485,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -8499,7 +8497,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -8514,7 +8512,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -8529,7 +8527,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -8544,7 +8542,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -8558,7 +8556,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -8573,7 +8571,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -8588,7 +8586,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -8603,7 +8601,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -8618,7 +8616,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -8633,7 +8631,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -8652,7 +8650,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -8670,7 +8668,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -8682,7 +8680,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchLabels}
 
 
 
@@ -8697,7 +8695,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions}
 
 
 
@@ -8709,22 +8707,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-key}
 
 
 
@@ -8739,7 +8722,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-values}
 
 
 
@@ -8763,7 +8761,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes}
+#### `csiNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -8775,7 +8773,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -8790,7 +8788,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -8802,7 +8800,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -8817,7 +8815,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -8832,7 +8830,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -8847,7 +8845,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -8861,7 +8859,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -8876,7 +8874,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -8891,7 +8889,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -8906,7 +8904,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -8921,7 +8919,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -8936,7 +8934,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -8955,7 +8953,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -8976,7 +8974,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers}
+#### `csiDrivers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -8988,7 +8986,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -9003,7 +9001,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -9015,7 +9013,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -9030,7 +9028,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -9045,7 +9043,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -9060,7 +9058,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -9074,7 +9072,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -9089,7 +9087,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -9104,7 +9102,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -9119,7 +9117,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -9134,7 +9132,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -9149,7 +9147,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -9168,7 +9166,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -9189,7 +9187,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities}
+#### `csiStorageCapacities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -9201,7 +9199,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -9216,7 +9214,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -9228,7 +9226,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -9243,7 +9241,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -9258,7 +9256,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -9273,7 +9271,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -9287,7 +9285,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -9302,7 +9300,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -9317,7 +9315,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -9332,7 +9330,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -9347,7 +9345,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -9362,7 +9360,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -9381,7 +9379,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -9402,7 +9400,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -9414,7 +9412,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -9429,7 +9427,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -9444,7 +9442,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -9456,7 +9454,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -9471,7 +9469,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -9486,7 +9484,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -9501,7 +9499,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -9515,7 +9513,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -9530,7 +9528,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -9545,7 +9543,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -9560,7 +9558,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -9575,7 +9573,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -9590,7 +9588,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -9609,7 +9607,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -9627,7 +9625,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings}
+##### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -9639,7 +9637,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -9676,7 +9674,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses}
+#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -9688,7 +9686,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -9703,7 +9701,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -9715,7 +9713,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -9730,7 +9728,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -9745,7 +9743,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -9760,7 +9758,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -9774,7 +9772,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -9789,7 +9787,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -9804,7 +9802,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -9819,7 +9817,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -9834,7 +9832,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -9849,7 +9847,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -9868,7 +9866,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -9889,7 +9887,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -9901,7 +9899,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -9916,7 +9914,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -9928,7 +9926,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -9943,7 +9941,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -9958,7 +9956,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -9973,7 +9971,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -9987,7 +9985,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -10002,7 +10000,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -10017,7 +10015,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -10032,7 +10030,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -10047,7 +10045,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -10062,7 +10060,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -10081,7 +10079,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -10099,7 +10097,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings}
+##### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -10111,7 +10109,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -10148,7 +10146,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -10160,7 +10158,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -10175,7 +10173,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -10187,7 +10185,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -10202,7 +10200,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -10217,7 +10215,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -10232,7 +10230,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -10246,7 +10244,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -10261,7 +10259,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -10276,7 +10274,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -10291,7 +10289,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -10306,7 +10304,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -10321,7 +10319,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -10340,7 +10338,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -10358,7 +10356,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings}
+##### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -10370,7 +10368,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -10407,7 +10405,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deviceClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses}
+#### `deviceClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses}
 
 DeviceClasses defines if device classes in the host should get synced to the virtual cluster
 
@@ -10419,7 +10417,7 @@ DeviceClasses defines if device classes in the host should get synced to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -10434,7 +10432,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -10446,7 +10444,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -10461,7 +10459,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -10476,7 +10474,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -10491,7 +10489,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -10505,7 +10503,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -10520,7 +10518,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -10535,7 +10533,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -10550,7 +10548,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -10565,7 +10563,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -10580,7 +10578,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -10599,7 +10597,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -10617,7 +10615,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -10629,7 +10627,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchLabels}
 
 
 
@@ -10644,7 +10642,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions}
 
 
 
@@ -10656,22 +10654,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-key}
 
 
 
@@ -10686,7 +10669,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-deviceClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost}
+## `fromHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -14,7 +14,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes}
+### `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -26,7 +26,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -41,7 +41,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-syncBackChanges}
+#### `syncBackChanges` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -56,7 +56,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-clearImageStatus}
+#### `clearImageStatus` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -71,7 +71,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -83,7 +83,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -98,7 +98,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -116,7 +116,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -128,7 +128,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -143,7 +143,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -158,7 +158,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -173,7 +173,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -187,7 +187,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -202,7 +202,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -217,7 +217,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -232,7 +232,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -247,7 +247,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -262,7 +262,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -281,7 +281,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -302,7 +302,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events}
+### `events` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -314,7 +314,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-events-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -329,7 +329,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -341,7 +341,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -356,7 +356,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -371,7 +371,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -386,7 +386,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -400,7 +400,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -415,7 +415,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -430,7 +430,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -445,7 +445,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -460,7 +460,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -475,7 +475,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -494,7 +494,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -515,7 +515,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses}
+### `ingressClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -527,7 +527,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -542,7 +542,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -554,7 +554,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -569,7 +569,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -584,7 +584,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -599,7 +599,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -613,7 +613,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -628,7 +628,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -643,7 +643,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -658,7 +658,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -673,7 +673,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -688,7 +688,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -707,7 +707,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -725,7 +725,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -737,7 +737,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchLabels}
 
 
 
@@ -752,7 +752,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions}
 
 
 
@@ -764,22 +764,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -794,7 +779,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-values}
 
 
 
@@ -818,7 +818,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `gatewayClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses}
+### `gatewayClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses}
 
 GatewayClasses defines if gateway classes should get synced from the control plane cluster to the tenant cluster, but not back.
 
@@ -830,7 +830,7 @@ GatewayClasses defines if gateway classes should get synced from the control pla
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -845,7 +845,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -857,7 +857,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -872,7 +872,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -887,7 +887,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -902,7 +902,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -916,7 +916,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -931,7 +931,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -946,7 +946,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -961,7 +961,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -976,7 +976,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -991,7 +991,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1010,7 +1010,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1028,7 +1028,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -1040,7 +1040,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchLabels}
 
 
 
@@ -1055,7 +1055,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions}
 
 
 
@@ -1067,22 +1067,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-key}
 
 
 
@@ -1097,7 +1082,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gatewayClasses-selector-matchExpressions-values}
 
 
 
@@ -1121,7 +1121,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways}
+### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways}
 
 Gateways defines if selected control plane Gateways should get synced from the control plane cluster to the tenant cluster, but not back.
 
@@ -1133,7 +1133,7 @@ Gateways defines if selected control plane Gateways should get synced from the c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1148,7 +1148,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1160,7 +1160,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1175,7 +1175,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1190,7 +1190,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1205,7 +1205,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1219,7 +1219,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1234,7 +1234,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1249,7 +1249,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1264,7 +1264,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1279,7 +1279,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1294,7 +1294,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1313,7 +1313,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1331,7 +1331,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -1343,7 +1343,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchLabels}
 
 
 
@@ -1358,7 +1358,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions}
 
 
 
@@ -1370,22 +1370,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-key}
 
 
 
@@ -1400,7 +1385,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-selector-matchExpressions-values}
 
 
 
@@ -1421,7 +1421,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-mappings}
+#### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-mappings}
 
 Mappings define control plane Gateway namespace/name to tenant-facing namespace/name placement.
 
@@ -1433,7 +1433,7 @@ Mappings define control plane Gateway namespace/name to tenant-facing namespace/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-gateways-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-gateways-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -1467,7 +1467,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `allowedRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes}
+#### `allowedRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes}
 
 AllowedRoutes configures the tenant-facing allowedRoutes policy shown on imported Gateways and enforced for Routes.
 
@@ -1479,7 +1479,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `defaultVirtualNamespacePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy}
+##### `defaultVirtualNamespacePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy}
 
 
 
@@ -1491,7 +1491,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-from}
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-from}
 
 
 
@@ -1506,7 +1506,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector}
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector}
 
 
 
@@ -1518,7 +1518,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchLabels}
 
 
 
@@ -1533,7 +1533,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions}
 
 
 
@@ -1545,22 +1545,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-key}
 
 
 
@@ -1575,43 +1560,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-values}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `overrides` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-hostNamespace}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-operator}
 
 
 
@@ -1626,7 +1575,7 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-name}
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-defaultVirtualNamespacePolicy-selector-matchExpressions-values}
 
 
 
@@ -1635,138 +1584,6 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 
 
 </details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `virtualNamespacePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-from}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchLabels}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-operator}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-values}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `allowedHostnames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-allowedHostnames}
-
-
-
-</summary>
-
 
 
 </details>
@@ -1782,7 +1599,190 @@ AllowedRoutes configures the tenant-facing allowedRoutes policy shown on importe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `status` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-status}
+##### `overrides` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `hostNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-hostNamespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualNamespacePolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `from` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-from}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-key}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-virtualNamespacePolicy-selector-matchExpressions-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `allowedHostnames` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-allowedRoutes-overrides-allowedHostnames}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-status}
 
 Status configures how Gateway status is mirrored.
 
@@ -1794,7 +1794,7 @@ Status configures how Gateway status is mirrored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `exposeAddresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-status-exposeAddresses}
+##### `exposeAddresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-status-exposeAddresses}
 
 
 
@@ -1812,7 +1812,7 @@ Status configures how Gateway status is mirrored.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-metadata}
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-metadata}
 
 Metadata configures imported Gateway metadata visibility.
 
@@ -1824,7 +1824,7 @@ Metadata configures imported Gateway metadata visibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `exposeSourceGateway` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-metadata-exposeSourceGateway}
+##### `exposeSourceGateway` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-gateways-metadata-exposeSourceGateway}
 
 
 
@@ -1842,7 +1842,7 @@ Metadata configures imported Gateway metadata visibility.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sanitize` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize}
+#### `sanitize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize}
 
 Sanitize configures sensitive control plane field sanitization.
 
@@ -1854,7 +1854,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certificateRefs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize-certificateRefs}
+##### `certificateRefs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize-certificateRefs}
 
 
 
@@ -1869,7 +1869,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `infrastructure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize-infrastructure}
+##### `infrastructure` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-gateways-sanitize-infrastructure}
 
 
 
@@ -1890,7 +1890,7 @@ Sanitize configures sensitive control plane field sanitization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses}
+### `runtimeClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -1902,7 +1902,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1917,7 +1917,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1929,7 +1929,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1944,7 +1944,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1959,7 +1959,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1974,7 +1974,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1988,7 +1988,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2003,7 +2003,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2018,7 +2018,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2033,7 +2033,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2048,7 +2048,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2063,7 +2063,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2082,7 +2082,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2100,7 +2100,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -2112,7 +2112,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchLabels}
 
 
 
@@ -2127,7 +2127,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions}
 
 
 
@@ -2139,22 +2139,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -2169,7 +2154,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-values}
 
 
 
@@ -2193,7 +2193,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -2205,7 +2205,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2220,7 +2220,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2232,7 +2232,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2247,7 +2247,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2262,7 +2262,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2277,7 +2277,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2291,7 +2291,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2306,7 +2306,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2321,7 +2321,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2336,7 +2336,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2351,7 +2351,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2366,7 +2366,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2385,7 +2385,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2403,7 +2403,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -2415,7 +2415,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchLabels}
 
 
 
@@ -2430,7 +2430,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions}
 
 
 
@@ -2442,22 +2442,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -2472,7 +2457,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-values}
 
 
 
@@ -2496,7 +2496,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -2508,7 +2508,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2523,7 +2523,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2535,7 +2535,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2550,7 +2550,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2565,7 +2565,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2580,7 +2580,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2594,7 +2594,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2609,7 +2609,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2624,7 +2624,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2639,7 +2639,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2654,7 +2654,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2669,7 +2669,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2688,7 +2688,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2706,7 +2706,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -2718,7 +2718,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchLabels}
 
 
 
@@ -2733,7 +2733,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions}
 
 
 
@@ -2745,22 +2745,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-key}
 
 
 
@@ -2775,7 +2760,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-values}
 
 
 
@@ -2799,7 +2799,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes}
+### `csiNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -2811,7 +2811,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiNodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2826,7 +2826,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2838,7 +2838,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2853,7 +2853,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2868,7 +2868,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2883,7 +2883,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2897,7 +2897,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2912,7 +2912,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2927,7 +2927,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2942,7 +2942,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2957,7 +2957,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2972,7 +2972,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2991,7 +2991,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3012,7 +3012,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers}
+### `csiDrivers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -3024,7 +3024,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3039,7 +3039,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3051,7 +3051,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3066,7 +3066,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3081,7 +3081,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3096,7 +3096,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3110,7 +3110,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3125,7 +3125,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3140,7 +3140,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3155,7 +3155,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3170,7 +3170,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3185,7 +3185,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3204,7 +3204,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3225,7 +3225,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities}
+### `csiStorageCapacities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -3237,7 +3237,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3252,7 +3252,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3264,7 +3264,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3279,7 +3279,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3294,7 +3294,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3309,7 +3309,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3323,7 +3323,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3338,7 +3338,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3353,7 +3353,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3368,7 +3368,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3383,7 +3383,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3398,7 +3398,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3417,7 +3417,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3438,7 +3438,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -3450,7 +3450,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3465,7 +3465,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -3480,7 +3480,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3492,7 +3492,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3507,7 +3507,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3522,7 +3522,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3537,7 +3537,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3551,7 +3551,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3566,7 +3566,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3581,7 +3581,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3596,7 +3596,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3611,7 +3611,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3626,7 +3626,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3645,7 +3645,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3663,7 +3663,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings}
+#### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -3675,7 +3675,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -3712,7 +3712,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses}
+### `volumeSnapshotClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -3724,7 +3724,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3739,7 +3739,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3751,7 +3751,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3766,7 +3766,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3781,7 +3781,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3796,7 +3796,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3810,7 +3810,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3825,7 +3825,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3840,7 +3840,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3855,7 +3855,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3870,7 +3870,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3885,7 +3885,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3904,7 +3904,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3925,7 +3925,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -3937,7 +3937,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3952,7 +3952,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3964,7 +3964,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3979,7 +3979,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3994,7 +3994,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4009,7 +4009,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4023,7 +4023,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4038,7 +4038,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4053,7 +4053,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4068,7 +4068,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4083,7 +4083,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4098,7 +4098,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4117,7 +4117,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4135,7 +4135,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings}
+#### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -4147,7 +4147,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -4184,7 +4184,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -4196,7 +4196,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4211,7 +4211,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4223,7 +4223,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4238,7 +4238,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4253,7 +4253,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4268,7 +4268,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4282,7 +4282,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4297,7 +4297,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4312,7 +4312,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4327,7 +4327,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4342,7 +4342,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4357,7 +4357,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4376,7 +4376,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4394,7 +4394,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings}
+#### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -4406,7 +4406,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -4443,7 +4443,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deviceClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses}
+### `deviceClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses}
 
 DeviceClasses defines if device classes in the host should get synced to the virtual cluster
 
@@ -4455,7 +4455,7 @@ DeviceClasses defines if device classes in the host should get synced to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4470,7 +4470,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4482,7 +4482,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4497,7 +4497,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4512,7 +4512,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4527,7 +4527,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4541,7 +4541,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4556,7 +4556,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4571,7 +4571,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4586,7 +4586,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4601,7 +4601,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4616,7 +4616,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4635,7 +4635,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4653,7 +4653,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -4665,7 +4665,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchLabels}
 
 
 
@@ -4680,7 +4680,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions}
 
 
 
@@ -4692,22 +4692,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-key}
 
 
 
@@ -4722,7 +4707,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-deviceClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/configMaps.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-mappings}
+### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#configMaps-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#configMaps-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/csiDrivers.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/csiDrivers.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers}
+## `csiDrivers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiDrivers-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/csiNodes.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/csiNodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes}
+## `csiNodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiNodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/csiStorageCapacities.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/csiStorageCapacities.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities}
+## `csiStorageCapacities` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiStorageCapacities-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/customResources.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -14,7 +14,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -44,7 +44,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -227,7 +227,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings}
+### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -239,7 +239,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/events.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/events.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events}
+## `events` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#events-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/gatewayClasses.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/gatewayClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `gatewayClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses}
+## `gatewayClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses}
 
 GatewayClasses defines if gateway classes should get synced from the control plane cluster to the tenant cluster, but not back.
 
@@ -14,7 +14,7 @@ GatewayClasses defines if gateway classes should get synced from the control pla
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/ingressClasses.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/ingressClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses}
+## `ingressClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingressClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/nodes.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/nodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes}
+## `nodes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -29,7 +29,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-syncBackChanges}
+### `syncBackChanges` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -44,7 +44,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-clearImageStatus}
+### `clearImageStatus` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -59,7 +59,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -71,7 +71,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-selector-all}
+#### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -86,7 +86,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#nodes-selector-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -104,7 +104,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -116,7 +116,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -131,7 +131,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -146,7 +146,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -161,7 +161,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -175,7 +175,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -190,7 +190,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -205,7 +205,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -220,7 +220,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -235,7 +235,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -250,7 +250,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -269,7 +269,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/priorityClasses.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/runtimeClasses.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/runtimeClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses}
+## `runtimeClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#runtimeClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/secrets.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-mappings}
+### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#secrets-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#secrets-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/storageClasses.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/fromHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector}
+### `selector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost}
+## `toHost` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -14,7 +14,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods}
+### `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -26,7 +26,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -41,7 +41,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#toHost-pods-translateImage}
+#### `translateImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -57,7 +57,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-enforceTolerations}
+#### `enforceTolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -72,7 +72,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-useSecretsForSATokens}
+#### `useSecretsForSATokens` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -88,7 +88,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-runtimeClassName}
+#### `runtimeClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -103,7 +103,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -118,7 +118,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts}
+#### `rewriteHosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -132,7 +132,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -147,7 +147,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -159,7 +159,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -171,7 +171,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -187,7 +187,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -202,7 +202,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -220,7 +220,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -232,7 +232,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -247,7 +247,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -271,7 +271,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -283,7 +283,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -298,7 +298,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -313,7 +313,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -328,7 +328,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -342,7 +342,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -357,7 +357,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -372,7 +372,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -387,7 +387,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -402,7 +402,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -417,7 +417,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -436,7 +436,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -454,7 +454,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling}
+#### `hybridScheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -466,7 +466,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -481,7 +481,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-hostSchedulers}
+##### `hostSchedulers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 
@@ -502,7 +502,7 @@ HostSchedulers is a list of schedulers that are deployed on the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -514,7 +514,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -529,7 +529,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-secrets-all}
+#### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -544,7 +544,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -556,7 +556,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -571,7 +571,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -586,7 +586,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -601,7 +601,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -615,7 +615,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -630,7 +630,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -645,7 +645,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -660,7 +660,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -675,7 +675,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -690,7 +690,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -709,7 +709,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -730,7 +730,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -742,7 +742,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -757,7 +757,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-configMaps-all}
+#### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -772,7 +772,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -784,7 +784,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -799,7 +799,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -814,7 +814,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -829,7 +829,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -843,7 +843,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -858,7 +858,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -873,7 +873,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -888,7 +888,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -903,7 +903,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -918,7 +918,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -937,7 +937,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -958,7 +958,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses}
+### `ingresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -970,7 +970,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-ingresses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -985,7 +985,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -997,7 +997,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1012,7 +1012,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1027,7 +1027,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1042,7 +1042,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1056,7 +1056,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1071,7 +1071,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1086,7 +1086,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1101,7 +1101,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1116,7 +1116,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1131,7 +1131,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1150,7 +1150,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1171,10 +1171,9 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `gatewayApi` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi}
+### `gatewayApi` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi}
 
 GatewayAPI defines Gateway API resources created within the tenant cluster that should get synced to the control plane cluster.
-Setting enabled: true turns on Gateway and HTTPRoute sync, imports control plane cluster GatewayClasses so tenant Gateways can resolve them, and serves tenant ReferenceGrants for validation; TLSRoutes and BackendTLSPolicies must be enabled individually.
 
 </summary>
 
@@ -1184,7 +1183,7 @@ Setting enabled: true turns on Gateway and HTTPRoute sync, imports control plane
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1199,7 +1198,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1211,7 +1210,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1226,7 +1225,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1241,7 +1240,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1256,7 +1255,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1270,7 +1269,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1285,7 +1284,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1300,7 +1299,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1315,7 +1314,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1330,7 +1329,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1345,7 +1344,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1364,7 +1363,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1382,7 +1381,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `httpRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes}
+#### `httpRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes}
 
 HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 
@@ -1394,7 +1393,7 @@ HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1409,7 +1408,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1421,7 +1420,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1436,7 +1435,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1451,7 +1450,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1466,7 +1465,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1480,7 +1479,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1495,7 +1494,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1510,7 +1509,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1525,7 +1524,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1540,7 +1539,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1555,7 +1554,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1574,7 +1573,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-httpRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1595,7 +1594,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways}
+#### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways}
 
 Gateways configures tenant-created Gateway sync to the control plane cluster.
 
@@ -1607,7 +1606,7 @@ Gateways configures tenant-created Gateway sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1622,7 +1621,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1634,7 +1633,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1649,7 +1648,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1664,7 +1663,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1679,7 +1678,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1693,7 +1692,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1708,7 +1707,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1723,7 +1722,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1738,7 +1737,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1753,7 +1752,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1768,7 +1767,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1787,7 +1786,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-gateways-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1808,7 +1807,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `tlsRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes}
+#### `tlsRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes}
 
 TLSRoutes configures TLSRoute sync to the control plane cluster.
 
@@ -1820,7 +1819,7 @@ TLSRoutes configures TLSRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1835,7 +1834,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1847,7 +1846,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1862,7 +1861,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1877,7 +1876,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1892,7 +1891,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1906,7 +1905,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1921,7 +1920,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1936,7 +1935,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1951,7 +1950,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1966,7 +1965,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1981,7 +1980,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2000,7 +1999,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-tlsRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2021,7 +2020,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `backendTLSPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies}
+#### `backendTLSPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies}
 
 BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster.
 
@@ -2033,7 +2032,7 @@ BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2048,7 +2047,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2060,7 +2059,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2075,7 +2074,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2090,7 +2089,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2105,7 +2104,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2119,7 +2118,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2134,7 +2133,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2149,7 +2148,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2164,7 +2163,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2179,7 +2178,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2194,7 +2193,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2213,7 +2212,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-backendTLSPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2234,10 +2233,9 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `referenceGrants` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants}
+#### `referenceGrants` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants}
 
 ReferenceGrants configures ReferenceGrant sync to the control plane cluster. Enabled may be "auto", "true", or "false".
-In auto mode grants follow route sync and are validated within the tenant cluster; they sync to the control plane cluster only when namespace sync is also enabled.
 
 </summary>
 
@@ -2247,7 +2245,7 @@ In auto mode grants follow route sync and are validated within the tenant cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-enabled}
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2262,7 +2260,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches}
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2274,7 +2272,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2289,7 +2287,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2304,7 +2302,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2319,7 +2317,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2333,7 +2331,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2348,7 +2346,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2363,7 +2361,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2378,7 +2376,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2393,7 +2391,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2408,7 +2406,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2427,7 +2425,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-gatewayApi-referenceGrants-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2451,7 +2449,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services}
+### `services` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -2463,7 +2461,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-services-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2478,7 +2476,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2490,7 +2488,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2505,7 +2503,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2520,7 +2518,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2535,7 +2533,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2549,7 +2547,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2564,7 +2562,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2579,7 +2577,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2594,7 +2592,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2609,7 +2607,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2624,7 +2622,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2643,7 +2641,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2664,7 +2662,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints}
+### `endpoints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -2676,7 +2674,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpoints-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2691,7 +2689,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2703,7 +2701,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2718,7 +2716,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2733,7 +2731,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2748,7 +2746,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2762,7 +2760,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2777,7 +2775,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2792,7 +2790,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2807,7 +2805,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2822,7 +2820,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2837,7 +2835,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2856,7 +2854,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2877,7 +2875,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `endpointSlices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices}
+### `endpointSlices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices}
 
 EndpointSlices defines if endpointslices created within the virtual cluster should get synced to the host cluster.
 
@@ -2889,7 +2887,7 @@ EndpointSlices defines if endpointslices created within the virtual cluster shou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpointSlices-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpointSlices-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2904,7 +2902,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2916,7 +2914,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2931,7 +2929,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2946,7 +2944,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2961,7 +2959,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2975,7 +2973,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2990,7 +2988,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3005,7 +3003,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3020,7 +3018,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3035,7 +3033,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3050,7 +3048,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3069,7 +3067,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpointSlices-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3090,7 +3088,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies}
+### `networkPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -3102,7 +3100,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-networkPolicies-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3117,7 +3115,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3129,7 +3127,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3144,7 +3142,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3159,7 +3157,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3174,7 +3172,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3188,7 +3186,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3203,7 +3201,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3218,7 +3216,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3233,7 +3231,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3248,7 +3246,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3263,7 +3261,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3282,7 +3280,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3303,7 +3301,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims}
+### `persistentVolumeClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -3315,7 +3313,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3330,7 +3328,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3342,7 +3340,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3357,7 +3355,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3372,7 +3370,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3387,7 +3385,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3401,7 +3399,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3416,7 +3414,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3431,7 +3429,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3446,7 +3444,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3461,7 +3459,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3476,7 +3474,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3495,7 +3493,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3516,7 +3514,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes}
+### `persistentVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -3528,7 +3526,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3543,7 +3541,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3555,7 +3553,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3570,7 +3568,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3585,7 +3583,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3600,7 +3598,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3614,7 +3612,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3629,7 +3627,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3644,7 +3642,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3659,7 +3657,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3674,7 +3672,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3689,7 +3687,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3708,7 +3706,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3729,7 +3727,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots}
+### `volumeSnapshots` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -3741,7 +3739,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3756,7 +3754,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3768,7 +3766,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3783,7 +3781,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3798,7 +3796,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3813,7 +3811,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3827,7 +3825,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3842,7 +3840,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3857,7 +3855,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3872,7 +3870,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3887,7 +3885,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3902,7 +3900,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3921,7 +3919,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3942,7 +3940,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents}
+### `volumeSnapshotContents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -3954,7 +3952,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3969,7 +3967,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3981,7 +3979,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3996,7 +3994,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4011,7 +4009,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4026,7 +4024,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4040,7 +4038,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4055,7 +4053,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4070,7 +4068,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4085,7 +4083,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4100,7 +4098,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4115,7 +4113,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4134,7 +4132,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4155,7 +4153,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -4167,7 +4165,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4182,7 +4180,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4194,7 +4192,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4209,7 +4207,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4224,7 +4222,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4239,7 +4237,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4253,7 +4251,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4268,7 +4266,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4283,7 +4281,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4298,7 +4296,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4313,7 +4311,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4328,7 +4326,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4347,7 +4345,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4368,7 +4366,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts}
+### `serviceAccounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -4380,7 +4378,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4395,7 +4393,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4407,7 +4405,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4422,7 +4420,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4437,7 +4435,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4452,7 +4450,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4466,7 +4464,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4481,7 +4479,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4496,7 +4494,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4511,7 +4509,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4526,7 +4524,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4541,7 +4539,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4560,7 +4558,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4581,7 +4579,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets}
+### `podDisruptionBudgets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -4593,7 +4591,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4608,7 +4606,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4620,7 +4618,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4635,7 +4633,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4650,7 +4648,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4665,7 +4663,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4679,7 +4677,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4694,7 +4692,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4709,7 +4707,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4724,7 +4722,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4739,7 +4737,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4754,7 +4752,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4773,7 +4771,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4794,7 +4792,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -4806,7 +4804,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4821,7 +4819,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4833,7 +4831,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4848,7 +4846,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4863,7 +4861,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4878,7 +4876,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4892,7 +4890,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4907,7 +4905,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4922,7 +4920,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4937,7 +4935,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4952,7 +4950,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4967,7 +4965,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4986,7 +4984,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5007,7 +5005,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -5020,7 +5018,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5035,7 +5033,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -5050,7 +5048,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5062,7 +5060,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5077,7 +5075,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5092,7 +5090,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5107,7 +5105,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5121,7 +5119,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5136,7 +5134,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5151,7 +5149,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5166,7 +5164,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5181,7 +5179,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5196,7 +5194,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5215,7 +5213,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5236,7 +5234,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces}
 
 Namespaces defines if namespaces created within the virtual cluster should get synced to the host cluster.
 
@@ -5248,7 +5246,7 @@ Namespaces defines if namespaces created within the virtual cluster should get s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-enabled}
+#### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5263,7 +5261,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5275,7 +5273,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5290,7 +5288,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5305,7 +5303,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5320,7 +5318,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5334,7 +5332,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5349,7 +5347,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5364,7 +5362,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5379,7 +5377,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5394,7 +5392,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5409,7 +5407,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5428,7 +5426,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5446,7 +5444,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings}
+#### `mappings` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings}
 
 Mappings for Namespace and Object
 
@@ -5458,7 +5456,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings-byName}
 
 ByName is a map of control-plane-object-namespace/control-plane-object-name: tenant-object-namespace/tenant-object-name.
 There are several wildcards supported:
@@ -5492,7 +5490,7 @@ byName:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-mappingsOnly}
+#### `mappingsOnly` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-mappingsOnly}
 
 MappingsOnly defines if creation of namespaces not matched by mappings should be allowed.
 
@@ -5507,7 +5505,7 @@ MappingsOnly defines if creation of namespaces not matched by mappings should be
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-extraLabels}
+#### `extraLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-extraLabels}
 
 ExtraLabels are additional labels to add to the namespace in the host cluster.
 
@@ -5525,7 +5523,7 @@ ExtraLabels are additional labels to add to the namespace in the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resourceClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims}
+### `resourceClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims}
 
 ResourceClaim defines if resource claims created within the virtual cluster should get synced to the host cluster.
 
@@ -5537,7 +5535,7 @@ ResourceClaim defines if resource claims created within the virtual cluster shou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-resourceClaims-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-resourceClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5552,7 +5550,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5564,7 +5562,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5579,7 +5577,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5594,7 +5592,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5609,7 +5607,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5623,7 +5621,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5638,7 +5636,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5653,7 +5651,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5668,7 +5666,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5683,7 +5681,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5698,7 +5696,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5717,7 +5715,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5738,7 +5736,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resourceClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates}
+### `resourceClaimTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates}
 
 ResourceClaimTemplates defines if resourceClaimTemplates created within the virtual cluster should get synced to the host cluster.
 
@@ -5750,7 +5748,7 @@ ResourceClaimTemplates defines if resourceClaimTemplates created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5765,7 +5763,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5777,7 +5775,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5792,7 +5790,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5807,7 +5805,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5822,7 +5820,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5836,7 +5834,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5851,7 +5849,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5866,7 +5864,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5881,7 +5879,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5896,7 +5894,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5911,7 +5909,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5930,7 +5928,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-resourceClaimTemplates-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/configMaps.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-all}
+### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/customResources.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -15,7 +15,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -30,7 +30,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -45,7 +45,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -57,7 +57,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -72,7 +72,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -87,7 +87,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -102,7 +102,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -116,7 +116,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -131,7 +131,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -146,7 +146,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -161,7 +161,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -176,7 +176,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -191,7 +191,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -210,7 +210,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/endpointSlices.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/endpointSlices.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `endpointSlices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices}
+## `endpointSlices` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices}
 
 EndpointSlices defines if endpointslices created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ EndpointSlices defines if endpointslices created within the virtual cluster shou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpointSlices-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpointSlices-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpointSlices-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/endpoints.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/endpoints.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints}
+## `endpoints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpoints-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/gatewayApi.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/gatewayApi.mdx
@@ -1,11 +1,13 @@
 
+Setting `enabled: true` turns on Gateway and HTTPRoute sync, imports control plane cluster GatewayClasses so tenant Gateways can resolve them, and serves tenant ReferenceGrants for validation; TLSRoutes and BackendTLSPolicies must be enabled individually.
+
+
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `gatewayApi` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi}
+## `gatewayApi` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi}
 
 GatewayAPI defines Gateway API resources created within the tenant cluster that should get synced to the control plane cluster.
-Setting enabled: true turns on Gateway and HTTPRoute sync, imports control plane cluster GatewayClasses so tenant Gateways can resolve them, and serves tenant ReferenceGrants for validation; TLSRoutes and BackendTLSPolicies must be enabled individually.
 
 </summary>
 
@@ -15,7 +17,7 @@ Setting enabled: true turns on Gateway and HTTPRoute sync, imports control plane
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -30,7 +32,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -42,7 +44,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -57,7 +59,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -72,7 +74,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -87,7 +89,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -101,7 +103,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -116,7 +118,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -131,7 +133,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -146,7 +148,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -161,7 +163,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -176,7 +178,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -195,7 +197,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -213,7 +215,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `httpRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes}
+### `httpRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes}
 
 HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 
@@ -225,7 +227,7 @@ HTTPRoutes configures HTTPRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -240,7 +242,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -252,7 +254,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -267,7 +269,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -282,7 +284,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -297,7 +299,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -311,7 +313,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -326,7 +328,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -341,7 +343,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -356,7 +358,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -371,7 +373,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -386,7 +388,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -405,7 +407,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-httpRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -426,7 +428,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways}
+### `gateways` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways}
 
 Gateways configures tenant-created Gateway sync to the control plane cluster.
 
@@ -438,7 +440,7 @@ Gateways configures tenant-created Gateway sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-gateways-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-gateways-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -453,7 +455,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -465,7 +467,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -480,7 +482,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -495,7 +497,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -510,7 +512,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -524,7 +526,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -539,7 +541,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -554,7 +556,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -569,7 +571,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -584,7 +586,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -599,7 +601,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -618,7 +620,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-gateways-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -639,7 +641,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `tlsRoutes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes}
+### `tlsRoutes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes}
 
 TLSRoutes configures TLSRoute sync to the control plane cluster.
 
@@ -651,7 +653,7 @@ TLSRoutes configures TLSRoute sync to the control plane cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -666,7 +668,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -678,7 +680,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -693,7 +695,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -708,7 +710,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -723,7 +725,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -737,7 +739,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -752,7 +754,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -767,7 +769,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -782,7 +784,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -797,7 +799,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -812,7 +814,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -831,7 +833,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-tlsRoutes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -852,7 +854,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `backendTLSPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies}
+### `backendTLSPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies}
 
 BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster.
 
@@ -864,7 +866,7 @@ BackendTLSPolicies configures BackendTLSPolicy sync to the control plane cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -879,7 +881,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -891,7 +893,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -906,7 +908,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -921,7 +923,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -936,7 +938,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -950,7 +952,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -965,7 +967,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -980,7 +982,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -995,7 +997,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1010,7 +1012,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1025,7 +1027,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1044,7 +1046,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-backendTLSPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1065,10 +1067,9 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `referenceGrants` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants}
+### `referenceGrants` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants}
 
 ReferenceGrants configures ReferenceGrant sync to the control plane cluster. Enabled may be "auto", "true", or "false".
-In auto mode grants follow route sync and are validated within the tenant cluster; they sync to the control plane cluster only when namespace sync is also enabled.
 
 </summary>
 
@@ -1078,7 +1079,7 @@ In auto mode grants follow route sync and are validated within the tenant cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1093,7 +1094,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches}
+#### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1105,7 +1106,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-path}
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1120,7 +1121,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1135,7 +1136,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1150,7 +1151,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1164,7 +1165,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1179,7 +1180,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1194,7 +1195,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1209,7 +1210,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1224,7 +1225,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1239,7 +1240,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1258,7 +1259,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#gatewayApi-referenceGrants-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/gatewayApi.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/gatewayApi.mdx
@@ -1,6 +1,8 @@
 
 Setting `enabled: true` turns on Gateway and HTTPRoute sync, imports control plane cluster GatewayClasses so tenant Gateways can resolve them, and serves tenant ReferenceGrants for validation; TLSRoutes and BackendTLSPolicies must be enabled individually.
 
+In auto mode grants follow route sync and are validated within the tenant cluster; they sync to the control plane cluster only when namespace sync is also enabled.
+
 
 <details className="config-field" data-expandable="true">
 <summary>

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/ingresses.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/ingresses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses}
+## `ingresses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingresses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/networkPolicies.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/networkPolicies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies}
+## `networkPolicies` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicies-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/persistentVolumeClaims.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/persistentVolumeClaims.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims}
+## `persistentVolumeClaims` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#persistentVolumeClaims-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/persistentVolumes.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/persistentVolumes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes}
+## `persistentVolumes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#persistentVolumes-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/podDisruptionBudgets.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/podDisruptionBudgets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets}
+## `podDisruptionBudgets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#podDisruptionBudgets-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/pods.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/pods.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods}
+## `pods` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#pods-translateImage}
+### `translateImage` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -45,7 +45,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-enforceTolerations}
+### `enforceTolerations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -60,7 +60,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-useSecretsForSATokens}
+### `useSecretsForSATokens` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -76,7 +76,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-runtimeClassName}
+### `runtimeClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -91,7 +91,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -106,7 +106,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts}
+### `rewriteHosts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -120,7 +120,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -135,7 +135,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer}
+#### `initContainer` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -147,7 +147,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -159,7 +159,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">mirror.gcr.io</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -175,7 +175,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -190,7 +190,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -208,7 +208,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -220,7 +220,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -235,7 +235,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -259,7 +259,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -271,7 +271,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -286,7 +286,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -301,7 +301,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -316,7 +316,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -330,7 +330,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -345,7 +345,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -360,7 +360,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -375,7 +375,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -390,7 +390,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -405,7 +405,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -424,7 +424,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -442,7 +442,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-hybridScheduling}
+### `hybridScheduling` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -454,7 +454,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-enabled}
+#### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -469,7 +469,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-hostSchedulers}
+#### `hostSchedulers` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/priorityClasses.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/secrets.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-all}
+### `all` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/serviceAccounts.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/serviceAccounts.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts}
+## `serviceAccounts` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceAccounts-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/services.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/services.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services}
+## `services` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#services-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/storageClasses.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/volumeSnapshots.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/sync/toHost/volumeSnapshots.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots}
+## `volumeSnapshots` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#volumeSnapshots-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches}
+### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-path}
+#### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.35.0/_partials/config/telemetry.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_partials/config/telemetry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `telemetry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry}
+## `telemetry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry}
 
 Configuration related to telemetry gathered about vCluster usage.
 
@@ -14,7 +14,7 @@ Configuration related to telemetry gathered about vCluster usage.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#telemetry-enabled}
+### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#telemetry-enabled}
 
 Enabled specifies that the telemetry for the vCluster control plane should be enabled.
 
@@ -29,7 +29,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `instanceCreator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-instanceCreator}
+### `instanceCreator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-instanceCreator}
 
 
 
@@ -44,7 +44,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `machineID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-machineID}
+### `machineID` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-machineID}
 
 
 
@@ -59,7 +59,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformUserID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformUserID}
+### `platformUserID` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformUserID}
 
 
 
@@ -74,7 +74,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformInstanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformInstanceID}
+### `platformInstanceID` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformInstanceID}
 
 
 


### PR DESCRIPTION
# Content Description
The platform and vCluster config reference pages labeled almost every field "required" (in both the body badge and the right-hand table of contents) because the generator defaulted every field to required and always emitted the literal "required" text, relying on CSS to hide it. This fixes the generator to read each field's actual required value from the schema and to emit the badge text only for genuinely required fields, then regenerates the reference partials and backports them to platform 4.10.0 and vCluster 0.35.0.

## What changed
- **Generator (`hack/`)**: required flag now derived from the schema `required` array (platform: via the `omitempty` convention; vCluster: from `vcluster.schema.json` required arrays). Badge text is conditional so the TOC reflects it. Nullable-field description fallback added. Gateway API sync prose moved into `pathExtras` so it survives regeneration.
- **Platform**: `status_reference.mdx` 114 → 29 required; backported to 4.10.0.
- **vCluster**: 0 → 384 required (genuinely required fields: patch path/apiVersion/kind, node pool name/quantity, autoNodes provider, etc.); backported to 0.35.0.

Note: This PR also backports the changes to both 0.35 and 4.10 versioned docs. Since the change applies to both sets of docs, and the backport CI doesn't handle multiple component backports.

## Known issue (tracked upstream)
Regenerating the vCluster partials reverts "tenant cluster" → "virtual cluster" in two field descriptions (snapshots, deletion) because the upstream schema comments still use the old term. This will recur on every regen until upstream is fixed.

## Preview Link
<!-- netlify deploy preview will be added automatically -->
https://deploy-preview-2321--vcluster-docs-site.netlify.app/docs/platform/next/configure/platform-configs/overview/#auth-github

This is the page called out in the issue, but it's worth poking around to make sure the fix applies correctly throughout. Also updates the vCluster generated docs.

## Internal Reference
Closes DOC-1526

Upstream follow-up for the missing `omitempty`/`+optional` tag hygiene: ENGCP-970


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)